### PR TITLE
Fix pom to inherit from common-parent, instead of common.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -81,6 +81,10 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>common-utils</artifactId>
+        </dependency>
         <!--test-->
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <groupId>io.confluent</groupId>
-        <artifactId>common</artifactId>
+        <artifactId>common-parent</artifactId>
         <version>6.0.0-SNAPSHOT</version>
     </parent>
 


### PR DESCRIPTION
By inheriting from common, it adds a dependency (common-utils) to all the poms that inherit from this one, which is not the intended behaviour. Child poms that rely on this dependency should depend on common-utils directly.