### PR TITLE
Issue #46: Expose Jetty JMX metrics

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-jmx</artifactId>
+            <version>${jetty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
             <version>${jetty.version}</version>
         </dependency>

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
 import io.confluent.common.config.ConfigException;
+import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.NetworkTrafficServerConnector;
 import org.eclipse.jetty.server.Server;
@@ -36,6 +37,7 @@ import org.glassfish.jersey.server.ServerProperties;
 import org.glassfish.jersey.server.validation.ValidationFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
 
+import java.lang.management.ManagementFactory;
 import java.util.EnumSet;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -128,6 +130,10 @@ public abstract class Application<T extends RestConfig> {
         Application.this.shutdownLatch.countDown();
       }
     };
+
+    MBeanContainer mbContainer = new MBeanContainer(ManagementFactory.getPlatformMBeanServer());
+    server.addEventListener(mbContainer);
+    server.addBean(mbContainer);
 
     MetricsListener metricsListener = new MetricsListener(metrics, "jetty", metricTags);
 


### PR DESCRIPTION
Fixes for #46.  I enabled the jetty JMX metrics per: http://www.eclipse.org/jetty/documentation/current/jmx-chapter.html