### PR TITLE
Call super.doStart last

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -178,7 +178,6 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   }
 
   protected final void doStart() throws Exception {
-    super.doStart();
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();
     for (Application app : applications.getApplications()) {
@@ -187,6 +186,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
       wsHandlers.addHandler(app.configureWebSocketHandler());
     }
     finalizeHandlerCollection(handlers, wsHandlers);
+    // Call super.doStart last to ensure that handlers are ready for incoming requests
+    super.doStart();
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
This is to ensure that handlers are ready for incoming requests.

Without this fix, Schema Registry would return 404 because handlers had not yet been initialized.  This caused tests in `sr_master_failover_test.py` to fail, since in the tests 404 should only be returned if a subject or version no longer exists.