### PR TITLE
Support custom init.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -90,9 +90,7 @@ import io.confluent.rest.validation.JacksonMessageBodyProvider;
  * resources with the JAX-RS server. Use createServer() to get a fully-configured, ready to run
  * Jetty server.
  */
-// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public abstract class Application<T extends RestConfig> {
-  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   protected T config;
   protected Server server = null;
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -173,10 +171,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Configure and create the server.
    */
-  // CHECKSTYLE_RULES.OFF: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
   public Server createServer() throws ServletException {
-    // CHECKSTYLE_RULES.ON: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
-
     // The configuration for the JAX-RS REST service
     ResourceConfig resourceConfig = new ResourceConfig();
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -17,7 +17,7 @@
 package io.confluent.rest;
 
 import static io.confluent.rest.RestConfig.REST_SERVLET_INITIALIZERS_CLASSES_CONFIG;
-import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG;
+import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
@@ -344,7 +344,7 @@ public abstract class Application<T extends RestConfig> {
         WebSocketServerContainerInitializer.configureContext(webSocketContext);
     registerWebSocketEndpoints(container);
 
-    applyCustomConfiguration(webSocketContext, WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG);
+    applyCustomConfiguration(webSocketContext, WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG);
 
     int gracefulShutdownMs = getConfiguration().getInt(RestConfig.SHUTDOWN_GRACEFUL_MS_CONFIG);
     if (gracefulShutdownMs > 0) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -90,7 +90,9 @@ import io.confluent.rest.validation.JacksonMessageBodyProvider;
  * resources with the JAX-RS server. Use createServer() to get a fully-configured, ready to run
  * Jetty server.
  */
+// CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public abstract class Application<T extends RestConfig> {
+  // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
   protected T config;
   protected Server server = null;
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -171,7 +173,10 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Configure and create the server.
    */
+  // CHECKSTYLE_RULES.OFF: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
   public Server createServer() throws ServletException {
+    // CHECKSTYLE_RULES.ON: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
+
     // The configuration for the JAX-RS REST service
     ResourceConfig resourceConfig = new ResourceConfig();
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -22,7 +22,7 @@ import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSE
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.security.ConstraintMapping;
@@ -360,10 +360,10 @@ public abstract class Application<T extends RestConfig> {
       ServletContextHandler context,
       String initializerConfigName) {
     getConfiguration()
-        .getConfiguredInstances(initializerConfigName, Consumer.class)
+        .getConfiguredInstances(initializerConfigName, BiConsumer.class)
         .forEach(initializer -> {
           try {
-            initializer.accept(context);
+            initializer.accept(context, getConfiguration());
           } catch (final Exception e) {
             throw new RuntimeException("Exception from custom initializer. "
                 + "config:" + initializerConfigName + ", initializer" + initializer, e);

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -228,7 +228,7 @@ public class RestConfig extends AbstractConfig {
       "websocket.servlet.initializor.classes";
   public static final String WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the websocket endpoint's ServletContextHandler. "
-          + "Each initializer must implement <ServletContextHandler>. "
+          + "Each initializer must implement Consumer<ServletContextHandler>. "
           + "It will be called to perform custom initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -219,7 +219,8 @@ public class RestConfig extends AbstractConfig {
       "rest.servlet.initializor.classes";
   public static final String REST_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the rest endpoint's ServletContextHandler. "
-          + "Each initializer must implement Consumer<ServletContextHandler>. "
+          + "Each initializer must implement "
+          + "BiConsumer<ServletContextHandler, ? extends RestConfig>. "
           + "It will be called to perform initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";
@@ -228,7 +229,8 @@ public class RestConfig extends AbstractConfig {
       "websocket.servlet.initializor.classes";
   public static final String WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the websocket endpoint's ServletContextHandler. "
-          + "Each initializer must implement Consumer<ServletContextHandler>. "
+          + "Each initializer must implement "
+          + "BiConsumer<ServletContextHandler, ? extends RestConfig>. "
           + "It will be called to perform custom initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class RestConfig extends AbstractConfig {
   public static final String DEBUG_CONFIG = "debug";
@@ -235,7 +234,9 @@ public class RestConfig extends AbstractConfig {
           + "including changes to the Jetty version";
 
 
+  // CHECKSTYLE_RULES.OFF: MethodLength
   public static ConfigDef baseConfigDef() {
+    // CHECKSTYLE_RULES.ON: MethodLength
     return new ConfigDef()
         .define(
             DEBUG_CONFIG,

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 
 public class RestConfig extends AbstractConfig {
   public static final String DEBUG_CONFIG = "debug";
@@ -219,8 +220,7 @@ public class RestConfig extends AbstractConfig {
       "rest.servlet.initializor.classes";
   public static final String REST_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the rest endpoint's ServletContextHandler. "
-          + "Each initializer must implement "
-          + "BiConsumer<ServletContextHandler, ? extends RestConfig>. "
+          + "Each initializer must implement Consumer<ServletContextHandler>. "
           + "It will be called to perform initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";
@@ -229,8 +229,7 @@ public class RestConfig extends AbstractConfig {
       "websocket.servlet.initializor.classes";
   public static final String WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the websocket endpoint's ServletContextHandler. "
-          + "Each initializer must implement "
-          + "BiConsumer<ServletContextHandler, ? extends RestConfig>. "
+          + "Each initializer must implement <ServletContextHandler>. "
           + "It will be called to perform custom initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";
@@ -473,7 +472,7 @@ public class RestConfig extends AbstractConfig {
   }
 
   public RestConfig(ConfigDef definition) {
-    super(definition, new TreeMap<Object,Object>());
+    super(definition, new TreeMap<>());
   }
 
   public Time getTime() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -215,6 +215,25 @@ public class RestConfig extends AbstractConfig {
   protected static final String ENABLE_GZIP_COMPRESSION_DOC = "Enable gzip compression";
   private static final boolean ENABLE_GZIP_COMPRESSION_DEFAULT = true;
 
+  public static final String REST_SERVLET_INITIALIZERS_CLASSES_CONFIG =
+      "rest.servlet.initializor.classes";
+  public static final String REST_SERVLET_INITIALIZER_CLASSES_DOC =
+      "Defines one or more initializer for the rest endpoint's ServletContextHandler. "
+          + "Each initializer must implement Consumer<ServletContextHandler>. "
+          + "It will be called to perform initialization of the handler, in order. "
+          + "This is an internal feature and subject to change, "
+          + "including changes to the Jetty version";
+
+  public static final String WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG =
+      "websocket.servlet.initializor.classes";
+  public static final String WEBSOCKET_SERVLET_INITIALIZER_CLASSES_DOC =
+      "Defines one or more initializer for the websocket endpoint's ServletContextHandler. "
+          + "Each initializer must implement Consumer<ServletContextHandler>. "
+          + "It will be called to perform custom initialization of the handler, in order. "
+          + "This is an internal feature and subject to change, "
+          + "including changes to the Jetty version";
+
+
   public static ConfigDef baseConfigDef() {
     return new ConfigDef()
         .define(
@@ -430,6 +449,18 @@ public class RestConfig extends AbstractConfig {
             "/ws",
             Importance.LOW,
             WEBSOCKET_PATH_PREFIX_DOC
+        ).define(
+            REST_SERVLET_INITIALIZERS_CLASSES_CONFIG,
+            Type.LIST,
+            Collections.emptyList(),
+            Importance.LOW,
+            REST_SERVLET_INITIALIZER_CLASSES_DOC
+        ).define(
+            WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG,
+            Type.LIST,
+            Collections.emptyList(),
+            Importance.LOW,
+            WEBSOCKET_SERVLET_INITIALIZER_CLASSES_DOC
         );
   }
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -217,16 +217,16 @@ public class RestConfig extends AbstractConfig {
 
   public static final String REST_SERVLET_INITIALIZERS_CLASSES_CONFIG =
       "rest.servlet.initializor.classes";
-  public static final String REST_SERVLET_INITIALIZER_CLASSES_DOC =
+  public static final String REST_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the rest endpoint's ServletContextHandler. "
           + "Each initializer must implement Consumer<ServletContextHandler>. "
           + "It will be called to perform initialization of the handler, in order. "
           + "This is an internal feature and subject to change, "
           + "including changes to the Jetty version";
 
-  public static final String WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG =
+  public static final String WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG =
       "websocket.servlet.initializor.classes";
-  public static final String WEBSOCKET_SERVLET_INITIALIZER_CLASSES_DOC =
+  public static final String WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC =
       "Defines one or more initializer for the websocket endpoint's ServletContextHandler. "
           + "Each initializer must implement Consumer<ServletContextHandler>. "
           + "It will be called to perform custom initialization of the handler, in order. "
@@ -454,13 +454,13 @@ public class RestConfig extends AbstractConfig {
             Type.LIST,
             Collections.emptyList(),
             Importance.LOW,
-            REST_SERVLET_INITIALIZER_CLASSES_DOC
+            REST_SERVLET_INITIALIZERS_CLASSES_DOC
         ).define(
-            WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG,
+            WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG,
             Type.LIST,
             Collections.emptyList(),
             Importance.LOW,
-            WEBSOCKET_SERVLET_INITIALIZER_CLASSES_DOC
+            WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC
         );
   }
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -234,9 +234,7 @@ public class RestConfig extends AbstractConfig {
           + "including changes to the Jetty version";
 
 
-  // CHECKSTYLE_RULES.OFF: MethodLength
   public static ConfigDef baseConfigDef() {
-    // CHECKSTYLE_RULES.ON: MethodLength
     return new ConfigDef()
         .define(
             DEBUG_CONFIG,

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -23,9 +23,10 @@ import static org.junit.Assert.fail;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import javax.websocket.EndpointConfig;
 import javax.websocket.OnOpen;
 import javax.websocket.Session;
@@ -162,10 +163,18 @@ public class CustomInitTest {
     }
   }
 
-  public static class CustomRestInitializer implements BiConsumer<ServletContextHandler, RestConfig> {
+  public static class CustomRestInitializer
+      implements Consumer<ServletContextHandler>, io.confluent.common.Configurable {
+
+    private RestConfig config;
 
     @Override
-    public void accept(final ServletContextHandler context, final RestConfig config) {
+    public void configure(final Map<String, ?> config) {
+      this.config = new RestConfig(RestConfig.baseConfigDef(), config);
+    }
+
+    @Override
+    public void accept(final ServletContextHandler context) {
       final List<String> roles = config.getList(RestConfig.AUTHENTICATION_ROLES_CONFIG);
       final Constraint constraint = new Constraint();
       constraint.setAuthenticate(true);
@@ -210,9 +219,9 @@ public class CustomInitTest {
     }
   }
 
-  public static class CustomWsInitializer implements BiConsumer<ServletContextHandler, RestConfig> {
+  public static class CustomWsInitializer implements Consumer<ServletContextHandler> {
     @Override
-    public void accept(final ServletContextHandler context, final RestConfig config) {
+    public void accept(final ServletContextHandler context) {
       try {
         ServerContainer container = context.getBean(ServerContainer.class);
 

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -78,7 +78,7 @@ public class CustomInitTest {
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
     props.put(RestConfig.REST_SERVLET_INITIALIZERS_CLASSES_CONFIG,
         Collections.singletonList(CustomRestInitializer.class.getName()));
-    props.put(RestConfig.WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG,
+    props.put(RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG,
         Collections.singletonList(CustomWsInitializer.class.getName()));
 
     app = new CustomInitTestApplication(new TestRestConfig(props));

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright 2016 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest;
+
+import static javax.ws.rs.core.Response.Status.FORBIDDEN;
+import static javax.ws.rs.core.Response.Status.OK;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.Collections;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import javax.websocket.EndpointConfig;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import javax.websocket.server.ServerEndpointConfig;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.ws.WebSocket;
+import org.asynchttpclient.ws.WebSocketListener;
+import org.asynchttpclient.ws.WebSocketUpgradeHandler;
+import org.eclipse.jetty.security.AbstractLoginService;
+import org.eclipse.jetty.security.ConstraintMapping;
+import org.eclipse.jetty.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.security.authentication.BasicAuthenticator;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.security.Password;
+import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CustomInitTest {
+
+  private static final Logger log = LoggerFactory.getLogger(CustomInitTest.class);
+  private static final String HTTP_URI = "http://localhost:8080";
+  private static final String WS_URI = "ws://localhost:8080/ws";
+  private static final String NEHAS_BASIC_AUTH = "bmVoYTpha2Zhaw==";
+  private static final String JUNS_BASIC_AUTH = "anVuOmthZmthLQ==";
+
+  private CustomInitTestApplication app;
+  private CloseableHttpClient httpclient;
+
+  @Before
+  public void setUp() throws Exception {
+    httpclient = HttpClients.createDefault();
+
+    final Properties props = new Properties();
+    props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI);
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    props.put(RestConfig.REST_SERVLET_INITIALIZERS_CLASSES_CONFIG,
+        Collections.singletonList(CustomRestInitializer.class.getName()));
+    props.put(RestConfig.WEBSOCKET_SERVLET_INITIALIZER_CLASSES_CONFIG,
+        Collections.singletonList(CustomWsInitializer.class.getName()));
+
+    app = new CustomInitTestApplication(new TestRestConfig(props));
+    app.start();
+  }
+
+  @After
+  public void cleanup() throws Exception {
+    httpclient.close();
+    app.stop();
+  }
+
+  @Test
+  public void shouldBeAbleToInstallSecurityHandler() throws Exception {
+    try (CloseableHttpResponse response = makeRestGetRequest(NEHAS_BASIC_AUTH)) {
+      assertEquals(OK.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+
+    try (CloseableHttpResponse response = makeRestGetRequest(JUNS_BASIC_AUTH)) {
+      assertEquals(FORBIDDEN.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+  }
+
+  @Test
+  public void shouldBeAbleToAddWebSocketEndPoint() throws Exception {
+    makeWsGetRequest();
+  }
+
+  private CloseableHttpResponse makeRestGetRequest(String basicAuth) throws Exception {
+    log.debug("Making GET " + HTTP_URI + "/test");
+    HttpGet httpget = new HttpGet(HTTP_URI + "/test");
+    if (basicAuth != null) {
+      httpget.setHeader(HttpHeaders.AUTHORIZATION, "Basic " + basicAuth);
+    }
+
+    CloseableHttpResponse response = null;
+    response = httpclient.execute(httpget);
+    return response;
+  }
+
+  private void makeWsGetRequest() throws Exception {
+    log.debug("Making WebSocket GET " + WS_URI + "/test");
+    final AtomicReference<Throwable> error = new AtomicReference<>();
+    WebSocketUpgradeHandler wsHandler = new WebSocketUpgradeHandler.Builder()
+        .addWebSocketListener(new WebSocketListener() {
+          public void onOpen(WebSocket websocket) {
+            // WebSocket connection opened
+          }
+          public void onClose(WebSocket websocket, int code, String reason) {
+            // WebSocket connection closed
+          }
+          public void onError(Throwable t) {
+            log.info("Websocket failed", t);
+            error.set(t);
+          }
+        }).build();
+
+    WebSocket ws = Dsl.asyncHttpClient()
+        .prepareGet(WS_URI + "/test")
+        .setRequestTimeout(5000)
+        .execute(wsHandler)
+        .get();
+
+    if (error.get() != null) {
+      throw new RuntimeException("Error connecting websocket", error.get());
+    }
+
+    ws.sendCloseFrame();
+  }
+
+  private static class CustomInitTestApplication extends Application<TestRestConfig> {
+    private CustomInitTestApplication(TestRestConfig props) {
+      super(props);
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
+      config.register(new CustomRestResource());
+    }
+  }
+
+  public static class CustomRestInitializer implements Consumer<ServletContextHandler> {
+
+    @Override
+    public void accept(final ServletContextHandler context) {
+      final Constraint constraint = new Constraint();
+      constraint.setAuthenticate(true);
+      constraint.setRoles(new String[]{"SomeRequiredRole"});
+      ConstraintMapping constraintMapping = new ConstraintMapping();
+      constraintMapping.setConstraint(constraint);
+      constraintMapping.setMethod("*");
+      constraintMapping.setPathSpec("/*");
+
+      final ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
+      securityHandler.addConstraintMapping(constraintMapping);
+      securityHandler.setAuthenticator(new BasicAuthenticator());
+      securityHandler.setLoginService(new TestLoginService("TestRealm"));
+      securityHandler.setRealmName("TestRealm");
+
+     context.setSecurityHandler(securityHandler);
+    }
+  }
+
+  private static class TestLoginService extends AbstractLoginService {
+    private TestLoginService(final String realm) {
+    }
+
+    @Override
+    protected String[] loadRoleInfo(final UserPrincipal user) {
+      if (user.getName().equals("jun")) {
+        return new String[] {"some-role"};
+      }
+      if (user.getName().equals("neha")) {
+        return new String[] {"SomeRequiredRole","another"};
+      }
+      return new String[0];
+    }
+
+    @Override
+    protected UserPrincipal loadUserInfo(final String username) {
+      if (username.equals("jun")) {
+        return new UserPrincipal(username, new Password("kafka-"));
+      }
+      if (username.equals("neha")) {
+        return new UserPrincipal(username, new Password("akfak"));
+      }
+      return null;
+    }
+  }
+
+  public static class CustomWsInitializer implements Consumer<ServletContextHandler> {
+
+    @Override
+    public void accept(final ServletContextHandler context) {
+      try {
+        ServerContainer container = context.getBean(ServerContainer.class);
+
+        container.addEndpoint(ServerEndpointConfig.Builder
+            .create(
+                WSEndpoint.class,
+                WSEndpoint.class.getAnnotation(ServerEndpoint.class).value()
+            ).build());
+      } catch (Exception e) {
+        fail("Invalid test");
+      }
+    }
+  }
+
+  @Path("/test")
+  @Produces(MediaType.TEXT_PLAIN)
+  public static class CustomRestResource {
+    @GET
+    @Path("/")
+    public String hello() {
+      return "Hello";
+    }
+  }
+
+  @ServerEndpoint(value = "/test")
+  public static class WSEndpoint {
+    @OnOpen
+    public void onOpen(final Session session, final EndpointConfig endpointConfig) {
+      session.getAsyncRemote().sendText("Test message",
+          result -> {
+            if (!result.isOK()) {
+              log.warn(
+                  "Error sending websocket message for session {}",
+                  session.getId(),
+                  result.getException()
+              );
+            }
+          });
+    }
+  }
+}


### PR DESCRIPTION
This PR looks to add some very basic hooks to allow the RESTful and WS servlets to be customised using _configuration_, rather than by subclassing.

It's petty basic. To customise, you write a class that `implements BiConsumer<ServletContextHandler, ? extends RestConfig>` and add it to the list of initialisers for either or both servlets. The app will then instantiate your class and pass you the appropriate servlet and app config, (after all other initialisation has been done, but before it is started), for you to do what you want with.

I've used `BiConsumer` as its a standard Java interface, meaning no need for any other deps.

There is obviously a risk that people can do dumb stuff with this, but that's not really the point. People can always do dumb stuff!  This enabled people to tweak things if they really want / need to.

I've made it clear this is an unsupported / internal / likely-to-change / no-promises-made-on-backwards-compatibility feature.
