### PR TITLE
updated registerApplication to work after jetty starts

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -147,7 +147,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   public void registerApplication(Application application) {
     applications.addApplication(application);
     //dynamic registration
-    if (isStarted()) {
+    if (isStarted() && wrappedHandler != null) {
       try {
         attachMetricsListener(application.metrics, application.getMetricsTags());
         Handler handler = application.configureHandler();

--- a/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
@@ -116,6 +116,20 @@ public class ApplicationGroupTest {
     assertThat(makeGetRequest("/app2/index.html"), is(Code.OK));
   }
 
+  /* Test Dynamic App Loading */
+  @Test
+  public void testDynamicAppLoading() throws Exception {
+    TestApp app1 = new TestApp("/app1");
+    TestApp app2 = new TestApp("/app2");
+
+    server.registerApplication(app1);
+    server.start();
+    server.registerApplication(app2);
+
+    assertThat(makeGetRequest("/app1/resource"), is(Code.OK));
+    assertThat(makeGetRequest("/app2/resource"), is(Code.OK));
+  }
+
   @SuppressWarnings("SameParameterValue")
   private HttpStatus.Code makeGetRequest(final String path) throws Exception {
     final HttpGet httpget = new HttpGet(server.getListeners().get(0).toString() + path);

--- a/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
@@ -124,8 +124,15 @@ public class ApplicationGroupTest {
 
     server.registerApplication(app1);
     server.start();
+
+    // only app1 is registered
+    assertThat(makeGetRequest("/app1/resource"), is(Code.OK));
+    assertThat(makeGetRequest("/app2/resource"), is(Code.NOT_FOUND));
+
+    // register app2
     server.registerApplication(app2);
 
+    // verify both apps are running
     assertThat(makeGetRequest("/app1/resource"), is(Code.OK));
     assertThat(makeGetRequest("/app2/resource"), is(Code.OK));
   }


### PR DESCRIPTION
This PR is to allow the addition of `Application` to a running Jetty `ApplicationServer`. 
The use case is to allow Kafka to start up a Jetty ApplicationServer (MetadataServer) in `ce-kafka` and manage it's lifecycle while other MDS modules (RBAC, config, etc) can register themselves to this jetty server. 
1. KafkaServer starts Jetty HTTP
2. RbacProvider loads rbac and builds rbac application, then registers to Jetty
3. ConfigProvider loads config settings and builds application, then registers to Jetty
4. Other modules do the same, obviously with different context paths.
