### PR TITLE
Decompose adding JSON provider into separate, protected method

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -395,7 +395,11 @@ public abstract class Application<T extends RestConfig> {
    * @param registerExceptionMapper Whether or not to register an additional exception mapper for
    *                                handling errors in (de)serialization
    */
-  protected void registerJsonProvider(Configurable<?> config, T restConfig, boolean registerExceptionMapper) {
+  protected void registerJsonProvider(
+      Configurable<?> config,
+      T restConfig,
+      boolean registerExceptionMapper
+  ) {
     ObjectMapper jsonMapper = getJsonMapper();
     JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(jsonMapper);
     config.register(jsonProvider);

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -375,9 +375,9 @@ public abstract class Application<T extends RestConfig> {
    * client.
    */
   public void configureBaseApplication(Configurable<?> config, Map<String, String> metricTags) {
-    RestConfig restConfig = getConfiguration();
-
     registerJsonProvider(config, true);
+
+    RestConfig restConfig = getConfiguration();
 
     config.register(ValidationFeature.class);
     config.register(ConstraintViolationExceptionMapper.class);

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -377,10 +377,7 @@ public abstract class Application<T extends RestConfig> {
   public void configureBaseApplication(Configurable<?> config, Map<String, String> metricTags) {
     RestConfig restConfig = getConfiguration();
 
-    ObjectMapper jsonMapper = getJsonMapper();
-    JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(jsonMapper);
-    config.register(jsonProvider);
-    config.register(JsonParseExceptionMapper.class);
+    registerJsonProvider(config, true);
 
     config.register(ValidationFeature.class);
     config.register(ConstraintViolationExceptionMapper.class);
@@ -391,6 +388,22 @@ public abstract class Application<T extends RestConfig> {
                                                                  metricTags, restConfig.getTime()));
 
     config.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);
+  }
+
+  /**
+   * Register a body provider and optional exception mapper for (de)serializing JSON in
+   * request/response entities.
+   * @param config The config to register the provider
+   * @param registerExceptionMapper Whether or not to register an additional exception mapper for
+   *                                handling errors in (de)serialization
+   */
+  protected void registerJsonProvider(Configurable<?> config, boolean registerExceptionMapper) {
+    ObjectMapper jsonMapper = getJsonMapper();
+    JacksonMessageBodyProvider jsonProvider = new JacksonMessageBodyProvider(jsonMapper);
+    config.register(jsonProvider);
+    if (registerExceptionMapper) {
+      config.register(JsonParseExceptionMapper.class);
+    }
   }
 
   public T getConfiguration() {


### PR DESCRIPTION
Was running into an issue where an `ExceptionMapper` instance I'd registered for all `Throwable`s was getting overridden by the `GenericExceptionMapper` class that's registered in the `configureBaseApplication()` method. At the moment it's not preferable to just avoid calling `super.configureBaseApplication()` altogether, since I still want to register a body provider for JSON handling (current workaround is to not call `super.configureBaseApplication()` and just copy+paste the JSON body provider code into the subclass's `configureBaseApplication()` method). So, it'd be nice if there were a separate method for registering the body provider without also registering the `GenericExceptionMapper` instance or, for that matter, any unwanted `ExceptionMapper`s.