### PR TITLE
Improve performance of CountingOutputStream.

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -317,15 +317,28 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
         return count;
       }
 
+      // Note that we override all of these even though FilterOutputStream only requires
+      // overriding the first to avoid doing byte-by-byte handling of the stream. Do NOT call
+      // super.write() for these as they will convert everything into a series of write(int)
+      // calls and wreck performance.
+
       @Override
       public void write(int b) throws IOException {
-        super.write(b);
         count++;
+        out.write(b);
       }
 
-      // The methods write(byte[]) and write(byte[],int,int) are guaranteed to call write(int),
-      // either directly or indirectly, for FilterOutputStream, so they do not need to be
-      // overridden -- all the accounting is handled by write(int)
+      @Override
+      public void write(byte[] bytes) throws IOException {
+        count += bytes.length;
+        out.write(bytes);
+      }
+
+      @Override
+      public void write(byte[] bytes, int off, int len) throws IOException {
+        count += len;
+        out.write(bytes, off, len);
+      }
     }
   }
 }


### PR DESCRIPTION
This overrides a few more methods in CountingOutputStream to improve performance
by avoiding FilterOutputStream's terrible behavior of converting all write calls
into underlying.write(int) streams, i.e. it writes everything one byte at a
time.

This makes a pretty significant improvement to throughput tests for kafka-rest. @nehanarkhede might make sense for you to review, I think you're the only other one who has looked at this code before.