### PR TITLE
Lazily load Application Metrics instance

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -119,16 +119,16 @@ public abstract class Application<T extends RestConfig> {
   /**
    * Configure Application MetricReport instances.
    */
-  private List<MetricsReporter> configureMetricsReporters() {
+  private List<MetricsReporter> configureMetricsReporters(RestConfig appConfig) {
     List<MetricsReporter> reporters =
-            config.getConfiguredInstances(
+            appConfig.getConfiguredInstances(
                     RestConfig.METRICS_REPORTER_CLASSES_CONFIG,
                     MetricsReporter.class);
 
     reporters.add(new JmxReporter());
 
     reporters.forEach(r -> r.configure(
-            config.metricsReporterConfig()));
+            appConfig.metricsReporterConfig()));
 
     return reporters;
   }
@@ -138,21 +138,23 @@ public abstract class Application<T extends RestConfig> {
    * Configure Application Metrics instance.
    */
   private void configureMetrics() {
+    RestConfig appConfig = getConfiguration();
+
     MetricConfig metricConfig = new MetricConfig()
-            .samples(config.getInt(RestConfig.METRICS_NUM_SAMPLES_CONFIG))
-            .timeWindow(config.getLong(RestConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG),
+            .samples(appConfig.getInt(RestConfig.METRICS_NUM_SAMPLES_CONFIG))
+            .timeWindow(appConfig.getLong(RestConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG),
                     TimeUnit.MILLISECONDS);
 
     metrics = new Metrics(metricConfig,
-            configureMetricsReporters(),
-            config.getTime(),
-            config.getMetricsContext());
+            configureMetricsReporters(appConfig),
+            appConfig.getTime(),
+            appConfig.getMetricsContext());
   }
 
   /**
    * Returns {@link Metrics} object
    */
-  public final Metrics getMetrics() {
+  public Metrics getMetrics() {
     if (this.metrics == null) {
       configureMetrics();
     }
@@ -226,7 +228,7 @@ public abstract class Application<T extends RestConfig> {
   public Map<String, String> configuredMetricTags() {
     // Combine metric tags without modifying original map.
     Map<String,String> metricsTags =
-            parseListToMap(config.getList(RestConfig.METRICS_TAGS_CONFIG));
+            parseListToMap(getConfiguration().getList(RestConfig.METRICS_TAGS_CONFIG));
     metricsTags.putAll(getMetricsTags());
 
     return metricsTags;

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -36,6 +36,8 @@ public class RestConfig extends AbstractConfig {
 
   private final RestMetricsContext metricsContext;
 
+  public static final String METRICS_REPORTER_CONFIG_PREFIX = "metric.reporters.";
+
   public static final String DEBUG_CONFIG = "debug";
   protected static final String DEBUG_CONFIG_DOC =
       "Boolean indicating whether extra debugging information is generated in some "
@@ -686,6 +688,10 @@ public class RestConfig extends AbstractConfig {
 
   public RestMetricsContext getMetricsContext() {
     return metricsContext;
+  }
+
+  public Map<String, Object> metricsReporterConfig() {
+    return originalsWithPrefix(METRICS_REPORTER_CONFIG_PREFIX);
   }
 
   public static void validateHttpResponseHeaderConfig(String config) {

--- a/core/src/test/java/io/confluent/rest/ApplicationMetricsContextTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationMetricsContextTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest;
+
+import static io.confluent.rest.metrics.TestRestMetricsContext.RESOURCE_LABEL_TYPE;
+import static org.apache.kafka.common.metrics.MetricsContext.NAMESPACE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.confluent.rest.metrics.RestMetricsContext;
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import javax.ws.rs.core.Configurable;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+
+
+public class ApplicationMetricsContextTest {
+
+  private static ApplicationServer server;
+
+  @Before
+  public void setup() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
+
+    server = new ApplicationServer(new TestRestConfig(props));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    server.stop();
+  }
+
+  @Test
+  public void testDefaultMetricsContext() throws Exception {
+    TestApp testApp = new TestApp();
+    server.registerApplication(testApp);
+    server.start();
+
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE),
+            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE),
+            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+  }
+
+  @Test
+  public void testMetricsContextResourceOverride() throws Exception  {
+    Map<String, Object> props = new HashMap<>();
+    props.put("metrics.context.resource.type", "FooApp");
+
+    TestApp testApp = new TestApp(props);
+    server.registerApplication(testApp);
+    server.start();
+
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
+      assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+
+      /* Only NameSpace should be propagated to JMX */
+      String jmx_domain = RestConfig.METRICS_JMX_PREFIX_DEFAULT;
+      String mbean_name = String.format("%s:type=kafka-metrics-count", jmx_domain);
+
+      MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+      assertNotNull(server.getObjectInstance(new ObjectName(mbean_name)));
+
+  }
+
+  @Test
+  public void testMetricsContextJMXPrefixPropagation() throws Exception  {
+    Map<String, Object> props = new HashMap<>();
+    props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
+
+    TestApp testApp = new TestApp(props);
+    server.registerApplication(testApp);
+    server.start();
+
+    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), "FooApp");
+  }
+
+  @Test
+  public void testMetricsReporterPrefixPropagation() throws Exception  {
+    Map<String, Object> props = new HashMap<>();
+    props.put(RestConfig.METRICS_REPORTER_CONFIG_PREFIX + "fooreporter.bootstrap.server",
+            "bar:9092");
+
+    TestApp testApp = new TestApp(props);
+
+    Map<String, Object> reporterProps = testApp.getConfiguration().metricsReporterConfig();
+    assertEquals(reporterProps.get("fooreporter.bootstrap.server"), "bar:9092");
+  }
+
+  @Test
+  public void testMetricsContextJMXBeanRegistration() throws Exception  {
+    Map<String, Object> props = new HashMap<>();
+    props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
+
+    TestApp testApp = new TestApp(props);
+    server.registerApplication(testApp);
+    server.start();
+
+    testApp.start();
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    assertNotNull(server.getObjectInstance(new ObjectName("FooApp:type=kafka-metrics-count")));
+  }
+
+  @Test
+  public void testMetricsContextJMXBeanRegistration_ApplicationGroup() throws Exception  {
+    Map<String, Object> appProps1 = new HashMap<>();
+    appProps1.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp1");
+
+    Map<String, Object> appProps2 = new HashMap<>();
+    appProps2.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp2");
+
+    TestApp testApp1 = new TestApp(appProps1);
+    TestApp testApp2 = new TestApp(appProps2);
+
+    server.registerApplication(testApp1);
+    server.registerApplication(testApp2);
+
+    server.start();
+
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    assertNotNull(server.getObjectInstance(new ObjectName("FooApp1:type=kafka-metrics-count")));
+    assertNotNull(server.getObjectInstance(new ObjectName("FooApp2:type=kafka-metrics-count")));
+  }
+
+  private static class TestApp extends Application<TestRestConfig> implements AutoCloseable {
+    public TestApp() throws Exception {
+      this(new HashMap<>());
+    }
+
+    public TestApp(final Map<String, Object> config) throws Exception {
+      super(createConfig(config));
+    }
+
+    public RestMetricsContext metricsContext() {
+      return getConfiguration().getMetricsContext();
+    }
+
+    @Override
+    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) { }
+
+    @Override
+    public void close() throws Exception {
+      stop();
+    }
+
+    private static TestRestConfig createConfig(final Map<String, Object> props) {
+      final HashMap<String, Object> config = new HashMap<>(props);
+      config.put(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
+      return new TestRestConfig(config);
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/ApplicationMetricsContextTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationMetricsContextTest.java
@@ -29,11 +29,9 @@ import java.util.Properties;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.ws.rs.core.Configurable;
-
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
 
 
 public class ApplicationMetricsContextTest {
@@ -66,7 +64,7 @@ public class ApplicationMetricsContextTest {
   }
 
   @Test
-  public void testMetricsContextResourceOverride() throws Exception  {
+  public void testMetricsContextResourceOverride() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put("metrics.context.resource.type", "FooApp");
 
@@ -75,19 +73,19 @@ public class ApplicationMetricsContextTest {
     server.start();
 
     assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-      assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
 
-      /* Only NameSpace should be propagated to JMX */
-      String jmx_domain = RestConfig.METRICS_JMX_PREFIX_DEFAULT;
-      String mbean_name = String.format("%s:type=kafka-metrics-count", jmx_domain);
+    /* Only NameSpace should be propagated to JMX */
+    String jmx_domain = RestConfig.METRICS_JMX_PREFIX_DEFAULT;
+    String mbean_name = String.format("%s:type=kafka-metrics-count", jmx_domain);
 
-      MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-      assertNotNull(server.getObjectInstance(new ObjectName(mbean_name)));
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    assertNotNull(server.getObjectInstance(new ObjectName(mbean_name)));
 
   }
 
   @Test
-  public void testMetricsContextJMXPrefixPropagation() throws Exception  {
+  public void testMetricsContextJMXPrefixPropagation() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
 
@@ -100,7 +98,7 @@ public class ApplicationMetricsContextTest {
   }
 
   @Test
-  public void testMetricsReporterPrefixPropagation() throws Exception  {
+  public void testMetricsReporterPrefixPropagation() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.METRICS_REPORTER_CONFIG_PREFIX + "fooreporter.bootstrap.server",
             "bar:9092");
@@ -112,7 +110,7 @@ public class ApplicationMetricsContextTest {
   }
 
   @Test
-  public void testMetricsContextJMXBeanRegistration() throws Exception  {
+  public void testMetricsContextJMXBeanRegistration() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
 
@@ -126,7 +124,7 @@ public class ApplicationMetricsContextTest {
   }
 
   @Test
-  public void testMetricsContextJMXBeanRegistration_ApplicationGroup() throws Exception  {
+  public void testMetricsContextJMXBeanRegistration_ApplicationGroup() throws Exception {
     Map<String, Object> appProps1 = new HashMap<>();
     appProps1.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp1");
 
@@ -160,7 +158,8 @@ public class ApplicationMetricsContextTest {
     }
 
     @Override
-    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) { }
+    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) {
+    }
 
     @Override
     public void close() throws Exception {

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -16,8 +16,6 @@
 
 package io.confluent.rest;
 
-import static io.confluent.rest.metrics.TestRestMetricsContext.RESOURCE_LABEL_TYPE;
-import static org.apache.kafka.common.metrics.MetricsContext.NAMESPACE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -30,7 +28,6 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.extension.ResourceExtension;
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
 import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
@@ -42,8 +39,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -325,56 +320,6 @@ public class ApplicationTest {
     testApp.stop();
     testApp.join();
     assertThat("shutdown called", TestApp.SHUTDOWN_CALLED.get(), is(true));
-  }
-
-  @Test
-  public void testDefaultMetricsContext() throws Exception {
-    TestApp testApp = new TestApp();
-
-    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE),
-            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
-    assertEquals(testApp.metricsContext().getLabel(NAMESPACE),
-            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
-  }
-
-  @Test
-  public void testMetricsContextResourceOverride() throws Exception  {
-    Map<String, Object> props = new HashMap<>();
-    props.put("metrics.context.resource.type", "FooApp");
-
-    TestApp testApp = new TestApp(props);
-
-    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
-
-    /* Only NameSpace should be propagated to JMX */
-    String jmx_domain =  RestConfig.METRICS_JMX_PREFIX_DEFAULT;
-    String mbean_name = String.format("%s:type=kafka-metrics-count", jmx_domain);
-
-    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-    assertNotNull(server.getObjectInstance(new ObjectName(mbean_name)));
-  }
-
-  @Test
-  public void testMetricsContextJMXPrefixPropagation() throws Exception  {
-    Map<String, Object> props = new HashMap<>();
-    props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
-
-    TestApp testApp = new TestApp(props);
-
-    assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), "FooApp");
-  }
-
-  @Test
-  public void testMetricsContextJMXBeanRegistration() throws Exception  {
-    Map<String, Object> props = new HashMap<>();
-    props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
-
-    new TestApp(props);
-
-    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-    assertNotNull(server.getObjectInstance(new ObjectName("FooApp:type=kafka-metrics-count")));
   }
 
   private void assertExpectedUri(URI uri, String scheme, String host, int port) {


### PR DESCRIPTION
Also provides common prefix for extracting MetricsReporter configs