### PR TITLE
allow cors on any HTTP verb available.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -134,7 +134,13 @@ public abstract class Application<T extends RestConfig> {
     if (allowedOrigins != null && !allowedOrigins.trim().isEmpty()) {
       FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
       filterHolder.setName("cross-origin");
-      filterHolder.setInitParameter("allowedOrigins", allowedOrigins);
+      filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, allowedOrigins);
+      String allowedMethods = getConfiguration().getString(
+          RestConfig.ACCESS_CONTROL_ALLOWED_METHODS
+      );
+      if (allowedMethods != null && !allowedOrigins.trim().isEmpty()) {
+        filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, allowedMethods);
+      }
       context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
     }
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -58,6 +58,12 @@ public class RestConfig extends AbstractConfig {
       "Set value for Jetty Access-Control-Allow-Origin header";
   protected static final String ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT = "";
 
+  public static final String ACCESS_CONTROL_ALLOWED_METHODS = "access.control.allowed.methods";
+  protected static final String ACCESS_CONTROL_ALLOWED_METHODS_DOC =
+      "Set value to Jetty Access-Control-Allow-Origin header for specified methods";
+  protected static final String ACCESS_CONTROL_ALLOWED_METHODS_DEFAULT = "";
+
+
   public static final String REQUEST_LOGGER_NAME_CONFIG = "request.logger.name";
   protected static final String REQUEST_LOGGER_NAME_DOC =
       "Name of the SLF4J logger to write the NCSA Common Log Format request log.";
@@ -106,6 +112,9 @@ public class RestConfig extends AbstractConfig {
         .define(ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, Type.STRING,
                 ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT, Importance.LOW,
                 ACCESS_CONTROL_ALLOW_ORIGIN_DOC)
+        .define(ACCESS_CONTROL_ALLOWED_METHODS, Type.STRING,
+                ACCESS_CONTROL_ALLOWED_METHODS_DEFAULT, Importance.LOW,
+                ACCESS_CONTROL_ALLOWED_METHODS_DOC)
         .define(REQUEST_LOGGER_NAME_CONFIG, Type.STRING,
                 REQUEST_LOGGER_NAME_DEFAULT, Importance.LOW,
                 REQUEST_LOGGER_NAME_DOC)


### PR DESCRIPTION
by default CrossOriginFilter will only allow cors for GET/POST/HEAD. 

we will now allow users to config a comma separated list of VERBs via `access.control.allowed.methods`