### PR TITLE
ST-3461: Nano versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ test:
 
 
 
-export RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//')
+export RPM_VERSION=$(shell echo $(VERSION) | sed -e 's/-alpha[0-9]*//' -e 's/-beta[0-9]*//' -e 's/-rc[0-9]*//' -e 's/-SNAPSHOT//' -e 's/-cp[0-9]*//' -e 's/-[0-9]*//')
 # Get any -alpha, -beta, -rc piece that we need to put into the Release part of
 # the version since RPM versions don't support non-numeric
 # characters. Ultimately, for something like 0.8.2-beta, we want to end up with


### PR DESCRIPTION
Updated the regex used to get the rpm version so it supports the format of nano versioned releases.

These changes will be merged during phase two of the nano versioning roll out.