### PR TITLE
Set default value for ssl.endpoint.identification.algorithm to https

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -420,10 +420,8 @@ public abstract class Application<T extends RestConfig> {
       sslContextFactory.setIncludeCipherSuites(cipherSuites.toArray(new String[0]));
     }
 
-    if (!config.getString(RestConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG).isEmpty()) {
-      sslContextFactory.setEndpointIdentificationAlgorithm(
-          config.getString(RestConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
-    }
+    sslContextFactory.setEndpointIdentificationAlgorithm(
+        config.getString(RestConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
 
     if (!config.getString(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG).isEmpty()) {
       sslContextFactory.setTrustStorePath(

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -199,8 +199,8 @@ public class RestConfig extends AbstractConfig {
       "ssl.endpoint.identification.algorithm";
   protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC =
       "The endpoint identification algorithm to validate the server hostname using the "
-      + "server certificate. Leave blank to use Jetty's default.";
-  protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = "";
+      + "server certificate. Default algorithm is https.";
+  protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = "https";
 
   public static final String AUTHENTICATION_METHOD_CONFIG = "authentication.method";
   public static final String AUTHENTICATION_METHOD_NONE = "NONE";


### PR DESCRIPTION
 In newer [version](https://github.com/confluentinc/rest-utils/pull/142) of Jetty,  default value for ssl.endpoint.identification.algorithm was changed to https. This PR sets default value for ssl.endpoint.identification.algorithm to https. Also allow users to set empty string to restore the previous behaviour.