### PR TITLE
Generalizing Application.parseListeners() to be used by the Schema Registry

### DIFF
--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -29,7 +30,8 @@ public class ApplicationTest {
   @Test
   public void testParseListenersDeprecated() {
     List<String> listenersConfig = new ArrayList<String>();
-    List<URI> listeners = Application.parseListeners(listenersConfig, RestConfig.PORT_CONFIG_DEFAULT);
+    List<URI> listeners = Application.parseListeners(listenersConfig, RestConfig.PORT_CONFIG_DEFAULT,
+            Arrays.asList("http", "https"), "http");
     assertEquals("Should have only one listener.", 1, listeners.size());
     assertExpectedUri(listeners.get(0), "http", "0.0.0.0", RestConfig.PORT_CONFIG_DEFAULT);
   }
@@ -39,7 +41,7 @@ public class ApplicationTest {
     List<String> listenersConfig = new ArrayList<String>();
     listenersConfig.add("http://localhost:123");
     listenersConfig.add("https://localhost:124");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1);
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
     assertEquals("Should have two listeners.", 2, listeners.size());
     assertExpectedUri(listeners.get(0), "http", "localhost", 123);
     assertExpectedUri(listeners.get(1), "https", "localhost", 124);
@@ -49,7 +51,7 @@ public class ApplicationTest {
   public void testParseListenersUnparseableUri() {
     List<String> listenersConfig = new ArrayList<String>();
     listenersConfig.add("!");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1);
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
   }
 
   @Test
@@ -57,7 +59,7 @@ public class ApplicationTest {
     List<String> listenersConfig = new ArrayList<String>();
     listenersConfig.add("http://localhost:8080");
     listenersConfig.add("foo://localhost:8081");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1);
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
     assertEquals("Should have one listener.", 1, listeners.size());
     assertExpectedUri(listeners.get(0), "http", "localhost", 8080);
   }
@@ -67,7 +69,14 @@ public class ApplicationTest {
     List<String> listenersConfig = new ArrayList<String>();
     listenersConfig.add("foo://localhost:8080");
     listenersConfig.add("bar://localhost:8081");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1);
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testParseListenersNoPort() {
+    List<String> listenersConfig = new ArrayList<String>();
+    listenersConfig.add("http://localhost");
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
   }
 
   private void assertExpectedUri(URI uri, String scheme, String host, int port) {


### PR DESCRIPTION
This change is to support https://github.com/confluentinc/schema-registry/pull/371