### PR TITLE
SEC-1034: log4j migration to confluent repackaged version

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -120,6 +120,12 @@
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,6 +31,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
- Confluent repackaged version fixes CVE-2019-17571
- `common/pom.xml` excludes default log4j as a transitive dependency, and the repackaged version must be explicitly added.

Ref: https://github.com/confluentinc/common/pull/270