### PR TITLE
MINOR: Fix compilation error from createKeyStore

### DIFF
--- a/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
+++ b/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
@@ -130,7 +130,7 @@ public class ApiHeadersTest {
     final X509Certificate cert = new CertificateBuilder(30, "SHA1withRSA")
         .sanDnsNames("localhost").generate("CN=mymachine.local, O=A client", keypair);
 
-    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias,
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD), alias,
         keypair.getPrivate(), cert);
     certs.put(alias, cert);
   }

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -101,7 +101,7 @@ public class SslTest {
     CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
     X509Certificate cCert = certificateBuilder.sanDnsNames("localhost")
         .generate("CN=mymachine.local, O=A client", keypair);
-    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD),alias, keypair.getPrivate(), cCert);
     certs.put(alias, cCert);
   }
 
@@ -125,7 +125,7 @@ public class SslTest {
     CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
     X509Certificate cCert = certificateBuilder.sanDnsNames("fail")
         .generate("CN=mymachine.local, O=A client", keypair);
-    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
     certs.put(alias, cCert);
   }
 


### PR DESCRIPTION
https://github.com/confluentinc/kafka/commit/7be8bd8cbfea5cc19f815a142c4689e97728ea4b#diff-10d99f28c40b6cd9640f95b1c763a7b2b4daaa0209249e1a724698f28a90df9bL118-L126 Removed the function definition of `createKeyStore` that tests in this repo were using. This PR fixes the compilation errors by conforming to the remaining definition of `createKeyStore` that required two Password args.

I was able to compile and run the tests locally