### PR TITLE
CC-3633: Enable SSL client authentication to be requested but not required

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -468,7 +468,7 @@ public abstract class Application<T extends RestConfig> {
       } else {
         log.warn(
             "The configuration {} is deprecated and should be replaced with {}",
-            RestConfig.SSL_CLIENT_AUTH_DEFAULT,
+            RestConfig.SSL_CLIENT_AUTH_CONFIG,
             RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG
         );
         clientAuthentication = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG)

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -408,21 +408,7 @@ public abstract class Application<T extends RestConfig> {
       }
     }
 
-    boolean requireClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG);
-    boolean requestClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG);
-    sslContextFactory.setNeedClientAuth(requestClientAuth);
-    if (requestClientAuth) {
-      if (requireClientAuth) {
-        log.warn(
-            "Configurations '{}' and '{}' both set to true; "
-                + "the former only takes effect if the latter is set to false",
-            RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG,
-            RestConfig.SSL_CLIENT_AUTH_CONFIG
-        );
-      } else {
-        sslContextFactory.setWantClientAuth(true);
-      }
-    }
+    configureClientAuth(sslContextFactory);
 
     List<String> enabledProtocols = config.getList(RestConfig.SSL_ENABLED_PROTOCOLS_CONFIG);
     if (!enabledProtocols.isEmpty()) {
@@ -465,6 +451,24 @@ public abstract class Application<T extends RestConfig> {
     sslContextFactory.setRenegotiationAllowed(false);
 
     return sslContextFactory;
+  }
+
+  private void configureClientAuth(SslContextFactory sslContextFactory) {
+    boolean requireClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG);
+    boolean requestClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG);
+    sslContextFactory.setNeedClientAuth(requireClientAuth);
+    if (requestClientAuth) {
+      if (requireClientAuth) {
+        log.warn(
+            "Configurations '{}' and '{}' both set to true; "
+                + "the former only takes effect if the latter is set to false",
+            RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG,
+            RestConfig.SSL_CLIENT_AUTH_CONFIG
+        );
+      } else {
+        sslContextFactory.setWantClientAuth(true);
+      }
+    }
   }
 
   public Handler wrapWithGzipHandler(Handler handler) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -408,7 +408,21 @@ public abstract class Application<T extends RestConfig> {
       }
     }
 
