### PR TITLE
WIP - enable rest-utils to load authentication plugin via config

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -23,6 +23,8 @@ import io.confluent.common.config.ConfigDef.Importance;
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 
+import io.confluent.rest.auth.Authenticator;
+import io.confluent.rest.auth.NoCustomAuth;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -179,27 +181,41 @@ public class RestConfig extends AbstractConfig {
       + "server certificate. Leave blank to use Jetty's default.";
   protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = "";
 
+  public static final String AUTHENTICATION_METHOD_CUSTOM_TYPE_CONFIG =
+      "authentication.custom.class";
+
+  private static final String AUTHENTICATION_METHOD_CUSTOM_TYPE_DOC =
+      "A custom authentication implementation. Must implement " + Authenticator.class.getName();
+
   public static final String AUTHENTICATION_METHOD_CONFIG = "authentication.method";
   public static final String AUTHENTICATION_METHOD_NONE = "NONE";
   public static final String AUTHENTICATION_METHOD_BASIC = "BASIC";
+  public static final String AUTHENTICATION_METHOD_CUSTOM = "CUSTOM";
   public static final String AUTHENTICATION_METHOD_DOC =
-      "Method of authentication. Must be BASIC to enable authentication. "
-      + "You must supply a valid JAAS config file for the 'java.security.auth.login.config'"
-      + " system property for the appropriate authentication provider.";
+      "Method of authentication. Must be BASIC or CUSTOM to enable authentication. "
+      + "For BASIC, you must supply a valid JAAS config file for the "
+      + "'java.security.auth.login.config' system property for the appropriate "
+      + "authentication provider. "
+      + "For CUSTOM, you must supply your own authentication implementation via '"
+      + AUTHENTICATION_METHOD_CUSTOM_TYPE_CONFIG + "'";
+
   public static final ConfigDef.ValidString AUTHENTICATION_METHOD_VALIDATOR =
       ConfigDef.ValidString.in(
           Arrays.asList(
               AUTHENTICATION_METHOD_NONE,
-              AUTHENTICATION_METHOD_BASIC
+              AUTHENTICATION_METHOD_BASIC,
+              AUTHENTICATION_METHOD_CUSTOM
           )
       );
+
+
   public static final String AUTHENTICATION_REALM_CONFIG = "authentication.realm";
   public static final String AUTHENTICATION_REALM_DOC =
       "Security realm to be used in authentication.";
   public static final String AUTHENTICATION_ROLES_CONFIG = "authentication.roles";
   public static final String AUTHENTICATION_ROLES_DOC = "Valid roles to authenticate against.";
   public static final List<String> AUTHENTICATION_ROLES_DEFAULT =
-      Collections.unmodifiableList(Arrays.asList("*"));
+      Collections.unmodifiableList(Collections.singletonList("")); // Defaults to no role required.
 
   public static final String AUTHENTICATION_SKIP_PATHS = "authentication.skip.paths";
   public static final String AUTHENTICATION_SKIP_PATHS_DOC = "Comma separated list of paths that "
@@ -393,6 +409,12 @@ public class RestConfig extends AbstractConfig {
             SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT,
             Importance.LOW,
             SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC
+        ).define(
+            AUTHENTICATION_METHOD_CUSTOM_TYPE_CONFIG,
+            Type.CLASS,
+            NoCustomAuth.class,
+            Importance.LOW,
+            AUTHENTICATION_METHOD_CUSTOM_TYPE_DOC
         ).define(
             AUTHENTICATION_METHOD_CONFIG,
             Type.STRING,

--- a/core/src/main/java/io/confluent/rest/auth/AuthenticationResult.java
+++ b/core/src/main/java/io/confluent/rest/auth/AuthenticationResult.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+import java.security.Principal;
+import java.util.List;
+import javax.security.auth.Subject;
+
+/**
+ * The result of an authentication request.
+ *
+ * <p>The result can be one of several sub-types that reflect the result of the authentication
+ * request.
+ */
+public interface AuthenticationResult {
+
+  /**
+   * A successful Authentication with User information.
+   */
+  interface User extends AuthenticationResult {
+
+    UserIdentity getUserIdentity();
+  }
+
+  /**
+   * An Authentication Failure has been sent.
+   */
+  interface Failure extends AuthenticationResult {
+
+  }
+
+  static AuthenticationResult.User user(
+      final Subject subject,
+      final Principal userPrincipal,
+      final List<String> roles) {
+
+    // todo(ac): move to concrete type
+    final UserIdentity identity = new UserIdentity() {
+      @Override
+      public Subject getSubject() {
+        return subject;
+      }
+
+      @Override
+      public Principal getUserPrincipal() {
+        return userPrincipal;
+      }
+
+      @Override
+      public List<String> getUserRoles() {
+        return roles;
+      }
+    };
+
+    return () -> identity;
+  }
+
+  AuthenticationResult.Failure SENT_FAILURE = new Failure() {
+    @Override
+    public String toString() {
+      return "FAILURE";
+    }
+  };
+}

--- a/core/src/main/java/io/confluent/rest/auth/Authenticator.java
+++ b/core/src/main/java/io/confluent/rest/auth/Authenticator.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Interface implemented by custom Authenticators.
+ */
+public interface Authenticator {
+
+  /**
+   * Get the authentication method this authorizer can handle.
+   *
+   * @return the authentication method.
+   */
+  String getAuthMethod();
+
+  /**
+   * Called to authenticate a request.
+   *
+   * @param request the request to be authenticated
+   * @param response the request to be authenticated
+   * @return an {@link AuthenticationResult} indicating the state of authentication.
+   * @throws RuntimeException any exception thrown will result in a 500 / "Internal Server Error"
+   *     being returned to the client.
+   */
+  AuthenticationResult authenticate(HttpServletRequest request, HttpServletResponse response);
+
+  /**
+   * Called to stop the authenticator and release any resources.
+   */
+  default void shutdown() {}
+}

--- a/core/src/main/java/io/confluent/rest/auth/NoCustomAuth.java
+++ b/core/src/main/java/io/confluent/rest/auth/NoCustomAuth.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * Used as a place marker to indicate no custom auth method is defined.
+ */
+public class NoCustomAuth implements Authenticator {
+
+  // Todo(ac): default to BASIC rather than NonCustom?
+
+  @Override
+  public String getAuthMethod() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public AuthenticationResult authenticate(
+      final HttpServletRequest request,
+      final HttpServletResponse response) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/core/src/main/java/io/confluent/rest/auth/ServerAuthException.java
+++ b/core/src/main/java/io/confluent/rest/auth/ServerAuthException.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+/**
+ * Exception thrown on general authentication issues.
+ */
+@SuppressWarnings("unused") // Public API
+public class ServerAuthException extends RuntimeException {
+
+  public ServerAuthException() {
+  }
+
+  public ServerAuthException(final String msg) {
+    super(msg);
+  }
+
+  public ServerAuthException(final String msg, final Throwable cause) {
+    super(msg, cause);
+  }
+
+  public ServerAuthException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/core/src/main/java/io/confluent/rest/auth/UserIdentity.java
+++ b/core/src/main/java/io/confluent/rest/auth/UserIdentity.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+import java.security.Principal;
+import java.util.List;
+import javax.security.auth.Subject;
+
+/**
+ * Definition of a user itentity.
+ */
+public interface UserIdentity {
+
+  /**
+   * @return The user subject.
+   */
+  Subject getSubject();
+
+  /**
+   * @return The user principal.
+   */
+  Principal getUserPrincipal();
+
+  /**
+   * @return the roles the user has.
+   */
+  List<String> getUserRoles();
+}

--- a/core/src/main/java/io/confluent/rest/auth/jetty/NoOpLoginService.java
+++ b/core/src/main/java/io/confluent/rest/auth/jetty/NoOpLoginService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth.jetty;
+
+import java.util.Objects;
+import javax.servlet.ServletRequest;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.server.UserIdentity;
+
+/**
+ * A dummy LoginService impl to keep Jetty happy, but which isn't actually used by the
+ * authentication plugins.
+ */
+class NoOpLoginService implements LoginService {
+
+  private final String name;
+
+  NoOpLoginService(final String name) {
+    this.name = Objects.requireNonNull(name, "name");
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public UserIdentity login(
+      final String username,
+      final Object credentials,
+      final ServletRequest request) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public boolean validate(final UserIdentity user) {
+    return true;
+  }
+
+  @Override
+  public IdentityService getIdentityService() {
+    return null;
+  }
+
+  @Override
+  public void setIdentityService(final IdentityService service) {
+  }
+
+  @Override
+  public void logout(final UserIdentity user) {
+  }
+}

--- a/core/src/main/java/io/confluent/rest/auth/jetty/PluggableAuthenticator.java
+++ b/core/src/main/java/io/confluent/rest/auth/jetty/PluggableAuthenticator.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth.jetty;
+
+import io.confluent.rest.auth.AuthenticationResult;
+import io.confluent.rest.auth.UserIdentity;
+import io.confluent.rest.auth.Authenticator;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.security.DefaultIdentityService;
+import org.eclipse.jetty.security.IdentityService;
+import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.UserAuthentication;
+import org.eclipse.jetty.server.Authentication;
+import org.eclipse.jetty.server.Authentication.User;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+
+/**
+ * Converts a KSQL authenticator into a Jetty authenticator.
+ */
+public class PluggableAuthenticator
+    extends AbstractLifeCycle implements org.eclipse.jetty.security.Authenticator {
+
+  private interface Handler<T extends AuthenticationResult> {
+
+    Authentication handle(PluggableAuthenticator authenticator, T result);
+  }
+
+  private static final Map<
+      Class<? extends AuthenticationResult>, Handler<AuthenticationResult>> HANDLERS;
+
+  static {
+    final HashMap<
+        Class<? extends AuthenticationResult>,
+        Handler<AuthenticationResult>> handlers = new HashMap<>();
+
+    handlers.put(AuthenticationResult.User.class,
+        castHandler(PluggableAuthenticator::handleUser, AuthenticationResult.User.class));
+    handlers.put(AuthenticationResult.Failure.class,
+        castHandler(PluggableAuthenticator::handleFailure, AuthenticationResult.Failure.class));
+
+    HANDLERS = Collections.unmodifiableMap(handlers);
+  }
+
+  private final LoginService loginService;
+  private final IdentityService identityService;  // Todo(ac): can be injected
+  private final Authenticator delegate;
+
+  public PluggableAuthenticator(final Authenticator delegate) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.loginService = new NoOpLoginService(getAuthMethod());
+    this.identityService = new DefaultIdentityService();
+  }
+
+  @Override
+  public String getAuthMethod() {
+    return delegate.getAuthMethod();
+  }
+
+  public LoginService getLoginService() {
+    return loginService;
+  }
+
+  public IdentityService getIdentifyService() {
+    return identityService;
+  }
+
+  @Override
+  public void setConfiguration(final AuthConfiguration configuration) {
+    if (configuration.getIdentityService() != identityService) {
+      throw new IllegalStateException("Different identify service");
+    }
+
+    if (configuration.getLoginService() != loginService) {
+      throw new IllegalStateException("Different login service");
+    }
+  }
+
+  @Override
+  public void prepareRequest(final ServletRequest request) {
+  }
+
+  @Override
+  public Authentication validateRequest(
+      final ServletRequest request,
+      final ServletResponse response,
+      final boolean mandatory) throws org.eclipse.jetty.security.ServerAuthException {
+    try {
+      final HttpServletRequest httpRequest = (HttpServletRequest) request;
+      final HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+      final AuthenticationResult authenticate = delegate.authenticate(httpRequest, httpResponse);
+      return handleResult(authenticate);
+    } catch (final Exception e) {
+      throw new org.eclipse.jetty.security.ServerAuthException(e);
+    }
+  }
+
+  @Override
+  public boolean secureResponse(
+      final ServletRequest request,
+      final ServletResponse response,
+      final boolean mandatory,
+      final User validatedUser) {
+    return true;
+  }
+
+  protected void doStop() {
+    delegate.shutdown();
+  }
+
+  public Authentication handleResult(final AuthenticationResult result) {
+    return HANDLERS.entrySet()
+        .stream()
+        .filter(e -> e.getKey().isAssignableFrom(result.getClass()))
+        .findAny()
+        .orElseThrow(() ->
+            new UnsupportedOperationException("Unknown input type" + result.getClass()))
+        .getValue()
+        .handle(this, result);
+  }
+
+  private Authentication handleUser(final AuthenticationResult.User result) {
+    final UserIdentity user = result.getUserIdentity();
+    final String[] userRoles = user.getUserRoles().toArray(new String[0]);
+    final org.eclipse.jetty.server.UserIdentity output = identityService
+        .newUserIdentity(user.getSubject(), user.getUserPrincipal(), userRoles);
+    return new UserAuthentication(getAuthMethod(), output);
+  }
+
+  private Authentication handleFailure(final AuthenticationResult.Failure result) {
+    return new Authentication.Failure() {
+      @Override
+      public String toString() {
+        return result.toString();
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T extends AuthenticationResult> Handler<AuthenticationResult> castHandler(
+      final Handler<T> mapper,
+      final Class<T> type) {
+    return (authenticator, result) -> mapper.handle(authenticator, type.cast(result));
+  }
+}

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -110,8 +110,7 @@ public class ApplicationTest {
     assertTrue(securityHandler.getRoles().isEmpty());
     assertNotNull(securityHandler.getLoginService());
     assertNotNull(securityHandler.getAuthenticator());
-    assertEquals(1, securityHandler.getConstraintMappings().size());
-    assertFalse(securityHandler.getConstraintMappings().get(0).getConstraint().isAnyRole());
+    assertEquals(0, securityHandler.getConstraintMappings().size());
   }
 
   @Test

--- a/core/src/test/java/io/confluent/rest/auth/ServerAuthTest.java
+++ b/core/src/test/java/io/confluent/rest/auth/ServerAuthTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.auth;
+
+import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
+
+import com.sun.org.apache.xml.internal.serialize.OutputFormat;
+import io.confluent.common.Configurable;
+import io.confluent.common.utils.IntegrationTest;
+import io.confluent.rest.RestConfig;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.security.Principal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.security.auth.Subject;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import junit.textui.TestRunner;
+import org.apache.http.auth.BasicUserPrincipal;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.security.JaasUtils;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.jaas.spi.PropertyFileLoginModule;
+import org.junit.After;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+
+@Category({IntegrationTest.class})
+public class ServerAuthTest{
+
+//  private static final String PROPS_JAAS_REALM = "KsqlServer-Props";
+//
+//  @ClassRule
+//  public static final TemporaryFolder TMP_FOLDER = new TemporaryFolder();
+//
+//  private TestTerminal terminal;
+//  private Cli localCli;
+//  private TestKsqlRestApp server;
+//
+//  @After
+//  public void tearDown() throws Exception {
+//    if (localCli != null) {
+//      localCli.close();
+//      localCli = null;
+//    }
+//
+//    if (terminal != null) {
+//      terminal.close();
+//      terminal = null;
+//    }
+//
+//    if (server != null) {
+//      server.stop();
+//      server = null;
+//    }
+//  }
+//
+//  @Test
+//  public void shouldWorkWithNoAuth() {
+//    givenServerWith(ImmutableMap.<String, Object>builder()
+//        .put(RestConfig.AUTHENTICATION_METHOD_CONFIG, "NONE")
+//        .build());
+//
+//    givenClientWith(client -> {
+//    });
+//
+//    assertCanConnect();
+//  }
+//
+//  @Test
+//  public void shouldWorkWithBasicAuth() {
+//    givenServerWith(ImmutableMap.<String, Object>builder()
+//        .put(RestConfig.AUTHENTICATION_METHOD_CONFIG, "BASIC")
+//        .put(RestConfig.AUTHENTICATION_REALM_CONFIG, PROPS_JAAS_REALM)
+//        .put(RestConfig.AUTHENTICATION_ROLES_CONFIG, "ksql-cluster-1")
+//        .put(JaasUtils.JAVA_LOGIN_CONFIG_PARAM, EmbeddedSingleNodeKafkaCluster.getJaasConfigPath())
+//        .build());
+//
+//    givenClientWith(client -> client.setupAuthenticationCredentials("harry", "changeme"));
+//
+//    assertCanConnect();
+//  }
+//
+//  @Test
+//  public void shouldWorkWithCustomWithNoRoles() {
+//    givenServerWith(ImmutableMap.<String, Object>builder()
+//        .put(RestConfig.AUTHENTICATION_METHOD_CONFIG, "CUSTOM")
+//        .put(KsqlRestConfig.KSQL_CUSTOM_AUTHENTICATION_METHOD_TYPE_CONFIG,
+//            TestSecurityHandlerFactory.class)
+//        .put(TestSecurityHandlerFactory.TestConfig.SHARED_SECRET, "DoNotTellAnyOneThis")
+//        .build());
+//
+//    givenClientWith(client -> client.setUpCustomAuthentication("MyAuth DoNotTellAnyOneThis"));
+//
+//    assertCanConnect();
+//  }
+//
+//  @Test
+//  public void shouldWorkWithCustomWithRoles() {
+//    givenServerWith(ImmutableMap.<String, Object>builder()
+//        .put(RestConfig.AUTHENTICATION_METHOD_CONFIG, "CUSTOM")
+//        .put(RestConfig.AUTHENTICATION_ROLES_CONFIG, "role1")
+//        .put(KsqlRestConfig.KSQL_CUSTOM_AUTHENTICATION_METHOD_TYPE_CONFIG,
+//            TestSecurityHandlerFactory.class)
+//        .put(TestSecurityHandlerFactory.TestConfig.SHARED_SECRET, "DoNotTellAnyOneThis")
+//        .put(TestSecurityHandlerFactory.TestConfig.INJECT_ROLE, "role1")
+//        .build());
+//
+//    givenClientWith(client -> client.setUpCustomAuthentication("MyAuth DoNotTellAnyOneThis"));
+//
+//    assertCanConnect();
+//  }
+//
+//  private void assertCanConnect() {
+//    try {
+//      final TestRunner testRunner = new TestRunner(localCli, terminal);
+//
+//      final OrderedResult expectedResult = OrderedResult.build(
+//          ImmutableList.of(ImmutableList.of("TIMESTAMPTOSTRING", "SCALAR")));
+//
+//      testRunner.test("show functions", expectedResult);
+//    } catch (final AssertionError e) {
+//      throw new AssertionError("Failed to connect and run test command", e);
+//    }
+//  }
+//
+//  private void givenServerWith(final Map<String, ?> props) {
+//    server = TestKsqlRestApp
+//        .builder(CLUSTER::bootstrapServers)
+//        .withProperties(props)
+//        .build();
+//    server.start();
+//  }
+//
+//  private void givenClientWith(final Consumer<KsqlRestClient> handler) {
+//    final Map<String, Object> props = new HashMap<>();
+//    final KsqlRestClient restClient =
+//        new KsqlRestClient(server.getListeners().get(0).toString(), props);
+//
+//    handler.accept(restClient);
+//
+//    terminal = new TestTerminal(OutputFormat.TABULAR, restClient);
+//    localCli = new Cli(10000L, 10000L, restClient, terminal);
+//  }
+//
+//  private static String createJaasConfigContent() {
+//    try {
+//      TMP_FOLDER.create();
+//    } catch (final IOException e) {
+//      throw new RuntimeException(e);
+//    }
+//    final File credFile = copyResourceFile("/test-credentials.props", "/test-credentials.props");
+//    return PROPS_JAAS_REALM + " {\n  "
+//        + PropertyFileLoginModule.class.getName() + " required\n"
+//        + "  file=\"" + credFile + "\"\n"
+//        + "  debug=\"true\";\n"
+//        + "};\n";
+//  }
+//
+//  private static File copyResourceFile(final String source, final String destination) {
+//    try {
+//      final File pem = TMP_FOLDER.newFile(destination);
+//      Files.copy(
+//          SecurityIntegrationTest.class.getResourceAsStream(source),
+//          pem.toPath(),
+//          StandardCopyOption.REPLACE_EXISTING
+//      );
+//      return pem;
+//    } catch (final Exception e) {
+//      throw new RuntimeException("Failed to create JWT public key file", e);
+//    }
+//  }
+//
+//  public static final class TestSecurityHandlerFactory implements KsqlAuthenticator, Configurable {
+//
+//    private String sharedSecret = "NotConfiguredYet";
+//    private String roleToInject = "";
+//
+//    @Override
+//    public void configure(final Map<String, ?> props) {
+//      final TestConfig config = new TestConfig(props);
+//      sharedSecret = config.getString(TestConfig.SHARED_SECRET);
+//      roleToInject = config.getString(TestConfig.INJECT_ROLE);
+//    }
+//
+//    @Override
+//    public String getAuthMethod() {
+//      return "MyAuth";
+//    }
+//
+//    @Override
+//    public AuthenticationResult authenticate(
+//        final HttpServletRequest request,
+//        final HttpServletResponse response) {
+//
+//      String token = request.getHeader(HttpHeader.AUTHORIZATION.asString());
+//      if (token != null) {
+//        int space = token.indexOf(' ');
+//        if (space > 0) {
+//          String method = token.substring(0, space);
+//          if (getAuthMethod().equalsIgnoreCase(method)) {
+//            token = token.substring(space + 1);
+//            if (sharedSecret.equals(token)) {
+//              final Subject subject = new Subject();
+//              final Principal principal = new BasicUserPrincipal("fred");
+//              subject.getPrincipals().add(principal);
+//              final List<String> roles = roleToInject.isEmpty()
+//                  ? Collections.emptyList() : Collections.singletonList(roleToInject);
+//              return AuthenticationResult.user(subject, principal, roles);
+//            }
+//          }
+//        }
+//      }
+//
+//      try {
+//        response.sendError(401);
+//        return AuthenticationResult.SENT_FAILURE;
+//      } catch (final IOException e) {
+//        throw new ServerAuthException(e);
+//      }
+//    }
+//
+//    private static class TestConfig extends AbstractConfig {
+//
+//      private static final String SHARED_SECRET = "my.shared.secret";
+//      private static final String INJECT_ROLE = "role.to.inject";
+//
+//      private static final ConfigDef CONFIG_DEF = new ConfigDef()
+//          .define(
+//              SHARED_SECRET,
+//              Type.STRING,
+//              NO_DEFAULT_VALUE,
+//              new ConfigDef.NonEmptyString(),
+//              Importance.HIGH,
+//              "Some really insecure example of authenticating a user"
+//          ).define(
+//              INJECT_ROLE,
+//              Type.STRING,
+//              "",
+//              new ConfigDef.NonNullValidator(),
+//              Importance.HIGH,
+//              "A hacky way to inject a role each authenticated user will be in"
+//          );
+//
+//      private TestConfig(final Map<?, ?> originals) {
+//        super(CONFIG_DEF, originals);
+//      }
+//    }
+//  }
+}


### PR DESCRIPTION
VERY MUCH WIP.... but as I'm away on holiday from the 25th until the 4th I thought I'd raise this one to get some feedback while I'm away.

General thinking here is that services such as KSQL and SR will want the ability to configure authentication and authorisation via plugins. 

We shouldn't let internal implementation details, such as our use of Jetty, bleed through into these plugins. So we need to expose new non-jetty interfaces to implement.

I have this code working on a KSQL fork, which functional tests.  I've just hacked this across to rest-utils, (where I believe it should live). I'll tidy up / add tests etc, on my return.


