### PR TITLE
Reduce importance level of some configs and turn off debug mode by defau...

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -30,7 +30,7 @@ public class RestConfig extends AbstractConfig {
   protected static final String DEBUG_CONFIG_DOC =
       "Boolean indicating whether extra debugging information is generated in some " +
       "error response entities.";
-  protected static final boolean DEBUG_CONFIG_DEFAULT = true;
+  protected static final boolean DEBUG_CONFIG_DEFAULT = false;
 
   public static final String PORT_CONFIG = "port";
   protected static final String PORT_CONFIG_DOC = "Port to listen on for new connections.";
@@ -86,14 +86,14 @@ public class RestConfig extends AbstractConfig {
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
         .define(DEBUG_CONFIG, Type.BOOLEAN,
-                DEBUG_CONFIG_DEFAULT, Importance.HIGH, DEBUG_CONFIG_DOC)
-        .define(PORT_CONFIG, Type.INT, PORT_CONFIG_DEFAULT, Importance.HIGH,
+                DEBUG_CONFIG_DEFAULT, Importance.LOW, DEBUG_CONFIG_DOC)
+        .define(PORT_CONFIG, Type.INT, PORT_CONFIG_DEFAULT, Importance.LOW,
                 PORT_CONFIG_DOC)
         .define(RESPONSE_MEDIATYPE_PREFERRED_CONFIG, Type.LIST,
-                RESPONSE_MEDIATYPE_PREFERRED_CONFIG_DEFAULT, Importance.HIGH,
+                RESPONSE_MEDIATYPE_PREFERRED_CONFIG_DEFAULT, Importance.LOW,
                 RESPONSE_MEDIATYPE_PREFERRED_CONFIG_DOC)
         .define(RESPONSE_MEDIATYPE_DEFAULT_CONFIG, Type.STRING,
-                RESPONSE_MEDIATYPE_DEFAULT_CONFIG_DEFAULT, Importance.HIGH,
+                RESPONSE_MEDIATYPE_DEFAULT_CONFIG_DEFAULT, Importance.LOW,
                 RESPONSE_MEDIATYPE_DEFAULT_CONFIG_DOC)
         .define(SHUTDOWN_GRACEFUL_MS_CONFIG, Type.INT,
                 SHUTDOWN_GRACEFUL_MS_DEFAULT, Importance.LOW,


### PR DESCRIPTION
...lt.

Reduce the importance level of some configs since they are important for
applications using rest-utils to override, but not important from that
application's user's perspective. Also disable the debug setting by default so
stack traces aren't included in error responses by default.

Easy review for anyone -- just config setting changes.
