### PR TITLE
Catch invalid format exception: #501

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -119,6 +120,9 @@ public class KafkaExceptionMapper extends GenericExceptionMapper {
       log.error("Kafka exception", exception);
       return getResponse(exception, Status.INTERNAL_SERVER_ERROR,
           KAFKA_ERROR_ERROR_CODE);
+    } else if (exception instanceof InvalidFormatException) {
+      return getResponse(exception, Status.BAD_REQUEST,
+          KAFKA_BAD_REQUEST_ERROR_CODE);
     } else {
       log.error("Unhandled exception", exception);
       return super.toResponse(exception);


### PR DESCRIPTION
Simple PR to better handle the `InvalidFormatException` which gets thrown if you try to commit offsets with a String rather than a Long with Rest Proxy.  This is for https://github.com/confluentinc/kafka-rest/issues/501 and now returns the 400 error code and suppresses the long stack trace being output into the log.