### PR TITLE
adding helper methods to AuthUtil for creating constraints

### DIFF
--- a/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
+++ b/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
@@ -181,6 +181,36 @@ public class AuthUtilTest {
     assertThat(mappings.get(1).getConstraint().getAuthenticate(), is(false));
   }
 
+  @Test
+  public void shouldCreateUnsecuredPathConstraint() {
+    // Given:
+    config = restConfigWith(ImmutableMap.of());
+
+    // When:
+    final ConstraintMapping mappings =
+        AuthUtil.createUnsecuredConstraint(config, "/path/*");
+
+    // Then:
+    assertThat(mappings.getMethod(), is("*"));
+    assertThat(mappings.getPathSpec(), is("/path/*"));
+    assertThat(mappings.getConstraint().getAuthenticate(), is(false));
+  }
+
+  @Test
+  public void shouldCreateSecuredPathConstraint() {
+    // Given:
+    config = restConfigWith(ImmutableMap.of());
+
+    // When:
+    final ConstraintMapping mappings =
+        AuthUtil.createSecuredConstraint(config, "/path/*");
+
+    // Then:
+    assertThat(mappings.getMethod(), is("*"));
+    assertThat(mappings.getPathSpec(), is("/path/*"));
+    assertThat(mappings.getConstraint().getAuthenticate(), is(true));
+  }
+
   private static RestConfig restConfigWith(final Map<String, Object> config) {
     return new RestConfig(RestConfig.baseConfigDef(), config);
   }


### PR DESCRIPTION
### what
adding two methods:
- `AuthUtil.createSecuredConstraint(config, path)`
- `AuthUtil.createUnsecuredConstraint(config, path)`

& generalizing some `Constraint` creation code

### why
these methods would be useful for adding custom auth constraints