### PR TITLE
Remove the single static ConfigDef from RestConfig.

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -24,8 +24,6 @@ import java.util.Map;
 import java.util.TreeMap;
 
 public class RestConfig extends AbstractConfig {
-  protected static final ConfigDef config;
-
   public static final String DEBUG_CONFIG = "debug";
   protected static final String DEBUG_CONFIG_DOC =
       "Boolean indicating whether extra debugging information is generated in some " +
@@ -58,8 +56,8 @@ public class RestConfig extends AbstractConfig {
       "Name of the SLF4J logger to write the NCSA Common Log Format request log.";
   protected static final String REQUEST_LOGGER_NAME_DEFAULT = "io.confluent.rest-utils.requests";
 
-  static {
-    config = new ConfigDef()
+  public static ConfigDef baseConfigDef() {
+    return new ConfigDef()
         .define(DEBUG_CONFIG, Type.BOOLEAN,
                 DEBUG_CONFIG_DEFAULT, Importance.HIGH, DEBUG_CONFIG_DOC)
         .define(PORT_CONFIG, Type.INT, PORT_CONFIG_DEFAULT, Importance.HIGH,
@@ -78,15 +76,11 @@ public class RestConfig extends AbstractConfig {
                 REQUEST_LOGGER_NAME_DOC);
   }
 
-  public RestConfig() {
-    super(config, new TreeMap<Object,Object>());
+  public RestConfig(ConfigDef definition, Map<?, ?> originals) {
+    super(definition, originals);
   }
 
-  public RestConfig(Map<?, ?> props) {
-    super(config, props);
-  }
-
-  public static void main(String[] args) {
-    System.out.println(config.toHtmlTable());
+  public RestConfig(ConfigDef definition) {
+    super(definition, new TreeMap<Object,Object>());
   }
 }

--- a/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
@@ -39,14 +39,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class ExceptionHandlingTest {
 
-  RestConfig config;
+  TestRestConfig config;
   ExceptionApplication app;
 
   @Before
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty("debug", "false");
-    config = new RestConfig(props);
+    config = new TestRestConfig(props);
     app = new ExceptionApplication(config);
     app.start();
   }
@@ -91,14 +91,14 @@ public class ExceptionHandlingTest {
   }
 
   // Test app just has endpoints that trigger different types of exceptions.
-  private static class ExceptionApplication extends Application<RestConfig> {
+  private static class ExceptionApplication extends Application<TestRestConfig> {
 
-    ExceptionApplication(RestConfig props) {
+    ExceptionApplication(TestRestConfig props) {
       super(props);
     }
 
     @Override
-    public void setupResources(Configurable<?> config, RestConfig appConfig) {
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
       config.register(ExceptionResource.class);
     }
   }

--- a/core/src/test/java/io/confluent/rest/ShutdownTest.java
+++ b/core/src/test/java/io/confluent/rest/ShutdownTest.java
@@ -18,8 +18,6 @@ package io.confluent.rest;
 
 import org.junit.Test;
 
-import java.io.IOException;
-import java.net.ServerSocket;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -37,7 +35,7 @@ public class ShutdownTest {
   public void testShutdownHook() throws Exception {
     Properties props = new Properties();
     props.put("shutdown.graceful.ms", "50");
-    ShutdownApplication app = new ShutdownApplication(new RestConfig(props));
+    ShutdownApplication app = new ShutdownApplication(new TestRestConfig(props));
     app.start();
 
     StopThread stop = new StopThread(app);
@@ -51,7 +49,7 @@ public class ShutdownTest {
   public void testGracefulShutdown() throws Exception {
     Properties props = new Properties();
     props.put("shutdown.graceful.ms", "50");
-    final RestConfig config = new RestConfig(props);
+    final TestRestConfig config = new TestRestConfig(props);
     ShutdownApplication app = new ShutdownApplication(config);
     app.start();
 
@@ -69,11 +67,11 @@ public class ShutdownTest {
   }
 
 
-  private static class ShutdownApplication extends Application<RestConfig> {
+  private static class ShutdownApplication extends Application<TestRestConfig> {
     public AtomicBoolean shutdown = new AtomicBoolean(false);
     public SlowResource resource = new SlowResource();
 
-    ShutdownApplication(RestConfig props) {
+    ShutdownApplication(TestRestConfig props) {
       super(props);
     }
 
@@ -83,7 +81,7 @@ public class ShutdownTest {
     }
 
     @Override
-    public void setupResources(Configurable<?> config, RestConfig appConfig) {
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
       config.register(resource);
     }
   }

--- a/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
@@ -38,7 +38,7 @@ public class WebApplicationExceptionMapperTest {
   public void setUp() {
     Properties props = new Properties();
     props.setProperty("debug", "false");
-    RestConfig config = new RestConfig(props);
+    RestConfig config = new TestRestConfig(props);
     mapper = new WebApplicationExceptionMapper(config);
   }
 

--- a/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldRestConfig.java
+++ b/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldRestConfig.java
@@ -17,6 +17,7 @@ package io.confluent.rest.examples.helloworld;
 
 import java.util.Map;
 
+import io.confluent.common.config.ConfigDef;
 import io.confluent.common.config.ConfigDef.Importance;
 import io.confluent.common.config.ConfigDef.Type;
 import io.confluent.rest.RestConfig;
@@ -28,23 +29,26 @@ import io.confluent.rest.RestConfig;
  * implementations.
  */
 public class HelloWorldRestConfig extends RestConfig {
+  private static ConfigDef config;
+
   public static final String GREETING_CONFIG = "greeting";
   private static final String GREETING_CONFIG_DOC = "Greeting template for responses.";
   private static final String GREETING_CONFIG_DEFAULT = "Hello, %s!";
 
   static {
-    config.define(GREETING_CONFIG,
-                  Type.STRING,
-                  GREETING_CONFIG_DEFAULT,
-                  Importance.HIGH,
-                  GREETING_CONFIG_DOC);
+    config = baseConfigDef()
+        .define(GREETING_CONFIG,
+                Type.STRING,
+                GREETING_CONFIG_DEFAULT,
+                Importance.HIGH,
+                GREETING_CONFIG_DOC);
   }
 
   public HelloWorldRestConfig() {
-    super();
+    super(config);
   }
 
   public HelloWorldRestConfig(Map<?, ?> props) {
-    super(props);
+    super(config, props);
   }
 }


### PR DESCRIPTION
Instead, provide a way to generate the equivalent ConfigDef. This allows
subclasses to ensure they have their own ConfigDef to work with. Previously, if
you had two RestConfig subclasses in the same process, they would share the same
ConfigDef, which easily leads to conflicts.
