### PR TITLE
CC-5576: Use SslContextFactory.Server to disable server-side hostname verification

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -387,7 +387,7 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private SslContextFactory createSslContextFactory() {
-    SslContextFactory sslContextFactory = new SslContextFactory();
+    SslContextFactory sslContextFactory = new SslContextFactory.Server();
     if (!config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG).isEmpty()) {
       sslContextFactory.setKeyStorePath(
           config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG)

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -199,8 +199,8 @@ public class RestConfig extends AbstractConfig {
       "ssl.endpoint.identification.algorithm";
   protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC =
       "The endpoint identification algorithm to validate the server hostname using the "
-      + "server certificate. Default algorithm is https.";
-  protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = "https";
+      + "server certificate. Leave blank to use Jetty's default.";
+  protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = null;
 
   public static final String AUTHENTICATION_METHOD_CONFIG = "authentication.method";
   public static final String AUTHENTICATION_METHOD_NONE = "NONE";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -199,7 +199,7 @@ public class RestConfig extends AbstractConfig {
       "ssl.endpoint.identification.algorithm";
   protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DOC =
       "The endpoint identification algorithm to validate the server hostname using the "
-      + "server certificate. Leave blank to use Jetty's default.";
+      + "server certificate.";
   protected static final String SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_DEFAULT = null;
 
   public static final String AUTHENTICATION_METHOD_CONFIG = "authentication.method";


### PR DESCRIPTION
Jetty recently enabled hostname verification by default, but this
only makes sense for clients. They introduced a new subclass that
should be used in server contexts.