### PR TITLE
 Make SslTest that verifies keystore reloading not flakey

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -142,5 +142,10 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -54,6 +54,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   private final T config;
   private final ApplicationGroup applications;
   private final SslContextFactory sslContextFactory;
+  private FileWatcher sslKeystoreFileWatcher;
 
   private List<NetworkTrafficServerConnector> connectors = new ArrayList<>();
 
@@ -177,6 +178,9 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   protected void doStop() throws Exception {
     super.doStop();
     applications.doStop();
+    if (sslKeystoreFileWatcher != null) {
+      sslKeystoreFileWatcher.shutdown();
+    }
   }
 
   protected final void doStart() throws Exception {
@@ -269,7 +273,9 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
       if (config.getBoolean(RestConfig.SSL_KEYSTORE_RELOAD_CONFIG)) {
         Path watchLocation = getWatchLocation(config);
         try {
-          FileWatcher.onFileChange(watchLocation, () -> {
+          // create and shutdown a sslKeystoreFileWatcher for each Application, so that
+          //  all Applications in the same JVM don't use the same shared threadpool
+          sslKeystoreFileWatcher = FileWatcher.onFileChange(watchLocation, () -> {
                 // Need to reset the key store path for symbolic link case
                 sslContextFactory.setKeyStorePath(
                     config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG)

--- a/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
+++ b/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
@@ -45,6 +45,7 @@ import org.apache.kafka.test.TestSslUtils.CertificateBuilder;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 public class ApiHeadersTest {
 
@@ -56,11 +57,16 @@ public class ApiHeadersTest {
   private static String clientKeystoreLocation;
   private static TestApplication app;
 
+  // Use a temporary folder so that .jks files created by this test are isolated
+  //  and deleted when the test is done
+  public static TemporaryFolder tempFolder = new TemporaryFolder();
+
   @BeforeClass
   public static void setUp() throws Exception {
-    final File trustStore = File.createTempFile("ApiHeadersTest-truststore", ".jks");
-    final File clientKeystore = File.createTempFile("ApiHeadersTest-client-keystore", ".jks");
-    final File serverKeystore = File.createTempFile("ApiHeadersTest-server-keystore", ".jks");
+    tempFolder.create();
+    final File trustStore = File.createTempFile("ApiHeadersTest-truststore", ".jks", tempFolder.getRoot());
+    final File clientKeystore = File.createTempFile("ApiHeadersTest-client-keystore", ".jks", tempFolder.getRoot());
+    final File serverKeystore = File.createTempFile("ApiHeadersTest-server-keystore", ".jks", tempFolder.getRoot());
 
     clientKeystoreLocation = clientKeystore.getAbsolutePath();
 
@@ -84,6 +90,7 @@ public class ApiHeadersTest {
     if (app != null) {
       app.stop();
     }
+    tempFolder.delete();
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <guava.version>24.0-jre</guava.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
+        <awaitility.version>4.0.3</awaitility.version>
     </properties>
 
     <repositories>
@@ -181,6 +182,12 @@
                 <groupId>org.glassfish.jersey.test-framework.providers</groupId>
                 <artifactId>jersey-test-framework-provider-jetty</artifactId>
                 <version>${jersey.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
   - 1 don't have a single static thread pool that all FileWatchers use
   - 2 update tests to cleanup temp/test keystore files

Also, introduced awaitility test library