### PR TITLE
Add test for default 'anyRole' config.

### DIFF
--- a/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
+++ b/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
@@ -18,7 +18,7 @@ package io.confluent.rest.auth;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.RestConfig;
@@ -108,6 +108,17 @@ public class AuthUtilTest {
 
     // Then:
     assertThat(mapping.getConstraint().getAuthenticate(), is(true));
+  }
+
+  @Test
+  public void shouldDefaultToCreatingGlobalConstraintWithAnyRole() {
+    // When:
+    final ConstraintMapping mapping = AuthUtil.createGlobalAuthConstraint(config);
+
+    // Then:
+    assertThat(mapping.getConstraint().isAnyRole(), is(true));
+    assertThat(mapping.getConstraint().isAnyAuth(), is(false));
+    assertThat(mapping.getConstraint().getRoles(), is(new String[]{"*"}));
   }
 
   @Test


### PR DESCRIPTION
Add test to check default config adds global constraint for 'anyRole' and not 'anyAuth'.

TBH, it seems to me that the default would be `anyAuth`, i.e. any authenticated user can connect, rather than `anyRole`, i.e. any authenticated user who belongs to _at least one role_. 

If we're happy with the current default, this test at least ensures we don't unintentionally change it.