### PR TITLE
Update Jetty and Jersey to latest versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,14 @@
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
+          <artifactId>jersey-guava</artifactId>
+        </dependency>
         <!-- Jersey dependency that was available in the JDK before Java 9 -->
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -214,7 +214,7 @@ public abstract class Application<T extends RestConfig> {
           );
 
           if (!config.getString(RestConfig.SSL_KEYMANAGER_ALGORITHM_CONFIG).isEmpty()) {
-            sslContextFactory.setSslKeyManagerFactoryAlgorithm(
+            sslContextFactory.setKeyManagerFactoryAlgorithm(
                     config.getString(RestConfig.SSL_KEYMANAGER_ALGORITHM_CONFIG));
           }
         }

--- a/core/src/main/java/io/confluent/rest/logging/AbstractNCSARequestLog.java
+++ b/core/src/main/java/io/confluent/rest/logging/AbstractNCSARequestLog.java
@@ -156,7 +156,7 @@ public abstract class AbstractNCSARequestLog extends AbstractLifeCycle implement
       buf.append("] \"");
       append(buf,request.getMethod());
       buf.append(' ');
-      append(buf, request.getUri().toString());
+      append(buf, request.getHttpURI().toString());
       buf.append(' ');
       append(buf,request.getProtocol());
       buf.append("\" ");

--- a/pom.xml
+++ b/pom.xml
@@ -51,11 +51,9 @@
         <apache.httpclient.version>4.5.3</apache.httpclient.version>
         <bouncycastle.bcpkix.version>1.58</bouncycastle.bcpkix.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <java.version>1.7</java.version>
-        <!-- can't upgrade jersey past 2.25 until we move to java 8 -->
-        <jersey.version>2.25</jersey.version>
-        <!-- can't upgrade jetty past 9.2 until we move to java 8 -->
-        <jetty.version>9.2.24.v20180105</jetty.version>
+        <jersey.version>2.27</jersey.version>
+        <jersey.guava.version>2.26-b03</jersey.guava.version>
+        <jetty.version>9.4.10.v20180503</jetty.version>
     </properties>
 
     <repositories>
@@ -86,6 +84,16 @@
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
                 <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.inject</groupId>
+                <artifactId>jersey-hk2</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.glassfish.jersey.bundles.repackaged</groupId>
+              <artifactId>jersey-guava</artifactId>
+              <version>${jersey.guava.version}</version>
             </dependency>
             <!-- Jersey dependency that was available in the JDK before Java 9 -->
             <dependency>


### PR DESCRIPTION
This is possible since we no longer support Java 7.