### PR TITLE
fix authentication breaking CORS preflight requests

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -303,19 +303,20 @@ public abstract class Application<T extends RestConfig> {
     List<String> unsecurePaths = config.getList(RestConfig.AUTHENTICATION_SKIP_PATHS);
     setUnsecurePathConstraints(context, unsecurePaths);
 
-    String allowedOrigins = getConfiguration().getString(
-        RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG
-    );
-    if (allowedOrigins != null && !allowedOrigins.trim().isEmpty()) {
+    if (isCorsEnabled()) {
+      String allowedOrigins = config.getString(RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
+      String allowedMethods = config.getString(RestConfig.ACCESS_CONTROL_ALLOW_METHODS);
       FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
       filterHolder.setName("cross-origin");
-      filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_ORIGINS_PARAM, allowedOrigins);
-      String allowedMethods = getConfiguration().getString(
-          RestConfig.ACCESS_CONTROL_ALLOW_METHODS
+      filterHolder.setInitParameter(
+          CrossOriginFilter.ALLOWED_ORIGINS_PARAM, allowedOrigins
+
       );
-      if (allowedMethods != null && !allowedOrigins.trim().isEmpty()) {
+      if (allowedMethods != null && !allowedMethods.trim().isEmpty()) {
         filterHolder.setInitParameter(CrossOriginFilter.ALLOWED_METHODS_PARAM, allowedMethods);
       }
+      // handle preflight cors requests at the filter level, do not forward down the filter chain
+      filterHolder.setInitParameter(CrossOriginFilter.CHAIN_PREFLIGHT_PARAM, "false");
       context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
     }
     configurePreResourceHandling(context);
@@ -366,6 +367,11 @@ public abstract class Application<T extends RestConfig> {
     server.setStopAtShutdown(true);
 
     return server;
+  }
+
+  private boolean isCorsEnabled() {
+    String allowedOrigins = config.getString(RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
+    return allowedOrigins != null && !allowedOrigins.trim().isEmpty();
   }
 
   @SuppressWarnings("unchecked")
@@ -432,12 +438,11 @@ public abstract class Application<T extends RestConfig> {
     }
   }
 
-
   static boolean enableBasicAuth(String authMethod) {
     return RestConfig.AUTHENTICATION_METHOD_BASIC.equals(authMethod);
   }
 
-  static ConstraintSecurityHandler createBasicSecurityHandler(String realm, List<String> roles) {
+  protected ConstraintSecurityHandler createBasicSecurityHandler(String realm, List<String> roles) {
     final ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
     ConstraintMapping constraintMapping = createGlobalAuthConstraint(roles);
     securityHandler.addConstraintMapping(constraintMapping);
@@ -448,13 +453,17 @@ public abstract class Application<T extends RestConfig> {
     return securityHandler;
   }
 
-  protected static ConstraintMapping createGlobalAuthConstraint(List<String> roles) {
+  protected ConstraintMapping createGlobalAuthConstraint(List<String> roles) {
     Constraint constraint = new Constraint();
     constraint.setAuthenticate(true);
     constraint.setRoles(roles.toArray(new String[0]));
     ConstraintMapping constraintMapping = new ConstraintMapping();
     constraintMapping.setConstraint(constraint);
     constraintMapping.setMethod("*");
+    if (isCorsEnabled()) {
+      // CORS preflight requests must be allowed without authentication
+      constraintMapping.setMethodOmissions(new String[]{"OPTIONS"});
+    }
     constraintMapping.setPathSpec("/*");
     return constraintMapping;
   }


### PR DESCRIPTION
* disable authentication for OPTIONS requests when CORS is enabled
* do not forward CORS preflight requests down the filter chain

Note: regular OPTIONS requests without CORS preflight headers will still
be forwarded down the filter chain, so this would break applications
that require authentication for those requests. I don't think we have
any application explicitly handling OPTIONS requests, so the risk should
be low.