### PR TITLE
CPKAFKA-4948: Make ssl.client.auth for REST consistent with Kafka

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -18,6 +18,7 @@ package io.confluent.rest;
 
 import io.confluent.common.metrics.Metrics;
 
+import java.util.Locale;
 import org.apache.kafka.common.config.ConfigException;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.Handler;
@@ -210,25 +211,31 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
                 RestConfig.SSL_CLIENT_AUTH_CONFIG,
                 RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG
         );
-        clientAuthentication = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG)
-                ? RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED
-                : RestConfig.SSL_CLIENT_AUTHENTICATION_NONE;
+        clientAuthentication = config.getString(RestConfig.SSL_CLIENT_AUTH_CONFIG);
       }
     }
 
-    switch (clientAuthentication) {
+    switch (clientAuthentication.toLowerCase(Locale.ROOT)) {
+      case "true":
+        log.warn("Config value 'true' is deprecated for {}, use 'required' instead.",
+            RestConfig.SSL_CLIENT_AUTH_CONFIG);
+        // fall through
       case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED:
         sslContextFactory.setNeedClientAuth(true);
         break;
       case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUESTED:
         sslContextFactory.setWantClientAuth(true);
         break;
+      case "false":
+        log.warn("Config value 'false' is deprecated for {}, use 'none' instead.",
+            RestConfig.SSL_CLIENT_AUTH_CONFIG);
+        // fall through
       case RestConfig.SSL_CLIENT_AUTHENTICATION_NONE:
         break;
       default:
         throw new ConfigException(
                 "Unexpected value for {} configuration: {}",
-                RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+                RestConfig.SSL_CLIENT_AUTH_CONFIG,
                 clientAuthentication
         );
     }

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -174,26 +174,44 @@ public class RestConfig extends AbstractConfig {
   protected static final String SSL_PROVIDER_DOC =
       "The SSL security provider name. Leave blank to use Jetty's default.";
   protected static final String SSL_PROVIDER_DEFAULT = "";
+  @Deprecated
   public static final String SSL_CLIENT_AUTHENTICATION_CONFIG = "ssl.client.authentication";
-  public static final String SSL_CLIENT_AUTHENTICATION_NONE = "NONE";
-  public static final String SSL_CLIENT_AUTHENTICATION_REQUESTED = "REQUESTED";
-  public static final String SSL_CLIENT_AUTHENTICATION_REQUIRED = "REQUIRED";
+  public static final String SSL_CLIENT_AUTHENTICATION_NONE = "none";
+  public static final String SSL_CLIENT_AUTHENTICATION_REQUESTED = "requested" ;
+  public static final String SSL_CLIENT_AUTHENTICATION_REQUIRED = "required";
+  // This was released as upper-case Strings for REST services. But Kafka uses lower-case, so
+  // making this case-insensitive. Deprecating in favour of Kafka's ssl.client.auth.
   protected static final String SSL_CLIENT_AUTHENTICATION_DOC =
       "SSL mutual auth. Set to NONE to disable SSL client authentication, set to REQUESTED to "
           + "request but not require SSL client authentication, and set to REQUIRED to require SSL "
-          + "client authentication.";
-  public static final ConfigDef.ValidString SSL_CLIENT_AUTHENTICATION_VALIDATOR =
-      ConfigDef.ValidString.in(
+          + "client authentication. Deprecated; please use 'ssl.client.auth' instead."
+          + "Note that this option overrides 'ssl.client.auth' if configured.";
+  public static final ConfigDef.CaseInsensitiveValidString SSL_CLIENT_AUTHENTICATION_VALIDATOR =
+      ConfigDef.CaseInsensitiveValidString.in(
           SSL_CLIENT_AUTHENTICATION_NONE,
           SSL_CLIENT_AUTHENTICATION_REQUESTED,
           SSL_CLIENT_AUTHENTICATION_REQUIRED
       );
-  @Deprecated
   public static final String SSL_CLIENT_AUTH_CONFIG = "ssl.client.auth";
   protected static final String SSL_CLIENT_AUTH_DOC =
-      "Whether or not to require the https client to authenticate via the server's trust store. " 
-          + "Deprecated; please use " + SSL_CLIENT_AUTHENTICATION_CONFIG + " instead.";
-  protected static final boolean SSL_CLIENT_AUTH_DEFAULT = false;
+      "Whether or not to require the https client to authenticate via the server's trust store. "
+          + "Set to 'none' to disable SSL client authentication, set to 'requested' to request "
+          + "but not require SSL client authentication and set to 'required' to require SSL client "
+          + "authentication. The boolean values 'true' and 'false` are deprecated, but still "
+          + "supported. These are equivalent to 'required' and 'none' respectively. Note that this "
+          + "option is overriden by " + SSL_CLIENT_AUTHENTICATION_CONFIG + " if configured.";
+  // This was a boolean, but the same config is a String value required/requested/none in Kafka
+  // brokers. Accept the Kafka values as well for consistency. Is case-insensitive to be consistent
+  // with `ssl.client.authentication` values.
+  public static final ConfigDef.CaseInsensitiveValidString SSL_CLIENT_AUTH_VALIDATOR =
+      ConfigDef.CaseInsensitiveValidString.in(
+          "true",
+          "false",
+          SSL_CLIENT_AUTHENTICATION_NONE,
+          SSL_CLIENT_AUTHENTICATION_REQUESTED,
+          SSL_CLIENT_AUTHENTICATION_REQUIRED
+      );
+  protected static final String SSL_CLIENT_AUTH_DEFAULT = SSL_CLIENT_AUTHENTICATION_NONE;
   public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
   protected static final String SSL_ENABLED_PROTOCOLS_DOC =
       "The list of protocols enabled for SSL connections. Comma-separated list. "
@@ -506,8 +524,9 @@ public class RestConfig extends AbstractConfig {
             SSL_CLIENT_AUTHENTICATION_DOC
         ).define(
             SSL_CLIENT_AUTH_CONFIG,
-            Type.BOOLEAN,
+            Type.STRING,
             SSL_CLIENT_AUTH_DEFAULT,
+            SSL_CLIENT_AUTH_VALIDATOR,
             Importance.MEDIUM,
             SSL_CLIENT_AUTH_DOC
         ).define(


### PR DESCRIPTION
`ssl.client.auth` is a String in Kafka that accepts lower-case values `required/requested/none`. In REST utils, we have two configs, a boolean `ssl.client.auth=true/false` that is deprecated and another config `ssl.client.authentication` that takes upper-case values `REQUIRED/REQUESTED/NONE`. `ssl.client.authentication`  has higher precedence than `ssl.client.auth`.

To make REST utils consistent with Kafka without breaking existing configuration, this PR:
  1) Undeprecates `ssl.client.auth` and deprecates `ssl.client.authentication`
  2) Makes both configs case insenstive
  3) Makes `ssl.client.auth` a String config that accepts `true/false/required/requested/none`
  4) Retains the existing precedence where`ssl.client.authentication` overrides `ssl.client.auth`

This PR was originally written because Kafka brokers failed to start with `ssl.client.auth` configured. This turned out to be another bug which affects multiple configs and is being fixed separately in MDS. Submitting this PR for review anyway to decide whether we want to make this change for consistency.