### PR TITLE
Migrate rest-utils to use AK library instead of common-metrics

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -69,10 +69,10 @@ import javax.servlet.DispatcherType;
 import javax.servlet.ServletException;
 import javax.ws.rs.core.Configurable;
 
-import io.confluent.common.metrics.JmxReporter;
-import io.confluent.common.metrics.MetricConfig;
-import io.confluent.common.metrics.Metrics;
-import io.confluent.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsReporter;
 import io.confluent.rest.auth.AuthUtil;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.GenericExceptionMapper;

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -16,7 +16,7 @@
 
 package io.confluent.rest;
 
-import io.confluent.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Metrics;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.eclipse.jetty.jmx.MBeanContainer;

--- a/core/src/main/java/io/confluent/rest/MetricsListener.java
+++ b/core/src/main/java/io/confluent/rest/MetricsListener.java
@@ -19,11 +19,11 @@ package io.confluent.rest;
 import java.net.Socket;
 import java.util.Map;
 
-import io.confluent.common.metrics.MetricName;
-import io.confluent.common.metrics.Metrics;
-import io.confluent.common.metrics.Sensor;
-import io.confluent.common.metrics.stats.Rate;
-import io.confluent.common.metrics.stats.Total;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.stats.Total;
 import org.eclipse.jetty.io.NetworkTrafficListener;
 
 public class MetricsListener extends NetworkTrafficListener.Adapter {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -17,14 +17,14 @@
 package io.confluent.rest;
 
 import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Importance;
-import org.apache.kafka.common.config.ConfigException;
-import io.confluent.common.utils.SystemTime;
-import io.confluent.common.utils.Time;
+import org.apache.kafka.common.utils.Time;
 
 import io.confluent.rest.extension.ResourceExtension;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -310,7 +310,6 @@ public class RestConfig extends AbstractConfig {
   public static final String RESPONSE_HTTP_HEADERS_DOC =
           "Set values for Jetty HTTP response headers";
   public static final String RESPONSE_HTTP_HEADERS_DEFAULT = "";
-
 
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
@@ -664,7 +663,7 @@ public class RestConfig extends AbstractConfig {
         );
   }
 
-  private static Time defaultTime = new SystemTime();
+  private static Time defaultTime = Time.SYSTEM;
 
   public RestConfig(ConfigDef definition, Map<?, ?> originals) {
     super(definition, originals);

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -16,8 +16,6 @@
 
 package io.confluent.rest.metrics;
 
-import io.confluent.common.metrics.stats.Percentile;
-import io.confluent.common.metrics.stats.Percentiles;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.Resource;
@@ -41,17 +39,20 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
-import io.confluent.common.metrics.MetricName;
-import io.confluent.common.metrics.Metrics;
-import io.confluent.common.metrics.Sensor;
-import io.confluent.common.metrics.stats.Avg;
-import io.confluent.common.metrics.stats.Count;
-import io.confluent.common.metrics.stats.Max;
-import io.confluent.common.metrics.stats.Rate;
-import io.confluent.common.utils.Time;
 import io.confluent.rest.annotations.PerformanceMetric;
 
 import javax.ws.rs.WebApplicationException;
+
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.metrics.stats.Percentile;
+import org.apache.kafka.common.metrics.stats.Percentiles;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.apache.kafka.common.metrics.stats.Rate;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.utils.Time;
 
 /**
  * Jersey ResourceMethodApplicationListener that records metrics for each endpoint by listening
@@ -188,7 +189,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       MetricName metricName = new MetricName(
           getName(method, annotation, "request-rate"), metricGrpName,
           "The average number of HTTP requests per second.", metricTags);
-      this.requestSizeSensor.add(metricName, new Rate(new Count()));
+      this.requestSizeSensor.add(metricName, new Rate(new WindowedCount()));
       metricName = new MetricName(
           getName(method, annotation, "request-byte-rate"), metricGrpName,
           "Bytes/second of incoming requests", metricTags);
@@ -206,7 +207,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       metricName = new MetricName(
           getName(method, annotation, "response-rate"), metricGrpName,
           "The average number of HTTP responses per second.", metricTags);
-      this.responseSizeSensor.add(metricName, new Rate(new Count()));
+      this.responseSizeSensor.add(metricName, new Rate(new WindowedCount()));
       metricName = new MetricName(
           getName(method, annotation, "response-byte-rate"), metricGrpName,
           "Bytes/second of outgoing responses", metricTags);

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -64,7 +64,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.SecurityContext;
 
-import io.confluent.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import io.confluent.rest.annotations.PerformanceMetric;
 
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -55,7 +55,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Configurable;
 
-import io.confluent.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import io.confluent.rest.annotations.PerformanceMetric;
 
 import static org.junit.Assert.assertEquals;

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -16,8 +16,8 @@
 
 package io.confluent.rest;
 
-import io.confluent.common.metrics.KafkaMetric;
-import io.confluent.common.metrics.MetricsReporter;
+import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.MetricsReporter;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -29,6 +29,11 @@ public class TestMetricsReporter implements MetricsReporter {
 
   public void metricChange(KafkaMetric metric) {
     metricTimeseries.add(metric);
+  }
+
+  @Override
+  public void metricRemoval(KafkaMetric kafkaMetric) {
+
   }
 
   public static List<KafkaMetric> getMetricTimeseries() {

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -1,6 +1,6 @@
 package io.confluent.rest.metrics;
 
-import io.confluent.common.metrics.KafkaMetric;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import io.confluent.rest.TestMetricsReporter;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.confluent.rest.exceptions.RestNotFoundException;


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/MMA-7195

As part of our efforts to converge on a single telemetry pipelines for Cloud, Hosted Monitoring, and Proactive Support, we want to standardize on one metrics library and associated metrics collection framework.

This change is prerequisite for Telemetry Reporter work.

Verfication
- [x] Manually cloned and verified downstream components build + test passes https://confluentinc.atlassian.net/wiki/spaces/MMA/pages/1193709217/Rest-utils+metrics+migration+plan
- [x] Muckrake spot test https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3710/
- [x] Packaging job https://jenkins.confluent.io/job/confluentinc-pr/job/packaging/job/PR-741/2/
- [x] Full Muckrake test 
baseline: https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3721/console
with this change: https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3715/

