### PR TITLE
Ability to skip authentication for specific paths

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -201,6 +201,12 @@ public class RestConfig extends AbstractConfig {
   public static final List<String> AUTHENTICATION_ROLES_DEFAULT =
       Collections.unmodifiableList(Arrays.asList("*"));
 
+  public static final String AUTHENTICATION_SKIP_PATHS = "authentication.skip.paths";
+  public static final String AUTHENTICATION_SKIP_PATHS_DOC = "Comma separated list of paths that "
+                                                             + "can be "
+                                                             + "accessed without authentication";
+  public static final String AUTHENTICATION_SKIP_PATHS_DEFAULT = "";
+
   public static final String ENABLE_GZIP_COMPRESSION_CONFIG = "compression.enable";
   protected static final String ENABLE_GZIP_COMPRESSION_DOC = "Enable gzip compression";
   private static final boolean ENABLE_GZIP_COMPRESSION_DEFAULT = false;
@@ -402,6 +408,12 @@ public class RestConfig extends AbstractConfig {
             AUTHENTICATION_ROLES_DEFAULT,
             Importance.LOW,
             AUTHENTICATION_ROLES_DOC
+        ).define(
+            AUTHENTICATION_SKIP_PATHS,
+            Type.LIST,
+            AUTHENTICATION_SKIP_PATHS_DEFAULT,
+            Importance.LOW,
+            AUTHENTICATION_SKIP_PATHS_DOC
         ).define(
             ENABLE_GZIP_COMPRESSION_CONFIG,
             Type.BOOLEAN,

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -19,8 +19,9 @@ package io.confluent.rest;
 import io.confluent.common.config.ConfigException;
 import jersey.repackaged.com.google.common.collect.Lists;
 
+import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.SecurityHandler;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.Test;
 
@@ -33,6 +34,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ApplicationTest {
@@ -136,6 +138,66 @@ public class ApplicationTest {
     assertFalse(constraint.isAnyRole());
     assertEquals(constraint.getRoles().length, roles.size());
     assertArrayEquals(constraint.getRoles(), roles.toArray(new String[roles.size()]));
+  }
+
+  @Test
+  public void testSetUnsecurePathConstraintsWithMultipleUnSecure(){
+    ServletContextHandler servletContextHandler  = new ServletContextHandler();
+    final ArrayList<String> roles = Lists.<String>newArrayList("roleA", "roleB");
+    ConstraintSecurityHandler securityHandler = Application.createSecurityHandler(REALM, roles);
+    servletContextHandler.setSecurityHandler(securityHandler);
+    setAndAssertUnsecureConstraints(servletContextHandler, securityHandler, 3);
+  }
+
+  @Test
+  public void testSetUnsecurePathConstraintsWithSingleUnSecure(){
+    ServletContextHandler servletContextHandler  = new ServletContextHandler();
+    final ArrayList<String> roles = Lists.<String>newArrayList("roleA", "roleB");
+    ConstraintSecurityHandler securityHandler = Application.createSecurityHandler(REALM, roles);
+    servletContextHandler.setSecurityHandler(securityHandler);
+    setAndAssertUnsecureConstraints(servletContextHandler, securityHandler, 1);
+  }
+
+  @Test
+  public void testSetUnsecurePathConstraintsWithNoUnSecure(){
+    ServletContextHandler servletContextHandler  = new ServletContextHandler();
+    final ArrayList<String> roles = Lists.<String>newArrayList("roleA", "roleB");
+    ConstraintSecurityHandler securityHandler = Application.createSecurityHandler(REALM, roles);
+    servletContextHandler.setSecurityHandler(securityHandler);
+    setAndAssertUnsecureConstraints(servletContextHandler, securityHandler, 0);
+  }
+
+  @Test
+  public void testSetUnsecurePathConstraintsWithoutSecurityConstraints(){
+    ServletContextHandler servletContextHandler  = new ServletContextHandler();
+    Application.setUnsecurePathConstraints(
+        servletContextHandler,
+        Lists.<String>newArrayList("/path1"));
+    assertNull(servletContextHandler.getSecurityHandler());
+
+  }
+
+  private void setAndAssertUnsecureConstraints(
+      ServletContextHandler servletContextHandler,
+      ConstraintSecurityHandler securityHandler,
+      int numPaths
+  ) {
+    final List<String> unsecurePaths = new ArrayList<>();
+
+    for (int i=1;i<=numPaths;i++){
+      unsecurePaths.add("/test"+i);
+    }
+    Application.setUnsecurePathConstraints(servletContextHandler, unsecurePaths);
+
+    assertEquals(numPaths+1, securityHandler.getConstraintMappings().size());
+
+    List<ConstraintMapping> unsecureMappings = securityHandler.getConstraintMappings().subList(1, numPaths+1);
+
+    for (int i=0;i<unsecureMappings.size();i++){
+      assertEquals(unsecurePaths.get(i), unsecureMappings.get(i).getPathSpec());
+      assertNotNull(unsecureMappings.get(i).getConstraint());
+      assertFalse(unsecureMappings.get(i).getConstraint().getAuthenticate());
+    }
   }
 
   private void assertExpectedUri(URI uri, String scheme, String host, int port) {


### PR DESCRIPTION
This PR adds the ability to configure paths that can be accessed unauthenticated while turning on authentication. We add unauthenticated constraint for each of the path if there is an existing constraint. This is useful when people want to provide open access for all GET requests or health check resources, etc.