### PR TITLE
Remove @Deprecated from Application and ApplicationServer methods.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -161,9 +161,7 @@ public abstract class Application<T extends RestConfig> {
 
   /**
    * expose SslContextFactory
-   * @deprecated Use {@link ApplicationServer#getSslContextFactory} instead.
    */
-  @Deprecated
   protected SslContextFactory getSslContextFactory() {
     return server.getSslContextFactory();
   }
@@ -191,11 +189,8 @@ public abstract class Application<T extends RestConfig> {
 
   /**
    * Configure and create the server.
-   *
-   * @deprecated Use {@link ApplicationServer#registerApplication(Application)} instead.
    */
   // CHECKSTYLE_RULES.OFF: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
-  @Deprecated
   public Server createServer() throws ServletException {
     // CHECKSTYLE_RULES.ON: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
     if (server == null) {
@@ -355,10 +350,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * TODO: delete deprecatedPort parameter when `PORT_CONFIG` is deprecated.
    * Helper function used to support the deprecated configuration.
-   *
-   * @deprecated This function will be removed with {@link RestConfig#PORT_CONFIG}
    */
-  @Deprecated
   public static List<URI> parseListeners(
           List<String> listenersConfig,
           int deprecatedPort,
@@ -528,10 +520,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Start the server (creating it if necessary).
    * @throws Exception If the application fails to start
-   *
-   * @deprecated Use {@link ApplicationServer#start()} instead.
    */
-  @Deprecated
   public void start() throws Exception {
     createServer();
     server.start();
@@ -541,10 +530,7 @@ public abstract class Application<T extends RestConfig> {
    * Wait for the server to exit, allowing existing requests to complete if graceful shutdown is
    * enabled and invoking the shutdown hook before returning.
    * @throws InterruptedException If the internal threadpool fails to stop
-   *
-   * @deprecated Use {@link ApplicationServer#join()} instead.
    */
-  @Deprecated
   public void join() throws InterruptedException {
     server.join();
     shutdownLatch.await();
@@ -553,10 +539,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Request that the server shutdown.
    * @throws Exception If the application fails to stop
-   *
-   * @deprecated Use {@link ApplicationServer#stop()} instead.
    */
-  @Deprecated
   public void stop() throws Exception {
     server.stop();
   }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -79,10 +79,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   /**
    * TODO: delete deprecatedPort parameter when `PORT_CONFIG` is deprecated.
    * It's only used to support the deprecated configuration.
-   *
-   * @deprecated This function will be removed with {@link RestConfig#PORT_CONFIG}
    */
-  @Deprecated
   static List<URI> parseListeners(
           List<String> listenersConfig,
           int deprecatedPort,


### PR DESCRIPTION
Broke KSQL (again): https://jenkins.confluent.io/job/confluentinc/job/ksql/job/5.4.x/88/