### PR TITLE
Fix build failure

### DIFF
--- a/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
+++ b/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
@@ -128,7 +128,7 @@ public class ApiHeadersTest {
     final KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
 
     final X509Certificate cert = new CertificateBuilder(30, "SHA1withRSA")
-        .sanDnsName("localhost").generate("CN=mymachine.local, O=A client", keypair);
+        .sanDnsNames("localhost").generate("CN=mymachine.local, O=A client", keypair);
 
     TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias,
         keypair.getPrivate(), cert);

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -99,7 +99,7 @@ public class SslTest {
   private void createKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
     KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
     CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
-    X509Certificate cCert = certificateBuilder.sanDnsName("localhost")
+    X509Certificate cCert = certificateBuilder.sanDnsNames("localhost")
         .generate("CN=mymachine.local, O=A client", keypair);
     TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
     certs.put(alias, cCert);
@@ -123,7 +123,7 @@ public class SslTest {
   private void createWrongKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
     KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
     CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
-    X509Certificate cCert = certificateBuilder.sanDnsName("fail")
+    X509Certificate cCert = certificateBuilder.sanDnsNames("fail")
         .generate("CN=mymachine.local, O=A client", keypair);
     TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
     certs.put(alias, cCert);


### PR DESCRIPTION
What
---
Fix build failure: https://jenkins.confluent.io/view/Packaging%20Snapshot/job/confluentinc/job/packaging/job/master/1823/execution/node/302/log/

Why
---
Jenkins build failed because TestSslUtils.CertificateBuilder api changed in kafka-clients-6.1.0-ccs-20200721.175538-46-test.jar
