### PR TITLE
Detaches the MetadataServer life-cycle from RBAC provider.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -127,6 +127,10 @@ public abstract class Application<T extends RestConfig> {
     this.requestLog.setLogLatency(true);
   }
 
+  public final String getPath() {
+    return path;
+  }
+
   /**
    * Register resources or additional Providers, ExceptionMappers, and other JAX-RS components with
    * the Jersey application. This, combined with your Configuration class, is where you can

--- a/core/src/main/java/io/confluent/rest/ApplicationGroup.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationGroup.java
@@ -22,25 +22,25 @@ import java.util.List;
 import java.util.Objects;
 
 final class ApplicationGroup {
-  private final ApplicationServer server;
+  private final ApplicationServer<?> server;
 
-  private final List<Application> applications = new ArrayList<>();
+  private final List<Application<?>> applications = new ArrayList<>();
 
-  ApplicationGroup(ApplicationServer server) {
+  ApplicationGroup(ApplicationServer<?> server) {
     this.server = Objects.requireNonNull(server);
   }
 
-  void addApplication(Application application) {
+  void addApplication(Application<?> application) {
     application.setServer(server);
     applications.add(application);
   }
 
-  List<Application> getApplications() {
+  List<Application<?>> getApplications() {
     return Collections.unmodifiableList(applications);
   }
 
   void doStop() {
-    for (Application application: applications) {
+    for (Application<?> application: applications) {
       application.metrics.close();
       application.doShutdown();
       application.shutdownLatch.countDown();

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -147,6 +147,10 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     applications.addApplication(application);
   }
 
+  public List<Application<?>> getApplications() {
+    return applications.getApplications();
+  }
+
   private void attachMetricsListener(Metrics metrics, Map<String, String> tags) {
     MetricsListener metricsListener = new MetricsListener(metrics, "jetty", tags);
     for (NetworkTrafficServerConnector connector : connectors) {
@@ -180,7 +184,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     super.doStart();
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();
-    for (Application app : (List<Application>) applications.getApplications()) {
+    for (Application app : applications.getApplications()) {
       attachMetricsListener(app.metrics, app.getMetricsTags());
       handlers.addHandler(app.configureHandler());
       wsHandlers.addHandler(app.configureWebSocketHandler());


### PR DESCRIPTION
See https://github.com/confluentinc/ce-kafka/pull/973.