-    sslContextFactory.setNeedClientAuth(config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG));
+    boolean requireClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG);
+    boolean requestClientAuth = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG);
+    sslContextFactory.setNeedClientAuth(requestClientAuth);
+    if (requestClientAuth) {
+      if (requireClientAuth) {
+        log.warn(
+            "Configurations '{}' and '{}' both set to true; "
+                + "the former only takes effect if the latter is set to false",
+            RestConfig.SSL_CLIENT_AUTH_REQUESTED_CONFIG,
+            RestConfig.SSL_CLIENT_AUTH_CONFIG
+        );
+      } else {
+        sslContextFactory.setWantClientAuth(true);
+      }
+    }
 
     List<String> enabledProtocols = config.getList(RestConfig.SSL_ENABLED_PROTOCOLS_CONFIG);
     if (!enabledProtocols.isEmpty()) {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -170,6 +170,11 @@ public class RestConfig extends AbstractConfig {
   protected static final String SSL_CLIENT_AUTH_DOC =
       "Whether or not to require the https client to authenticate via the server's trust store.";
   protected static final boolean SSL_CLIENT_AUTH_DEFAULT = false;
+  public static final String SSL_CLIENT_AUTH_REQUESTED_CONFIG = "ssl.client.auth.requested";
+  protected static final String SSL_CLIENT_AUTH_REQUESTED_DOC =
+      "Whether or not to request the https client to authenticate via the server's trust store. "
+          + "Will have no effect if " + SSL_CLIENT_AUTH_CONFIG + " is set to true.";
+  protected static final boolean SSL_CLIENT_AUTH_REQUESTED_DEFAULT = false;
   public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
   protected static final String SSL_ENABLED_PROTOCOLS_DOC =
       "The list of protocols enabled for SSL connections. Comma-separated list. "
@@ -466,6 +471,12 @@ public class RestConfig extends AbstractConfig {
             SSL_CLIENT_AUTH_DEFAULT,
             Importance.MEDIUM,
             SSL_CLIENT_AUTH_DOC
+        ).define(
+            SSL_CLIENT_AUTH_REQUESTED_CONFIG,
+            Type.BOOLEAN,
+            SSL_CLIENT_AUTH_REQUESTED_DEFAULT,
+            Importance.LOW,
+            SSL_CLIENT_AUTH_REQUESTED_DOC
         ).define(
             SSL_ENABLED_PROTOCOLS_CONFIG,
             Type.LIST,

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -166,15 +166,26 @@ public class RestConfig extends AbstractConfig {
   protected static final String SSL_PROVIDER_DOC =
       "The SSL security provider name. Leave blank to use Jetty's default.";
   protected static final String SSL_PROVIDER_DEFAULT = "";
+  public static final String SSL_CLIENT_AUTHENTICATION_CONFIG = "ssl.client.authentication";
+  public static final String SSL_CLIENT_AUTHENTICATION_NONE = "NONE";
+  public static final String SSL_CLIENT_AUTHENTICATION_REQUESTED = "REQUESTED";
+  public static final String SSL_CLIENT_AUTHENTICATION_REQUIRED = "REQUIRED";
+  protected static final String SSL_CLIENT_AUTHENTICATION_DOC =
+      "SSL mutual auth. Set to NONE to disable SSL client authentication, set to REQUESTED to "
+          + "request but not require SSL client authentication, and set to REQUIRED to require SSL "
+          + "client authentication.";
+  public static final ConfigDef.ValidString SSL_CLIENT_AUTHENTICATION_VALIDATOR =
+      ConfigDef.ValidString.in(
+          SSL_CLIENT_AUTHENTICATION_NONE,
+          SSL_CLIENT_AUTHENTICATION_REQUESTED,
+          SSL_CLIENT_AUTHENTICATION_REQUIRED
+      );
+  @Deprecated
   public static final String SSL_CLIENT_AUTH_CONFIG = "ssl.client.auth";
   protected static final String SSL_CLIENT_AUTH_DOC =
-      "Whether or not to require the https client to authenticate via the server's trust store.";
+      "Whether or not to require the https client to authenticate via the server's trust store. " 
+          + "Deprecated; please use " + SSL_CLIENT_AUTHENTICATION_CONFIG + " instead.";
   protected static final boolean SSL_CLIENT_AUTH_DEFAULT = false;
-  public static final String SSL_CLIENT_AUTH_REQUESTED_CONFIG = "ssl.client.auth.requested";
-  protected static final String SSL_CLIENT_AUTH_REQUESTED_DOC =
-      "Whether or not to request the https client to authenticate via the server's trust store. "
-          + "Will have no effect if " + SSL_CLIENT_AUTH_CONFIG + " is set to true.";
-  protected static final boolean SSL_CLIENT_AUTH_REQUESTED_DEFAULT = false;
   public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
   protected static final String SSL_ENABLED_PROTOCOLS_DOC =
       "The list of protocols enabled for SSL connections. Comma-separated list. "
@@ -334,6 +345,7 @@ public class RestConfig extends AbstractConfig {
   }
 
   // CHECKSTYLE_RULES.OFF: MethodLength
+  @SuppressWarnings("deprecation")
   private static ConfigDef incompleteBaseConfigDef() {
     // CHECKSTYLE_RULES.ON: MethodLength
     return new ConfigDef()
@@ -466,17 +478,18 @@ public class RestConfig extends AbstractConfig {
             Importance.MEDIUM,
             SSL_PROVIDER_DOC
         ).define(
+            SSL_CLIENT_AUTHENTICATION_CONFIG,
+            Type.STRING,
+            SSL_CLIENT_AUTHENTICATION_NONE,
+            SSL_CLIENT_AUTHENTICATION_VALIDATOR,
+            Importance.MEDIUM,
+            SSL_CLIENT_AUTHENTICATION_DOC
+        ).define(
             SSL_CLIENT_AUTH_CONFIG,
             Type.BOOLEAN,
             SSL_CLIENT_AUTH_DEFAULT,
             Importance.MEDIUM,
             SSL_CLIENT_AUTH_DOC
-        ).define(
-            SSL_CLIENT_AUTH_REQUESTED_CONFIG,
-            Type.BOOLEAN,
-            SSL_CLIENT_AUTH_REQUESTED_DEFAULT,
-            Importance.LOW,
-            SSL_CLIENT_AUTH_REQUESTED_DOC
         ).define(
             SSL_ENABLED_PROTOCOLS_CONFIG,
             Type.LIST,


### PR DESCRIPTION
This is part of our effort to enable anonymous access for Schema Registry.

The changes here add a configuration, `ssl.client.auth.requested`, which corresponds to a boolean value that's passed to the `setWantClientAuth(...)` method of the underlying `SslContextFactory` if and only if the `ssl.client.auth` configuration is not set to `true`. If both `ssl.client.auth` and `ssl.client.auth.requested` are set to `true`, the `ssl.client.auth` configuration is given precedence and a warning message is logged.