### PR TITLE
adding OAUTHBEARER config

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -189,12 +189,17 @@ public class RestConfig extends AbstractConfig {
   public static final String AUTHENTICATION_METHOD_CONFIG = "authentication.method";
   public static final String AUTHENTICATION_METHOD_NONE = "NONE";
   public static final String AUTHENTICATION_METHOD_BASIC = "BASIC";
+  public static final String AUTHENTICATION_METHOD_OAUTHBEARER = "OAUTHBEARER";
   public static final String AUTHENTICATION_METHOD_DOC =
       "Method of authentication. Must be BASIC to enable authentication. "
       + "You must supply a valid JAAS config file for the 'java.security.auth.login.config'"
       + " system property for the appropriate authentication provider.";
   public static final ConfigDef.ValidString AUTHENTICATION_METHOD_VALIDATOR =
-      ConfigDef.ValidString.in(AUTHENTICATION_METHOD_NONE, AUTHENTICATION_METHOD_BASIC);
+      ConfigDef.ValidString.in(
+          AUTHENTICATION_METHOD_NONE,
+          AUTHENTICATION_METHOD_BASIC,
+          AUTHENTICATION_METHOD_OAUTHBEARER
+      );
   public static final String AUTHENTICATION_REALM_CONFIG = "authentication.realm";
   public static final String AUTHENTICATION_REALM_DOC =
       "Security realm to be used in authentication.";


### PR DESCRIPTION
### what
allow config `authentication.method=OAUTHBEARER`

### why
since `RestConfig` actually validates `authentication.method`, we can't just pass in `OAUTHBEARER` and expect it to work...

also, since we don't want to fully-support `OAUTHBEARER` in rest-utils, this is a hack...

fallback for this PR: https://github.com/confluentinc/rest-utils/pull/136