### PR TITLE
Require Java 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
                 <version>2.5.1</version>
                 <inherited>true</inherited>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Since Kafka will also require Java 7.

This opens the door to upgrading Jersey and Jetty and perhaps getting rid of JettyTestContainer.