### PR TITLE
Extensible Application Metrics instance configuration

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationGroup.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationGroup.java
@@ -41,7 +41,7 @@ final class ApplicationGroup {
 
   void doStop() {
     for (Application<?> application: applications) {
-      application.metrics.close();
+      application.getMetrics().close();
       application.doShutdown();
     }
   }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -192,7 +192,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();
     for (Application app : applications.getApplications()) {
-      attachMetricsListener(app.metrics, app.getMetricsTags());
+      attachMetricsListener(app.getMetrics(), app.getMetricsTags());
       handlers.addHandler(app.configureHandler());
       wsHandlers.addHandler(app.configureWebSocketHandler());
     }

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -49,6 +49,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
+
+import io.confluent.rest.metrics.RestMetricsContext;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -329,9 +331,9 @@ public class ApplicationTest {
   public void testDefaultMetricsContext() throws Exception {
     TestApp testApp = new TestApp();
 
-    assertEquals(testApp.metricsContext.getLabel(RESOURCE_LABEL_TYPE),
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE),
             RestConfig.METRICS_JMX_PREFIX_DEFAULT);
-    assertEquals(testApp.metricsContext.getLabel(NAMESPACE),
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE),
             RestConfig.METRICS_JMX_PREFIX_DEFAULT);
   }
 
@@ -342,8 +344,8 @@ public class ApplicationTest {
 
     TestApp testApp = new TestApp(props);
 
-    assertEquals(testApp.metricsContext.getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-    assertEquals(testApp.metricsContext.getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
 
     /* Only NameSpace should be propagated to JMX */
     String jmx_domain =  RestConfig.METRICS_JMX_PREFIX_DEFAULT;
@@ -360,8 +362,8 @@ public class ApplicationTest {
 
     TestApp testApp = new TestApp(props);
 
-    assertEquals(testApp.metricsContext.getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-    assertEquals(testApp.metricsContext.getLabel(NAMESPACE), "FooApp");
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), "FooApp");
   }
 
   @Test
@@ -403,6 +405,10 @@ public class ApplicationTest {
 
     public TestApp(final Map<String, Object> config) {
       super(createConfig(config));
+    }
+
+    public RestMetricsContext metricsContext() {
+      return getConfiguration().getMetricsContext();
     }
 
     @Override

--- a/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
@@ -95,7 +95,7 @@ public class RequestScopedMetricsIntegrationTest {
     }
 
     public int numMetrics() {
-      return metrics.metrics().size();
+      return getMetrics().metrics().size();
     }
   }
 


### PR DESCRIPTION
We leak some metrics reporter configs into kafka-rest. This is intended facilitate breaking some of that coupling. 