### PR TITLE
MMA-2878 - Enable security on websocket end points as well as http.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,5 +115,17 @@
             <classifier>test</classifier>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,13 +118,12 @@
         <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
-            <version>2.2.0</version>
+            <version>${asynchttpclient.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -161,7 +161,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Configure and create the server.
    */
-  public Server createServer() throws RestConfigException, ServletException {
+  public Server createServer() throws ServletException {
     // The configuration for the JAX-RS REST service
     ResourceConfig resourceConfig = new ResourceConfig();
 
@@ -323,6 +323,9 @@ public abstract class Application<T extends RestConfig> {
     webSocketServletContext.setContextPath(
         config.getString(RestConfig.WEBSOCKET_PATH_PREFIX_CONFIG)
     );
+
+    configureSecurityHandler(webSocketServletContext);
+
     final ContextHandlerCollection contexts = new ContextHandlerCollection();
     contexts.setHandlers(new Handler[] {
         statsHandler,

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -39,7 +39,9 @@ import org.asynchttpclient.ws.WebSocketUpgradeHandler;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,10 +88,13 @@ public class SaslTest {
   private SaslTestApplication app;
   private CloseableHttpClient httpclient;
 
+  @Rule
+  public final TemporaryFolder tmpFolder = new TemporaryFolder();
+
   @Before
   public void setUp() throws Exception {
-    File jaasFile = File.createTempFile("jaas", ".config");
-    File loginPropertiesFile = File.createTempFile("login", ".properties");
+    File jaasFile = tmpFolder.newFile("jaas.config");
+    File loginPropertiesFile = tmpFolder.newFile("login.properties");
 
     String jaas = "c3 {\n"
                   + "  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required\n"

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,27 @@
 
 package io.confluent.rest;
 
-import org.apache.http.HttpResponse;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.websocket.DeploymentException;
+import javax.websocket.EndpointConfig;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
+import javax.ws.rs.core.Response;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.ws.WebSocket;
+import org.asynchttpclient.ws.WebSocketListener;
+import org.asynchttpclient.ws.WebSocketUpgradeHandler;
+import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,7 +47,6 @@ import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
@@ -46,30 +60,36 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
 import javax.ws.rs.core.SecurityContext;
 
 import io.confluent.common.metrics.KafkaMetric;
 import io.confluent.rest.annotations.PerformanceMetric;
 
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.OK;
+import static javax.ws.rs.core.Response.Status.UNAUTHORIZED;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class SaslTest {
-  private static final Logger log = LoggerFactory.getLogger(SaslTest.class);
 
-  private File jaasFile;
-  private File loginPropertiesFile;
+  private static final Logger log = LoggerFactory.getLogger(SaslTest.class);
+  private static final String NEHA_BASIC_AUTH = "bmVoYTpha2Zhaw==";
+  private static final String JUN_BASIC_AUTH = "anVuOmthZmthLQ==";
+  private static final String HTTP_URI = "http://localhost:8080";
+  private static final String WS_URI = "ws://localhost:8080/ws";
+  private static final Pattern WS_ERROR_PATTERN = Pattern.compile(".*code=(\\d+).*");
+
   private String previousAuthConfig;
   private SaslTestApplication app;
   private CloseableHttpClient httpclient;
-  String httpUri = "http://localhost:8080";
 
   @Before
   public void setUp() throws Exception {
-    jaasFile = File.createTempFile("jaas", ".config");
-    loginPropertiesFile = File.createTempFile("login", ".properties");
+    File jaasFile = File.createTempFile("jaas", ".config");
+    File loginPropertiesFile = File.createTempFile("login", ".properties");
 
     String jaas = "c3 {\n"
                   + "  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required\n"
@@ -96,7 +116,7 @@ public class SaslTest {
     httpclient = HttpClients.createDefault();
     TestMetricsReporter.reset();
     Properties props = new Properties();
-    props.put(RestConfig.LISTENERS_CONFIG, httpUri);
+    props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI);
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
     configBasic(props);
     TestRestConfig config = new TestRestConfig(props);
@@ -106,6 +126,8 @@ public class SaslTest {
 
   @After
   public void cleanup() throws Exception {
+    assertMetricsCollected();
+
     Configuration.setConfiguration(null);
     if (previousAuthConfig != null) {
       System.setProperty("java.security.auth.login.config", previousAuthConfig);
@@ -117,56 +139,75 @@ public class SaslTest {
   private void configBasic(Properties props) {
     props.put(RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BASIC);
     props.put(RestConfig.AUTHENTICATION_REALM_CONFIG, "c3");
-    props.put(RestConfig.AUTHENTICATION_ROLES_CONFIG, Arrays.asList("Administrators"));
+    props.put(RestConfig.AUTHENTICATION_ROLES_CONFIG, Collections.singletonList("Administrators"));
   }
 
   @Test
   public void testNoAuthAttempt() throws Exception {
-    HttpResponse response = makeGetRequest(httpUri + "/test");
-    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusLine().getStatusCode());
-    assertMetricsCollected();
-  }
-
-  @Test
-  public void testBadLoginAttempt() throws Exception {
-    HttpResponse response = makeGetRequest(httpUri + "/test", "this shouldnt work");
-    assertEquals(Response.Status.UNAUTHORIZED.getStatusCode(), response.getStatusLine().getStatusCode());
-    assertMetricsCollected();
-  }
-
-
-  @Test
-  public void testAuthorizedAttempt() throws Exception {
-    CloseableHttpResponse response = null;
-    try {
-      response = makeGetRequest(httpUri + "/principal", "bmVoYTpha2Zhaw=="); // neha's user/pass
-      assertEquals(Response.Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
-      assertEquals("neha", EntityUtils.toString(response.getEntity()));
-      response.close();
-
-      response = makeGetRequest(httpUri + "/role/Administrators", "bmVoYTpha2Zhaw=="); // neha's user/pass
-      assertEquals(Response.Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
-      assertEquals("true", EntityUtils.toString(response.getEntity()));
-      response.close();
-
-      response = makeGetRequest(httpUri + "/role/blah", "bmVoYTpha2Zhaw=="); // neha's user/pass
-      assertEquals(Response.Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
-      assertEquals("false", EntityUtils.toString(response.getEntity()));
-      response.close();
-
-      assertMetricsCollected();
-    } finally {
-      if (response != null) {
-        response.close();
-      }
+    try (CloseableHttpResponse response = makeGetRequest( "/test")) {
+      assertEquals(UNAUTHORIZED.getStatusCode(), response.getStatusLine().getStatusCode());
     }
   }
 
   @Test
+  public void testNoAuthAttemptOnWs() throws Exception {
+    int statusCode = makeWsGetRequest(null);
+    assertEquals(UNAUTHORIZED.getStatusCode(), statusCode);
+  }
+
+  @Test
+  public void testBadLoginAttempt() throws Exception {
+    try (CloseableHttpResponse response =
+        makeGetRequest("/test", "this shouldnt work")) {
+      assertEquals(UNAUTHORIZED.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+  }
+
+  @Test
+  public void testBadLoginAttemptOnWs() throws Exception {
+    int statusCode = makeWsGetRequest("this shouldnt work");
+    assertEquals(UNAUTHORIZED.getStatusCode(), statusCode);
+  }
+
+  @Test
+  public void testAuthorizedAttempt() throws Exception {
+    try (CloseableHttpResponse response =
+        makeGetRequest("/principal", NEHA_BASIC_AUTH)) {
+      assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+      assertEquals("neha", EntityUtils.toString(response.getEntity()));
+    }
+
+    try (CloseableHttpResponse response =
+        makeGetRequest("/role/Administrators", NEHA_BASIC_AUTH)) {
+      assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+      assertEquals("true", EntityUtils.toString(response.getEntity()));
+    }
+
+    try (CloseableHttpResponse response =
+      makeGetRequest("/role/blah", NEHA_BASIC_AUTH)) {
+      assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+      assertEquals("false", EntityUtils.toString(response.getEntity()));
+    }
+  }
+
+  @Test
+  public void testAuthorizedAttemptOnWs() throws Exception {
+    int statusCode = makeWsGetRequest(NEHA_BASIC_AUTH);
+    assertEquals(OK.getStatusCode(), statusCode);
+  }
+
+  @Test
   public void testUnauthorizedAttempt() throws Exception {
-    HttpResponse response = makeGetRequest(httpUri + "/principal", "anVuOmthZmthLQ=="); // jun's user/pass
-    assertEquals(Response.Status.FORBIDDEN.getStatusCode(), response.getStatusLine().getStatusCode());
-    assertMetricsCollected();
+    try (CloseableHttpResponse response =
+        makeGetRequest("/principal", JUN_BASIC_AUTH)) {
+      assertEquals(FORBIDDEN.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+  }
+
+  @Test
+  public void testUnAuthorizedAttemptOnWs() throws Exception {
+    int statusCode = makeWsGetRequest(JUN_BASIC_AUTH);
+    assertEquals(FORBIDDEN.getStatusCode(), statusCode);
   }
 
   private void assertMetricsCollected() {
@@ -183,30 +224,88 @@ public class SaslTest {
       String url,
       String basicAuth
   ) throws Exception {
-    log.debug("Making GET " + url);
-    HttpGet httpget = new HttpGet(url);
+    log.debug("Making GET " + HTTP_URI + url);
+    HttpGet httpget = new HttpGet(HTTP_URI + url);
     if (basicAuth != null) {
       httpget.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth);
     }
 
-    CloseableHttpResponse response = null;
-    response = httpclient.execute(httpget);
-    return response;
+    return httpclient.execute(httpget);
   }
 
-  // returns the http response status code.
-  private HttpResponse makeGetRequest(String url) throws Exception {
+  private CloseableHttpResponse makeGetRequest(String url) throws Exception {
     return makeGetRequest(url, null);
   }
 
+  private int makeWsGetRequest(String basicAuth) throws Exception {
+    log.debug("Making WebSocket GET " + WS_URI + "/test");
+
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+
+    WebSocketUpgradeHandler wsHandler = new WebSocketUpgradeHandler.Builder()
+        .addWebSocketListener(new WebSocketListener() {
+          public void onOpen(WebSocket websocket) {
+            // WebSocket connection opened
+          }
+
+          public void onClose(WebSocket websocket, int code, String reason) {
+            // WebSocket connection closed
+          }
+
+          public void onError(Throwable t) {
+            log.info("Websocket failed", t);
+            error.set(t);
+          }
+        }).build();
+
+    BoundRequestBuilder requestBuilder = Dsl.asyncHttpClient()
+        .prepareGet(WS_URI + "/test");
+
+    if (basicAuth != null) {
+      requestBuilder = requestBuilder
+          .addHeader(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth);
+    }
+
+    WebSocket ws = requestBuilder
+        .setRequestTimeout(5000)
+        .execute(wsHandler)
+        .get();
+
+    if (error.get() != null) {
+      return extractStatusCode(error.get().getMessage());
+    }
+
+    ws.sendCloseFrame();
+    return Response.Status.OK.getStatusCode();
+  }
+
+  private static int extractStatusCode(final String message) {
+    final Matcher matcher = WS_ERROR_PATTERN.matcher(message);
+    assertTrue("Test invalid", matcher.matches());
+    return Integer.parseInt(matcher.group(1));
+  }
+
   private static class SaslTestApplication extends Application<TestRestConfig> {
-    public SaslTestApplication(TestRestConfig props) {
+    private SaslTestApplication(TestRestConfig props) {
       super(props);
     }
 
     @Override
     public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
       config.register(new SaslTestResource());
+    }
+
+    @Override
+    protected void registerWebSocketEndpoints(final ServerContainer container) {
+      try {
+        container.addEndpoint(ServerEndpointConfig.Builder
+            .create(
+                WSEndpoint.class,
+                WSEndpoint.class.getAnnotation(ServerEndpoint.class).value()
+            ).build());
+      } catch (DeploymentException e) {
+        fail("Invalid test");
+      }
     }
 
     @Override
@@ -233,6 +332,27 @@ public class SaslTest {
         @Context SecurityContext context
     ) {
       return context.isUserInRole(role);
+    }
+  }
+
+  @ServerEndpoint(value = "/test")
+  public static class WSEndpoint {
+    public WSEndpoint() {
+
+    }
+
+    @OnOpen
+    public void onOpen(final Session session, final EndpointConfig endpointConfig) {
+      session.getAsyncRemote().sendText("Test message",
+          result -> {
+            if (!result.isOK()) {
+              log.warn(
+                  "Error sending websocket message for session {}",
+                  session.getId(),
+                  result.getException()
+              );
+            }
+          });
     }
   }
 }

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -337,10 +337,6 @@ public class SaslTest {
 
   @ServerEndpoint(value = "/test")
   public static class WSEndpoint {
-    public WSEndpoint() {
-
-    }
-
     @OnOpen
     public void onOpen(final Session session, final EndpointConfig endpointConfig) {
       session.getAsyncRemote().sendText("Test message",

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.11.v20180605</jetty.version>
+        <asynchttpclient.version>2.2.0</asynchttpclient.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Fixes: [MMA-2878](https://confluentinc.atlassian.net/browse/MMA-2878)

Noticed that the rest utils does not currently set up security on the websocket end points. This PR adds a puts the same auth on the websocket requests as was already on the http requests, and adds suitable tests.