### PR TITLE
SEC-592:  Customize Jetty request queue and threadpool size

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -456,11 +456,9 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
     BlockingQueue<Runnable> requestQueue =
             new BlockingArrayQueue<>(initialCapacity, growBy, maxCapacity);
-
-    /* The Jetty default value for idle time out is 60_000 ms */
+    
     return new QueuedThreadPool(config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG),
             config.getInt(RestConfig.THREAD_POOL_MIN_CONFIG),
-            60000,
             requestQueue);
   }
 }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -32,6 +32,9 @@ import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.StatisticsHandler;
 import org.eclipse.jetty.server.handler.gzip.GzipHandler;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.eclipse.jetty.util.BlockingArrayQueue;
+import org.eclipse.jetty.util.thread.ThreadPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +50,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.concurrent.BlockingQueue;
 
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ApplicationServer<T extends RestConfig> extends Server {
@@ -60,7 +64,12 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   private static final Logger log = LoggerFactory.getLogger(ApplicationServer.class);
 
   public ApplicationServer(T config) {
-    super();
+    this(config, createThreadPool(config));
+  }
+
+  public ApplicationServer(T config, ThreadPool threadPool) {
+    super(threadPool);
+
     this.config = config;
     this.applications = new ApplicationGroup(this);
 
@@ -382,6 +391,42 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
             .collect(Collectors.toList());
   }
 
+  /**
+   * For unit testing.
+   *
+   * @return the total number of threads currently in the pool.
+   */
+  public int getThreads() {
+    return getThreadPool().getThreads();
+  }
+
+  /**
+   * For unit testing.
+   *
+   * @return the total number of maximum threads configured in the pool.
+   */
+  public int getMaxThreads() {
+    return config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG);
+  }
+
+  /**
+   * For unit testing.
+   *
+   * @return the size of the queue in the pool.
+   */
+  public int getQueueSize() {
+    return ((QueuedThreadPool)getThreadPool()).getQueueSize();
+  }
+
+  /**
+   * For unit testing.
+   *
+   * @return the capacity of the queue in the pool.
+   */
+  public int getQueueCapacity() {
+    return config.getInt(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG);
+  }
+
   static Handler wrapWithGzipHandler(RestConfig config, Handler handler) {
     if (config.getBoolean(RestConfig.ENABLE_GZIP_COMPRESSION_CONFIG)) {
       GzipHandler gzip = new GzipHandler();
@@ -394,5 +439,28 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   private Handler wrapWithGzipHandler(Handler handler) {
     return wrapWithGzipHandler(config, handler);
+  }
+
+  /**
+   * Create the thread pool with request queue.
+   *
+   * @return thread pool used by the server
+   */
+  private static ThreadPool createThreadPool(RestConfig config) {
+    /* Create blocking queue for the thread pool. */
+    int initialCapacity = config.getInt(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG);
+    int growBy = config.getInt(RestConfig.REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG);
+    int maxCapacity = config.getInt(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG);
+    log.info("Initial capacity {}, increased by {}, maximum capacity {}.",
+            initialCapacity, growBy, maxCapacity);
+
+    BlockingQueue<Runnable> requestQueue =
+            new BlockingArrayQueue<>(initialCapacity, growBy, maxCapacity);
+
+    /* The Jetty default value for idle time out is 60_000 ms */
+    return new QueuedThreadPool(config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG),
+            config.getInt(RestConfig.THREAD_POOL_MIN_CONFIG),
+            60000,
+            requestQueue);
   }
 }

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -276,6 +276,31 @@ public class RestConfig extends AbstractConfig {
           "The number of milliseconds to hold an idle session open for.";
   public static final long IDLE_TIMEOUT_MS_DEFAULT = 30_000;
 
+  public static final String THREAD_POOL_MIN_CONFIG = "thread.pool.min";
+  public static final String THREAD_POOL_MIN_DOC =
+          "The minimum number of threads will be startred for HTTP Servlet server.";
+  public static final int THREAD_POOL_MIN_DEFAULT = 8;
+
+  public static final String THREAD_POOL_MAX_CONFIG = "thread.pool.max";
+  public static final String THREAD_POOL_MAX_DOC =
+          "The maxinum number of threads will be startred for HTTP Servlet server.";
+  public static final int THREAD_POOL_MAX_DEFAULT = 200;
+
+  public static final String REQUEST_QUEUE_CAPACITY_CONFIG = "request.queue.capacity";
+  public static final String REQUEST_QUEUE_CAPACITY_DOC =
+          "The capacity of request queue for each thread pool.";
+  public static final int REQUEST_QUEUE_CAPACITY_DEFAULT = Integer.MAX_VALUE;
+
+  public static final String REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG = "request.queue.capacity.init";
+  public static final String REQUEST_QUEUE_CAPACITY_INITIAL_DOC =
+          "The initial capacity of request queue for each thread pool.";
+  public static final int REQUEST_QUEUE_CAPACITY_INITIAL_DEFAULT = 128;
+
+  public static final String REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG = "request.queue.capacity.growby";
+  public static final String REQUEST_QUEUE_CAPACITY_GROWBY_DOC =
+          "The size of request queue will be increased by.";
+  public static final int REQUEST_QUEUE_CAPACITY_GROWBY_DEFAULT = 64;
+
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
         PORT_CONFIG_DEFAULT,
@@ -589,6 +614,36 @@ public class RestConfig extends AbstractConfig {
             IDLE_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             IDLE_TIMEOUT_MS_DOC
+        ).define(
+            THREAD_POOL_MIN_CONFIG,
+            Type.INT,
+            THREAD_POOL_MIN_DEFAULT,
+            Importance.LOW,
+            THREAD_POOL_MIN_DOC
+        ).define(
+            THREAD_POOL_MAX_CONFIG,
+            Type.INT,
+            THREAD_POOL_MAX_DEFAULT,
+            Importance.LOW,
+            THREAD_POOL_MAX_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_INITIAL_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_INITIAL_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_GROWBY_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_GROWBY_DOC
         );
   }
 

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -1,5 +1,3 @@
-
-
 /**
  * Copyright 2019 Confluent Inc.
  *
@@ -39,12 +37,12 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 public class TestCustomizeThreadPool {
 
   private static final Logger log = LoggerFactory.getLogger(TestCustomizeThreadPool.class);
   private static Object locker = new Object();
-  private static int waitingTimeSec = 10*1000; //5 seconds
 
   /**
    * Good path testing.
@@ -91,8 +89,8 @@ public class TestCustomizeThreadPool {
     } catch (Exception e) {
     } finally {
       log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
-      assertTrue("Total number of running threads reach maximum number of threads " + app.getServer().getMaxThreads(),
-              app.getServer().getThreads() - app.getServer().getMaxThreads() == 0);
+      assertEquals("Total number of running threads reach maximum number of threads.", app.getServer().getMaxThreads(),
+              app.getServer().getThreads());
       app.stop();
     }
   }
@@ -122,7 +120,7 @@ public class TestCustomizeThreadPool {
   }
 
   /**
-   * Simualate multiple HTTP clients sending HTTP requests samt time. Each client will send one HTTP request.
+   * Simulate multiple HTTP clients sending HTTP requests same time. Each client will send one HTTP request.
    * The requests will be put in queue if the number of clients are more than the working threads.
    * */
   @SuppressWarnings("SameParameterValue")
