### PR TITLE
Include separate metrics for each HTTP error code

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+        "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+        "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+
+    <suppress checks="ClassDataAbstractionCoupling"
+              files="MetricsResourceMethodApplicationListener.java"/>
+</suppressions>

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -278,7 +278,11 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     public void exception(final RequestEvent event) {
       int errorCode = event.getContainerResponse() == null ? 0
           : event.getContainerResponse().getStatus();
-      errorSensorByStatus[errorCode / 100].record();
+      int idx = errorCode / 100;
+      // Index 0 means "unknown" status codes.
+      idx = idx < 0 || idx >=6 ? 0 : idx;
+
+      errorSensorByStatus[idx].record();
       errorSensor.record();
     }
 

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -62,7 +62,9 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
-  protected static final String ERROR_CODE_TAG_KEY = "error_code";
+  protected static final String HTTP_STATUS_CODE_TAG = "http_status_code";
+  private static final String[] HTTP_STATUS_CODE_TEXT = {
+      "unknown", "1xx", "2xx", "3xx", "4xx", "5xx"};
   private static final int PERCENTILE_NUM_BUCKETS = 200;
   private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(10);
 
@@ -240,18 +242,15 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
               "The 99th percentile request latency in ms", metricTags), 99));
       this.requestLatencySensor.add(percs);
 
-      String code = "unknown";
       for (int i = 0; i < 6; i++) {
-        if (i > 0) {
-          code = i + "xx";
-        }
         errorSensorByStatus[i] = metrics.sensor(getName(method, annotation, "errors" + i));
         HashMap<String, String> tags = new HashMap<>(metricTags);
-        tags.put(ERROR_CODE_TAG_KEY, code);
+        tags.put(HTTP_STATUS_CODE_TAG, HTTP_STATUS_CODE_TEXT[i]);
         metricName = new MetricName(getName(method, annotation, "request-error-rate"),
             metricGrpName,
             "The average number of requests"
-                + " per second that resulted in HTTP error responses with code " + code,
+                + " per second that resulted in HTTP error responses with code "
+                + HTTP_STATUS_CODE_TEXT[i],
             tags);
         errorSensorByStatus[i].add(metricName, new Rate());
       }

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -278,8 +278,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
      * Indicate that a request has failed with an exception.
      */
     public void exception(final RequestEvent event) {
-      final int statusCode = event.getException() instanceof WebApplicationException ?
-        ((WebApplicationException) event.getException()).getResponse().getStatus() : 0;
+      final int statusCode = event.getException() instanceof WebApplicationException
+          ? ((WebApplicationException) event.getException()).getResponse().getStatus() : 0;
       int idx = statusCode / 100;
       // Index 0 means "unknown" status codes.
       idx = idx < 0 || idx >= 6 ? 0 : idx;

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -31,7 +31,7 @@ import io.confluent.rest.Application;
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.TestRestConfig;
 
-import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.ERROR_CODE_TAG_KEY;
+import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.HTTP_STATUS_CODE_TAG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -99,7 +99,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     for (KafkaMetric metric: TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
-        if (metric.metricName().tags().getOrDefault(ERROR_CODE_TAG_KEY, "").equals("4xx")) {
+        if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("4xx")) {
           assertTrue("Actual: " + metric.value(),
               metric.value() > 0);
         } else if (!metric.metricName().tags().isEmpty()) {

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -44,6 +44,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   @Before
   public void setUp() throws Exception {
+    TestMetricsReporter.reset();
     Properties props = new Properties();
     props.setProperty("debug", "false");
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
@@ -99,9 +100,11 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     for (KafkaMetric metric: TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
         if (metric.metricName().tags().getOrDefault(ERROR_CODE_TAG_KEY, "").equals("4xx")) {
-          assertTrue("Actual: " + metric.value() + metric.metricName(), metric.value() > 0);
+          assertTrue("Actual: " + metric.value(),
+              metric.value() > 0);
         } else if (!metric.metricName().tags().isEmpty()) {
-          assertTrue("Actual: " + metric.value() + metric.metricName(), metric.value() == 0.0 || Double.isNaN(metric.value()));
+          assertTrue("Actual: " + metric.value() + metric.metricName(),
+              metric.value() == 0.0 || Double.isNaN(metric.value()));
         }
       }
     }

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -104,7 +104,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     for (KafkaMetric metric: TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
         if (metric.metricName().tags().getOrDefault(ERROR_CODE_TAG_KEY, "").equals("4xx")) {
-          assertTrue("Actual: "+metric.value(), metric.value() > 0);
+          assertTrue("Actual: " + metric.value() + metric.metricName(), metric.value() > 0);
         } else if (!metric.metricName().tags().isEmpty()) {
           assertTrue("Actual: " + metric.value() + metric.metricName(), metric.value() == 0.0 || Double.isNaN(metric.value()));
         }

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
         <jetty.version>9.4.18.v20190429</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <guava.version>24.0-jre</guava.version>
+        <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This will allow us to distinguish between server errors and
user/input errors, which will let us specify alerting better.

Specifically, for projects like Schema Registry we may want to alert only on 5xx errors and not 4xx errors.