### PR TITLE
Add RestSecurityContext as @Context annotation on REST calls

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -136,5 +136,10 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
 import io.confluent.rest.auth.AuthUtil;
 
+import io.confluent.rest.contexts.RestSecurityContextBinder;
 import org.apache.kafka.common.config.ConfigException;
 import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.jmx.MBeanContainer;
@@ -202,6 +203,7 @@ public abstract class Application<T extends RestConfig> {
     configureBaseApplication(resourceConfig, combinedMetricsTags);
     configureResourceExtensions(resourceConfig);
     setupResources(resourceConfig, getConfiguration());
+    configureExtraContexts(resourceConfig);
 
     // Configure the servlet container
     ServletContainer servletContainer = new ServletContainer(resourceConfig);
@@ -549,6 +551,14 @@ public abstract class Application<T extends RestConfig> {
     }
 
     return listeners;
+  }
+
+  /**
+   * Register extra context classes that can be injected in the application when using the
+   * {@link javax.ws.rs.core.Context} annotation.
+   */
+  private void configureExtraContexts(Configurable<?> config) {
+    config.register(new RestSecurityContextBinder());
   }
 
   public void configureBaseApplication(Configurable<?> config) {

--- a/core/src/main/java/io/confluent/rest/contexts/RestSecurityContext.java
+++ b/core/src/main/java/io/confluent/rest/contexts/RestSecurityContext.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.contexts;
+
+import javax.ws.rs.core.SecurityContext;
+
+/**
+ * Encapsulates extra security information that can injected into the REST calls for security
+ * purposes.
+ */
+public class RestSecurityContext {
+  private final SecurityContext securityContext;
+  private final String bearerToken;
+
+  public RestSecurityContext(final SecurityContext securityContext, final String bearerToken) {
+    this.securityContext = securityContext;
+    this.bearerToken = bearerToken;
+  }
+
+  public SecurityContext getSecurityContext() {
+    return securityContext;
+  }
+
+  public String getBearerToken() {
+    return bearerToken;
+  }
+}

--- a/core/src/main/java/io/confluent/rest/contexts/RestSecurityContextBinder.java
+++ b/core/src/main/java/io/confluent/rest/contexts/RestSecurityContextBinder.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.contexts;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ * Configures the {@link RestSecurityContext} class for dependency injection. The
+ * {@code RestSecurityContext} class contains extra security context that may be
+ * used by the REST application for other security purposes.
+ * </p>
+ * Inject {@code RestSecurityContext} on each REST method as follows:
+ * i.e. myMethod(@Context RestSecurityContext securityContext)
+ */
+public class RestSecurityContextBinder extends AbstractBinder {
+  @Override
+  protected void configure() {
+    bindFactory(RestSecurityContextFactory.class).to(RestSecurityContext.class);
+  }
+}

--- a/core/src/main/java/io/confluent/rest/contexts/RestSecurityContextFactory.java
+++ b/core/src/main/java/io/confluent/rest/contexts/RestSecurityContextFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.contexts;
+
+import org.glassfish.hk2.api.Factory;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.SecurityContext;
+import java.util.List;
+
+/**
+ * This class implements {@link Factory}, which allows a REST application to create
+ * a new {@link RestSecurityContext} during REST requests.
+ */
+public class RestSecurityContextFactory implements Factory<RestSecurityContext> {
+  private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+  private static final String AUTHORIZATION_BEARER_TYPE = "Bearer";
+  private static final String EMPTY_BEARER_TOKEN = "";
+
+  private final SecurityContext securityContext;
+  private final HttpHeaders httpHeaders;
+
+  @Inject
+  public RestSecurityContextFactory(
+      final SecurityContext securityContext,
+      final HttpHeaders httpHeaders
+  ) {
+    this.securityContext = securityContext;
+    this.httpHeaders = httpHeaders;
+  }
+
+  @Override
+  public RestSecurityContext provide() {
+    final String token = findBearerToken();
+    return new RestSecurityContext(securityContext, token);
+  }
+
+  @Override
+  public void dispose(final RestSecurityContext ksqlUserContext) {
+    // unused
+  }
+
+  /**
+   * Search and returns the BEARER token on the HTTP headers.
+   */
+  private String findBearerToken() {
+    /*
+     * The token is found on the Authorization header in the following string form:
+     * Authorization: Bearer TOKEN
+     */
+
+    final List<String> authHeaders = httpHeaders.getRequestHeader(AUTHORIZATION_HEADER_NAME);
+    if (authHeaders != null) {
+      for (String authMethod : authHeaders) {
+        if (authMethod.startsWith(AUTHORIZATION_BEARER_TYPE + " ")) {
+          return authMethod.substring(AUTHORIZATION_BEARER_TYPE.length() + 1).trim();
+        }
+      }
+    }
+
+    return EMPTY_BEARER_TOKEN;
+  }
+}

--- a/core/src/test/java/io/confluent/rest/contexts/RestSecurityContextFactoryTests.java
+++ b/core/src/test/java/io/confluent/rest/contexts/RestSecurityContextFactoryTests.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest.contexts;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.SecurityContext;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class RestSecurityContextFactoryTests {
+  private static final String AUTHORIZATION_HEADER_NAME = "Authorization";
+
+  @Mock
+  private HttpHeaders httpHeaders;
+
+  @Mock
+  private SecurityContext securityContext;
+
+  @Before
+  public void setUp() {
+
+  }
+
+  @Test
+  public void shouldGetBearerTokenWhenFound() {
+    // Given:
+    givenAuthorizationHeader(Arrays.asList(
+        "Basic user:pass",
+        "Bearer 123"
+    ));
+
+    // When:
+    RestSecurityContext securityContext = createRestSecurityContext();
+
+    // Then:
+    assertThat(securityContext.getBearerToken(), is("123"));
+  }
+
+  @Test
+  public void shouldGetEmptyBearerTokenWhenNotFound() {
+    // Given:
+    givenAuthorizationHeader(Arrays.asList(
+        "Basic user:pass",
+        "Bearer123",
+        "BEARER x"
+    ));
+
+    // When:
+    RestSecurityContext securityContext = createRestSecurityContext();
+
+    // Then:
+    assertThat(securityContext.getBearerToken(), is(""));
+  }
+
+  @Test
+  public void shouldGetEmptyBearerTokenWhenAuthorizationNotFound() {
+    // Given:
+    givenAuthorizationHeader( null);
+
+    // When:
+    RestSecurityContext securityContext = createRestSecurityContext();
+
+    // Then:
+    assertThat(securityContext.getBearerToken(), is(""));
+  }
+
+  private void givenAuthorizationHeader(List<String> values) {
+    when(httpHeaders.getRequestHeader(AUTHORIZATION_HEADER_NAME))
+        .thenReturn(values);
+  }
+
+  private void givenBearerToken(String token) {
+    when(httpHeaders.getRequestHeader("Authorization"))
+        .thenReturn(Collections.singletonList(token));
+  }
+
+  private RestSecurityContext createRestSecurityContext() {
+    return new RestSecurityContextFactory(securityContext, httpHeaders).provide();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -186,6 +186,12 @@
                 <artifactId>jersey-test-framework-provider-jetty</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>${mockito-all.version}</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR allows REST applications to inject a `RestSecurityContext` on each of the REST calls like this:
```
@POST
  public Response handleKsqlStatements(
      final @Context RestSecurityContext securityContext,
      final KsqlRequest request
  ) {}
```

This new context includes extra security information, such as Bearer tokens, so that we can use it for impersonation. 

The new context is registered by `RestSecurityContextBinder`, which is called by the `Application` class.  This registers the `RestSecurityContextFactory` which is called on every REST request to generate a new `RestSecurityContext`.

The `RestSecurityContextFactory` searches for the Bearer token and includes it into the `RestSecurityContext`.