### PR TITLE
Use prefix to propagate metrics reporter configs

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -135,7 +135,7 @@ public abstract class Application<T extends RestConfig> {
                     MetricsReporter.class);
     reporters.add(new JmxReporter());
 
-    reporters.forEach(r -> r.configure(appConfig.originals()));
+    reporters.forEach(r -> r.configure(appConfig.metricsReporterConfig()));
     return reporters;
   }
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -36,6 +36,8 @@ public class RestConfig extends AbstractConfig {
 
   private final RestMetricsContext metricsContext;
 
+  public static final String METRICS_REPORTER_CONFIG_PREFIX = "metric.reporters.";
+
   public static final String DEBUG_CONFIG = "debug";
   protected static final String DEBUG_CONFIG_DOC =
       "Boolean indicating whether extra debugging information is generated in some "
@@ -682,6 +684,10 @@ public class RestConfig extends AbstractConfig {
 
   public Time getTime() {
     return defaultTime;
+  }
+
+  public Map<String, Object> metricsReporterConfig() {
+    return originalsWithPrefix(METRICS_REPORTER_CONFIG_PREFIX);
   }
 
   public RestMetricsContext getMetricsContext() {

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -27,6 +27,8 @@ public class TestMetricsReporter implements MetricsReporter {
 
   private static List<KafkaMetric> metricTimeseries = new LinkedList<KafkaMetric>();
 
+  private Map<String, ?> configs;
+
   public void metricChange(KafkaMetric metric) {
     metricTimeseries.add(metric);
   }
@@ -49,6 +51,11 @@ public class TestMetricsReporter implements MetricsReporter {
   }
 
   public void configure(Map<String, ?> configs) {
+    this.configs = configs;
+  }
+
+  public Map<String, ?> getConfigs() {
+    return this.configs;
   }
 
   public void init(List<KafkaMetric> metrics) {

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -13,6 +13,8 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import javax.servlet.RequestDispatcher;
@@ -33,9 +35,7 @@ import io.confluent.rest.RestConfig;
 import io.confluent.rest.TestRestConfig;
 
 import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.HTTP_STATUS_CODE_TAG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
@@ -111,6 +111,25 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
   }
 
+  @Test
+  public void testMetricReporterConfiguration() {
+    ApplicationWithFilter app;
+    Properties props = new Properties();
+
+    props.put(RestConfig.METRICS_REPORTER_CONFIG_PREFIX + "prop1", "val1");
+    props.put(RestConfig.METRICS_REPORTER_CONFIG_PREFIX + "prop2", "val2");
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    props.put("not.reporter.config", "val3");
+
+    app = new ApplicationWithFilter(new TestRestConfig(props));
+    TestMetricsReporter reporter = (TestMetricsReporter) app.getMetrics().reporters().get(0);
+
+    assertFalse(reporter.getConfigs().containsKey("not.reporter.config"));
+    assertTrue(reporter.getConfigs().containsKey("prop1"));
+    assertTrue(reporter.getConfigs().containsKey("prop2"));
+  }
+
+
   private class ApplicationWithFilter extends Application<TestRestConfig> {
 
     Configurable resourceConfig;
@@ -143,6 +162,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         }
       });
     }
+
   }
 
   @Produces(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
What: Helper function to capture all metric reporter specific configs

Why: Currently rest-utils passes all originals to the metrics reporter. This may prove problematic for some reporters and or higher order applications with stricter configuration handling needs. 