### PR TITLE
Revert Jersey to v2.27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.3</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.28</jersey.version>
+        <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.20.v20190813</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <guava.version>24.0-jre</guava.version>


### PR DESCRIPTION
REST applications (especially in KSQL) were failing to start due to the previous Jersy v2.28. Reverting version to v2.27 fixes the incompatibility issue.