### PR TITLE
Removed OPTION omission for CORS

### DIFF
--- a/core/src/main/java/io/confluent/rest/auth/AuthUtil.java
+++ b/core/src/main/java/io/confluent/rest/auth/AuthUtil.java
@@ -128,9 +128,6 @@ public final class AuthUtil {
     final ConstraintMapping mapping = new ConstraintMapping();
     mapping.setConstraint(constraint);
     mapping.setMethod("*");
-    if (authenticate && AuthUtil.isCorsEnabled(restConfig)) {
-      mapping.setMethodOmissions(new String[]{"OPTIONS"});
-    }
     mapping.setPathSpec(pathSpec);
     return mapping;
   }

--- a/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
+++ b/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
@@ -76,32 +76,6 @@ public class AuthUtilTest {
   }
 
   @Test
-  public void shouldCreateGlobalConstraintWithNoMethodsOmittedForNonCor() {
-    // Given:
-    config = restConfigWith(ImmutableMap.of(
-        RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, ""));
-
-    // When:
-    final ConstraintMapping mapping = AuthUtil.createGlobalAuthConstraint(config);
-
-    // Then:
-    assertThat(mapping.getMethodOmissions(), is(nullValue()));
-  }
-
-  @Test
-  public void shouldCreateGlobalConstraintWithOptionsOmittedForCor() {
-    // Given:
-    config = restConfigWith(ImmutableMap.of(
-        RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG, "something"));
-
-    // When:
-    final ConstraintMapping mapping = AuthUtil.createGlobalAuthConstraint(config);
-
-    // Then:
-    assertThat(mapping.getMethodOmissions(), is(new String[]{"OPTIONS"}));
-  }
-
-  @Test
   public void shouldCreateGlobalConstraintWithAuthRequired() {
     // When:
     final ConstraintMapping mapping = AuthUtil.createGlobalAuthConstraint(config);


### PR DESCRIPTION
This had to be done for https://confluentinc.atlassian.net/browse/ESCALATION-3168.
When Customer has RBAC/CORS enabled together, anonymous requests run into issue because of jetty/OAuthBearerAuthenticator. 
We came to conclusion to get it fixed in rest-utils. 
This change will require all HTTP methods (including OPTION) to require authentication if it was enabled.