### PR TITLE
Add hook to allow applications to configure the JSON ObjectMapper.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -15,6 +15,7 @@
  */
 package io.confluent.rest;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
 import org.eclipse.jetty.server.Handler;
@@ -131,7 +132,9 @@ public abstract class Application<T extends RestConfig> {
   public void configureBaseApplication(Configurable<?> config) {
     RestConfig restRestConfig = getConfiguration();
 
-    config.register(JacksonMessageBodyProvider.class);
+    ObjectMapper jsonMapper = getJsonMapper();
+    JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(jsonMapper);
+    config.register(jsonProvider);
     config.register(JsonParseExceptionMapper.class);
 
     config.register(ValidationFeature.class);
@@ -144,6 +147,16 @@ public abstract class Application<T extends RestConfig> {
 
   public T getConfiguration() {
     return this.config;
+  }
+
+  /**
+   * Gets a JSON ObjectMapper to use for (de)serialization of request/response entities. Override
+   * this to configure the behavior of the serializer. One simple example of customization is to
+   * set the INDENT_OUTPUT flag to make the output more readable. The default is a default
+   * Jackson ObjectMapper.
+   */
+  protected ObjectMapper getJsonMapper() {
+    return new ObjectMapper();
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/validation/JacksonMessageBodyProvider.java
+++ b/core/src/main/java/io/confluent/rest/validation/JacksonMessageBodyProvider.java
@@ -43,6 +43,10 @@ public class JacksonMessageBodyProvider extends JacksonJaxbJsonProvider {
     setMapper(new ObjectMapper());
   }
 
+  public JacksonMessageBodyProvider(ObjectMapper mapper) {
+    setMapper(mapper);
+  }
+
   @Override
   protected boolean hasMatchingMediaType(MediaType mediaType) {
     return super.hasMatchingMediaType(mediaType) ||


### PR DESCRIPTION
This allows toggling ObjectMapper feature flags. I'm running into an issue now with features in Jackson that aren't permitted by default because they aren't always safe to combine. This hook lets me work around the issue.
