### PR TITLE
Add RestConstraintViolationException for better error codes for some constraint violations.

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/ConstraintViolationExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/ConstraintViolationExceptionMapper.java
@@ -47,10 +47,16 @@ public class ConstraintViolationExceptionMapper
 
   @Override
   public Response toResponse(ConstraintViolationException exception) {
-    final ErrorMessage message = new ErrorMessage(
-        UNPROCESSABLE_ENTITY_CODE,
-        ConstraintViolations.formatUntyped(exception.getConstraintViolations())
-    );
+    final ErrorMessage message;
+    if (exception instanceof RestConstraintViolationException) {
+      RestConstraintViolationException restException = (RestConstraintViolationException)exception;
+      message = new ErrorMessage(restException.getErrorCode(), restException.getMessage());
+    } else {
+      message = new ErrorMessage(
+          UNPROCESSABLE_ENTITY_CODE,
+          ConstraintViolations.formatUntyped(exception.getConstraintViolations())
+      );
+    }
 
     return Response.status(UNPROCESSABLE_ENTITY_CODE)
         .entity(message)

--- a/core/src/main/java/io/confluent/rest/exceptions/RestConstraintViolationException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestConstraintViolationException.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2015 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest.exceptions;
+
+import java.util.Set;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.ws.rs.core.Response;
+
+/**
+ * ConstraintViolationException that includes RestException-like data to create a standard error
+ * response. Note that this does not inherit from RestException because it must inherit from
+ * ConstraintViolationException to be caught by the correct ExceptionMapper.
+ */
+public class RestConstraintViolationException extends ConstraintViolationException {
+
+  private int errorCode;
+
+  public RestConstraintViolationException(String message, int errorCode) {
+    this(message, errorCode, null);
+  }
+
+  public RestConstraintViolationException(String message, int errorCode,
+                                          Set<? extends ConstraintViolation<?>>
+                                              constraintViolations) {
+    super(message, constraintViolations);
+    this.errorCode = errorCode;
+  }
+
+  public int getStatus() {
+    return ConstraintViolationExceptionMapper.UNPROCESSABLE_ENTITY_CODE;
+  }
+
+  public int getErrorCode() {
+    return errorCode;
+  }
+}


### PR DESCRIPTION
Some applications will check constraints that are not as generic as parsing or
simple non-null requirements. In this case, they should be able to provide a
more specific error code than the generic 422 that is generated by default.