@@ -178,7 +176,7 @@ public class TestCustomizeThreadPool {
     public String get() {
       synchronized(locker) {
         try {
-          locker.wait(waitingTimeSec);
+          locker.wait(10000);
         } catch (Exception e) {
           log.info(e.getMessage());
         }

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -1,0 +1,225 @@
+
+
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Test;
+import java.util.Properties;
+import java.util.concurrent.RejectedExecutionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpStatus.Code;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class TestCustomizeThreadPool {
+
+  private static final Logger log = LoggerFactory.getLogger(TestCustomizeThreadPool.class);
+  private static Object locker = new Object();
+  private static int waitingTimeSec = 10*1000; //5 seconds
+
+  /**
+   * Good path testing.
+   * Total number of running threads is less than capacity of thread pool configured.
+   * Total number of jobs in queue is less than capacity of queue configured.
+   */
+  @Test
+  public void testThreadPoolLessThreshold()throws Exception {
+    int numOfClients = 3;
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication();
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } catch (Exception e) {
+    } finally {
+      log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
+      assertTrue("Total number of running threads is less than maximum number of threads " + app.getServer().getMaxThreads(),
+              app.getServer().getThreads() - app.getServer().getMaxThreads() < 0);
+      log.info("Total jobs in queue {}, capacity of queue {}.", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+      assertTrue("Total number of jobs in queue is less than capacity of queue " + app.getServer().getQueueCapacity(),
+              app.getServer().getQueueSize() - app.getServer().getQueueCapacity() < 0);
+      app.stop();
+    }
+  }
+
+  /**
+   * This test will test the number of running threads will be increased as more clients request coming in, but
+   * the total number of threads will not over the maximum threads configured even there are more clients requests
+   * coming in. Server will finally throw following exceptions when more http client send requests.
+   * [ReservedThreadExecutor@1b1f5012{s=0/2,p=0}] rejected org.eclipse.jetty.io.ManagedSelector$Accept@26ac0324
+   * (org.eclipse.jetty.util.thread.QueuedThreadPool:471)
+   * java.util.concurrent.RejectedExecutionException:
+   * This test also test the size of jobs in queue will not over the capacity of queue configured.
+   **/
+  @Test
+  public void testThreadPoolReachThreshold()throws Exception {
+    int numOfClients = 40;
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication();
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } catch (Exception e) {
+    } finally {
+      log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
+      assertTrue("Total number of running threads reach maximum number of threads " + app.getServer().getMaxThreads(),
+              app.getServer().getThreads() - app.getServer().getMaxThreads() == 0);
+      app.stop();
+    }
+  }
+
+  /**
+   * Simulate the case that the queue of thread pool is full. Http server will reject request if the queue is full and
+   * throw RejectedExecutionException.
+   **/
+  @Test(expected = RejectedExecutionException.class)
+  public void testQueueFull() throws Exception {
+    int numOfClients = 1;
+    Properties props = new Properties();
+    props.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
+    props.put(RestConfig.THREAD_POOL_MIN_CONFIG, "2");
+    props.put(RestConfig.THREAD_POOL_MAX_CONFIG, "10");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG, "0");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG, "0");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG, "2");
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication(props);
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } finally {
+      app.stop();
+    }
+  }
+
+  /**
+   * Simualate multiple HTTP clients sending HTTP requests samt time. Each client will send one HTTP request.
+   * The requests will be put in queue if the number of clients are more than the working threads.
+   * */
+  @SuppressWarnings("SameParameterValue")
+  private void makeConcurrentGetRequests(String uri, int numThread, TestCustomizeThreadPoolApplication app) throws Exception {
+    Thread[] threads = new Thread[numThread];
+    for(int i = 0; i < numThread; i++) {
+      threads[i] = new Thread() {
+        public void run() {
+          HttpGet httpget = new HttpGet(uri);
+          CloseableHttpClient httpclient = HttpClients.createDefault();
+          CloseableHttpResponse response = null;
+          try {
+            response = httpclient.execute(httpget);
+            HttpStatus.Code statusCode = HttpStatus.getCode(response.getStatusLine().getStatusCode());
+            log.info("Status code {}, reason {} ", statusCode, response.getStatusLine().getReasonPhrase());
+            assertThat(statusCode, is(Code.OK));
+          } catch (Exception e) {
+          } finally {
+            try {
+              if (response != null) {
+                response.close();
+              }
+              httpclient.close();
+            } catch (Exception e) {
+            }
+          }
+        }
+      };
+
+      threads[i].start();
+    }
+
+    long startingTime = System.currentTimeMillis();
+    while(System.currentTimeMillis() - startingTime < 360*1000) {
+      log.info("Queue size {}, queue capacity {} ", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+      assertTrue("Number of jobs in queue is not more than capacity of queue ", app.getServer().getQueueSize() <= app.getServer().getQueueCapacity());
+      Thread.sleep(2000);
+      if (app.getServer().getQueueSize() == 0)
+        break;
+    }
+
+    for(int i = 0; i < numThread; i++) {
+      threads[i].join();
+    }
+    log.info("End queue size {}, queue capacity {} ", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+  }
+
+  @Path("/custom")
+  @Produces(MediaType.TEXT_PLAIN)
+  public static class RestResource {
+    @GET
+    @Path("/resource")
+    public String get() {
+      synchronized(locker) {
+        try {
+          locker.wait(waitingTimeSec);
+        } catch (Exception e) {
+          log.info(e.getMessage());
+        }
+      }
+      return "ThreadPool";
+    }
+  }
+
+  private static class TestCustomizeThreadPoolApplication extends Application<TestRestConfig> {
+    static Properties props = null;
+
+    public TestCustomizeThreadPoolApplication() {
+      super(createConfig());
+    }
+    public TestCustomizeThreadPoolApplication(Properties props) {
+      super(new TestRestConfig(props));
+      this.props = props;
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
+      config.register(new RestResource());
+    }
+
+    public String getUri() {
+      return (String)props.get(RestConfig.LISTENERS_CONFIG);
+    }
+
+    private static TestRestConfig createConfig() {
+      props = new Properties();
+      String uri = "http://localhost:8080";
+      props.put(RestConfig.LISTENERS_CONFIG, uri);
+      props.put(RestConfig.THREAD_POOL_MIN_CONFIG, "2");
+      props.put(RestConfig.THREAD_POOL_MAX_CONFIG, "10");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG, "2");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG, "8");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG, "2");
+      return new TestRestConfig(props);
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
This is new PR for customizing the thread pool and size of request queue. This PR is from old PR https://github.com/confluentinc/rest-utils/pull/150. It is too much work for merging the PR 150 due to code had dramatic changes since supporting one Jetty Server instance can contain multiple Applications. Milo had reviewed old PR and team decided to merge code after 5.4. Please see old review comments in old PR.  