### PR TITLE
Updating upstream dependency to common

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,5 @@
 
 common {
   slackChannel = '#clients-eng'
-  upstreamProjects = 'confluentinc/common-docker'
+  upstreamProjects = 'confluentinc/common'
 }

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <groupId>io.confluent</groupId>
-        <artifactId>common-docker</artifactId>
+        <artifactId>common</artifactId>
         <version>4.1.0-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
Updating upstream dependency to common
- Based on ST-620. common-docker is being consolidated to common
- Staged PR for https://github.com/confluentinc/common/pull/91