### PR TITLE
Add percentile metrics for latency

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 
 import io.confluent.common.metrics.MetricName;
 import io.confluent.common.metrics.Metrics;
@@ -60,7 +61,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
   private static final int PERCENTILE_NUM_BUCKETS = 100;
-  private static final double PERCENTILE_MAX_LATENCY_IN_MS = 10 * 1000;
+  private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(5);
 
   private final Metrics metrics;
   private final String metricGrpPrefix;
@@ -226,7 +227,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       Percentiles percs = new Percentiles(Float.SIZE / 8 * PERCENTILE_NUM_BUCKETS,
           0.0,
           PERCENTILE_MAX_LATENCY_IN_MS,
-          Percentiles.BucketSizing.LINEAR,
+          Percentiles.BucketSizing.CONSTANT,
           new Percentile(new MetricName(
               getName(method, annotation, "request-latency-95"), metricGrpName,
               "The 95th percentile request latency in ms", metricTags), 95),

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -16,6 +16,8 @@
 
 package io.confluent.rest.metrics;
 
+import io.confluent.common.metrics.stats.Percentile;
+import io.confluent.common.metrics.stats.Percentiles;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.Resource;
@@ -217,6 +219,24 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           getName(method, annotation, "request-latency-max"), metricGrpName,
           "The maximum request latency in ms", metricTags);
       this.requestLatencySensor.add(metricName, new Max());
+
+      Percentiles percs = new Percentiles(4 * 100,
+          0.0,
+          100.0,
+          Percentiles.BucketSizing.LINEAR,
+          new Percentile(new MetricName(
+              getName(method, annotation, "request-latency-50"), metricGrpName,
+              "The 50th percentile request latency in ms", metricTags), 50),
+          new Percentile(new MetricName(
+              getName(method, annotation, "request-latency-90"), metricGrpName,
+              "The 90th percentile request latency in ms", metricTags), 90),
+          new Percentile(new MetricName(
+              getName(method, annotation, "request-latency-95"), metricGrpName,
+              "The 95th percentile request latency in ms", metricTags), 95),
+          new Percentile(new MetricName(
+              getName(method, annotation, "request-latency-99"), metricGrpName,
+              "The 99th percentile request latency in ms", metricTags), 99));
+      this.requestLatencySensor.add(percs);
 
       this.errorSensor = metrics.sensor(getName(method, annotation, "errors"));
       metricName = new MetricName(

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -59,6 +59,9 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
+  private static final int PERCENTILE_NUM_BUCKETS = 100;
+  private static final double PERCENTILE_MAX_LATENCY_IN_MS = 10*1000;
+
   private final Metrics metrics;
   private final String metricGrpPrefix;
   private Map<String, String> metricTags;
@@ -220,16 +223,10 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           "The maximum request latency in ms", metricTags);
       this.requestLatencySensor.add(metricName, new Max());
 
-      Percentiles percs = new Percentiles(4 * 100,
+      Percentiles percs = new Percentiles(Float.SIZE / 8 * PERCENTILE_NUM_BUCKETS,
           0.0,
-          100.0,
+          PERCENTILE_MAX_LATENCY_IN_MS,
           Percentiles.BucketSizing.LINEAR,
-          new Percentile(new MetricName(
-              getName(method, annotation, "request-latency-50"), metricGrpName,
-              "The 50th percentile request latency in ms", metricTags), 50),
-          new Percentile(new MetricName(
-              getName(method, annotation, "request-latency-90"), metricGrpName,
-              "The 90th percentile request latency in ms", metricTags), 90),
           new Percentile(new MetricName(
               getName(method, annotation, "request-latency-95"), metricGrpName,
               "The 95th percentile request latency in ms", metricTags), 95),

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -60,8 +60,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
-  private static final int PERCENTILE_NUM_BUCKETS = 100;
-  private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(5);
+  private static final int PERCENTILE_NUM_BUCKETS = 200;
+  private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(10);
 
   private final Metrics metrics;
   private final String metricGrpPrefix;

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -60,7 +60,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
   private static final int PERCENTILE_NUM_BUCKETS = 100;
-  private static final double PERCENTILE_MAX_LATENCY_IN_MS = 10*1000;
+  private static final double PERCENTILE_MAX_LATENCY_IN_MS = 10 * 1000;
 
   private final Metrics metrics;
   private final String metricGrpPrefix;


### PR DESCRIPTION
Include percentile metrics for latency.

Open Question: I just picked an arbitrary bucket size and sizing scheme. If anyone can recommend a scientific way to get that, it's great.