### PR TITLE
Fix NPE in MetricsRequestEventListener when @PreMatching ContainerRequestFilter throws exception

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -325,12 +325,13 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
     @Override
     public void onEvent(RequestEvent event) {
-      if (event.getType() == RequestEvent.Type.MATCHING_START) {
+      if (started == 0L) {
         started = time.milliseconds();
         final ContainerRequest request = event.getContainerRequest();
         wrappedRequestStream = new CountingInputStream(request.getEntityStream());
         request.setEntityStream(wrappedRequestStream);
-      } else if (event.getType() == RequestEvent.Type.RESP_FILTERS_START) {
+      }
+      if (event.getType() == RequestEvent.Type.RESP_FILTERS_START) {
         final ContainerResponse response = event.getContainerResponse();
         wrappedResponseStream = new CountingOutputStream(response.getEntityStream());
         response.setEntityStream(wrappedResponseStream);


### PR DESCRIPTION
I registered a @PreMatching ContainerRequestFilter via kafka.rest.resource.extension.class and sometimes need to throw exceptions that are mapped to responses. This works fine (client gets the correct response), but the MetricsRequestEventListener logs a NPE.

Root cause: The event RequestEvent.Type.MATCHING_START is never invoked in this case (exception is thrown in PreMatching filter), thus never initializing the wrappedRequestStream field. Later, handling the FINISHED event assumes wrappedRequestStream is set, throwin the NPE.

I believe MetricsRequestEventListener must be patched to initialize the wrappedRequestStream and started without depending on MATCHING_START event, because in this case it is never triggered.

This PR simply replaces the condition if (event.getType() == RequestEvent.Type.MATCHING_START) by if (started == 0L) or if (wrappedRequestStream == null) (at https://github.com/confluentinc/rest-utils/blob/5.3.1-post/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java#L301) to initialize variables the first time any event is triggered.

