### PR TITLE
ST-3461: Nano versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,5 +2,9 @@
 
 common {
   slackChannel = '#c3-alerts'
-  upstreamProjects = 'confluentinc/common'
+  downStreamRepos = ["schema-registry", "metadata-service", "kafka-rest",
+    "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
+    "confluent-cloud-plugins"]
+  nanoVersion = true
 }
+//change

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>rest-utils</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <artifactId>rest-utils-parent</artifactId>
         <groupId>io.confluent</groupId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>rest-utils-examples</artifactId>
@@ -19,11 +19,13 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
         </dependency>
 
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils-test</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>rest-utils-package</artifactId>
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,12 +8,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>[6.1.0-0, 6.1.1-0)</version>
     </parent>
 
     <artifactId>rest-utils-parent</artifactId>
     <packaging>pom</packaging>
     <name>rest-utils-parent</name>
+    <version>6.1.0-0</version>
     <organization>
         <name>Confluent, Inc.</name>
         <url>http://confluent.io</url>
@@ -54,6 +55,7 @@
         <jetty.version>9.4.30.v20200611</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
+        <io.confluent.rest-utils.version>6.1.0-0</io.confluent.rest-utils.version>
     </properties>
 
     <repositories>
@@ -70,12 +72,12 @@
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>rest-utils</artifactId>
-                <version>${project.version}</version>
+                <version>${io.confluent.rest-utils.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.confluent</groupId>
                 <artifactId>rest-utils-test</artifactId>
-                <version>${project.version}</version>
+                <version>${io.confluent.rest-utils.version}</version>
                 <scope>test</scope>
             </dependency>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>rest-utils-parent</artifactId>
-        <version>6.1.0-SNAPSHOT</version>
+        <version>6.1.0-0</version>
     </parent>
 
     <artifactId>rest-utils-test</artifactId>
@@ -19,6 +19,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>rest-utils</artifactId>
+            <version>${io.confluent.rest-utils.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Setting the jenkins config to use nano versioning. No longer need to define upstream repos as we now define downstream repos which will be automated in the future. Removed all of the snapshot versions and replaced with nano versions. Updated all of the dependency versions.

These changes will be merged during phase two of the nano versioning roll out.