### PR TITLE
(backport) SEC-592:  Customize Jetty request queue and threadpool size (#172)

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -273,6 +273,31 @@ public class RestConfig extends AbstractConfig {
           "The number of milliseconds to hold an idle session open for.";
   public static final long IDLE_TIMEOUT_MS_DEFAULT = 30_000;
 
+  public static final String THREAD_POOL_MIN_CONFIG = "thread.pool.min";
+  public static final String THREAD_POOL_MIN_DOC =
+          "The minimum number of threads will be startred for HTTP Servlet server.";
+  public static final int THREAD_POOL_MIN_DEFAULT = 8;
+
+  public static final String THREAD_POOL_MAX_CONFIG = "thread.pool.max";
+  public static final String THREAD_POOL_MAX_DOC =
+          "The maxinum number of threads will be startred for HTTP Servlet server.";
+  public static final int THREAD_POOL_MAX_DEFAULT = 200;
+
+  public static final String REQUEST_QUEUE_CAPACITY_CONFIG = "request.queue.capacity";
+  public static final String REQUEST_QUEUE_CAPACITY_DOC =
+          "The capacity of request queue for each thread pool.";
+  public static final int REQUEST_QUEUE_CAPACITY_DEFAULT = Integer.MAX_VALUE;
+
+  public static final String REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG = "request.queue.capacity.init";
+  public static final String REQUEST_QUEUE_CAPACITY_INITIAL_DOC =
+          "The initial capacity of request queue for each thread pool.";
+  public static final int REQUEST_QUEUE_CAPACITY_INITIAL_DEFAULT = 128;
+
+  public static final String REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG = "request.queue.capacity.growby";
+  public static final String REQUEST_QUEUE_CAPACITY_GROWBY_DOC =
+          "The size of request queue will be increased by.";
+  public static final int REQUEST_QUEUE_CAPACITY_GROWBY_DEFAULT = 64;
+
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
         PORT_CONFIG_DEFAULT,
@@ -580,6 +605,36 @@ public class RestConfig extends AbstractConfig {
             IDLE_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             IDLE_TIMEOUT_MS_DOC
+        ).define(
+            THREAD_POOL_MIN_CONFIG,
+            Type.INT,
+            THREAD_POOL_MIN_DEFAULT,
+            Importance.LOW,
+            THREAD_POOL_MIN_DOC
+        ).define(
+            THREAD_POOL_MAX_CONFIG,
+            Type.INT,
+            THREAD_POOL_MAX_DEFAULT,
+            Importance.LOW,
+            THREAD_POOL_MAX_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_INITIAL_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_INITIAL_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_DOC
+        ).define(
+            REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG,
+            Type.INT,
+            REQUEST_QUEUE_CAPACITY_GROWBY_DEFAULT,
+            Importance.LOW,
+            REQUEST_QUEUE_CAPACITY_GROWBY_DOC
         );
   }
 

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -1,0 +1,223 @@
+/**
+ * Copyright 2019 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.Test;
+import java.util.Properties;
+import java.util.concurrent.RejectedExecutionException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpStatus.Code;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+
+public class TestCustomizeThreadPool {
+
+  private static final Logger log = LoggerFactory.getLogger(TestCustomizeThreadPool.class);
+  private static Object locker = new Object();
+
+  /**
+   * Good path testing.
+   * Total number of running threads is less than capacity of thread pool configured.
+   * Total number of jobs in queue is less than capacity of queue configured.
+   */
+  @Test
+  public void testThreadPoolLessThreshold()throws Exception {
+    int numOfClients = 3;
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication();
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } catch (Exception e) {
+    } finally {
+      log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
+      assertTrue("Total number of running threads is less than maximum number of threads " + app.getServer().getMaxThreads(),
+              app.getServer().getThreads() - app.getServer().getMaxThreads() < 0);
+      log.info("Total jobs in queue {}, capacity of queue {}.", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+      assertTrue("Total number of jobs in queue is less than capacity of queue " + app.getServer().getQueueCapacity(),
+              app.getServer().getQueueSize() - app.getServer().getQueueCapacity() < 0);
+      app.stop();
+    }
+  }
+
+  /**
+   * This test will test the number of running threads will be increased as more clients request coming in, but
+   * the total number of threads will not over the maximum threads configured even there are more clients requests
+   * coming in. Server will finally throw following exceptions when more http client send requests.
+   * [ReservedThreadExecutor@1b1f5012{s=0/2,p=0}] rejected org.eclipse.jetty.io.ManagedSelector$Accept@26ac0324
+   * (org.eclipse.jetty.util.thread.QueuedThreadPool:471)
+   * java.util.concurrent.RejectedExecutionException:
+   * This test also test the size of jobs in queue will not over the capacity of queue configured.
+   **/
+  @Test
+  public void testThreadPoolReachThreshold()throws Exception {
+    int numOfClients = 40;
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication();
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } catch (Exception e) {
+    } finally {
+      log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
+      assertEquals("Total number of running threads reach maximum number of threads.", app.getServer().getMaxThreads(),
+              app.getServer().getThreads());
+      app.stop();
+    }
+  }
+
+  /**
+   * Simulate the case that the queue of thread pool is full. Http server will reject request if the queue is full and
+   * throw RejectedExecutionException.
+   **/
+  @Test(expected = RejectedExecutionException.class)
+  public void testQueueFull() throws Exception {
+    int numOfClients = 1;
+    Properties props = new Properties();
+    props.put(RestConfig.LISTENERS_CONFIG, "http://localhost:8080");
+    props.put(RestConfig.THREAD_POOL_MIN_CONFIG, "2");
+    props.put(RestConfig.THREAD_POOL_MAX_CONFIG, "10");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG, "0");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG, "0");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG, "2");
+    TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication(props);
+    String uri = app.getUri();
+    try {
+      app.start();
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+    } finally {
+      app.stop();
+    }
+  }
+
+  /**
+   * Simulate multiple HTTP clients sending HTTP requests same time. Each client will send one HTTP request.
+   * The requests will be put in queue if the number of clients are more than the working threads.
+   * */
+  @SuppressWarnings("SameParameterValue")
+  private void makeConcurrentGetRequests(String uri, int numThread, TestCustomizeThreadPoolApplication app) throws Exception {
+    Thread[] threads = new Thread[numThread];
+    for(int i = 0; i < numThread; i++) {
+      threads[i] = new Thread() {
+        public void run() {
+          HttpGet httpget = new HttpGet(uri);
+          CloseableHttpClient httpclient = HttpClients.createDefault();
+          CloseableHttpResponse response = null;
+          try {
+            response = httpclient.execute(httpget);
+            HttpStatus.Code statusCode = HttpStatus.getCode(response.getStatusLine().getStatusCode());
+            log.info("Status code {}, reason {} ", statusCode, response.getStatusLine().getReasonPhrase());
+            assertThat(statusCode, is(Code.OK));
+          } catch (Exception e) {
+          } finally {
+            try {
+              if (response != null) {
+                response.close();
+              }
+              httpclient.close();
+            } catch (Exception e) {
+            }
+          }
+        }
+      };
+
+      threads[i].start();
+    }
+
+    long startingTime = System.currentTimeMillis();
+    while(System.currentTimeMillis() - startingTime < 360*1000) {
+      log.info("Queue size {}, queue capacity {} ", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+      assertTrue("Number of jobs in queue is not more than capacity of queue ", app.getServer().getQueueSize() <= app.getServer().getQueueCapacity());
+      Thread.sleep(2000);
+      if (app.getServer().getQueueSize() == 0)
+        break;
+    }
+
+    for(int i = 0; i < numThread; i++) {
+      threads[i].join();
+    }
+    log.info("End queue size {}, queue capacity {} ", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
+  }
+
+  @Path("/custom")
+  @Produces(MediaType.TEXT_PLAIN)
+  public static class RestResource {
+    @GET
+    @Path("/resource")
+    public String get() {
+      synchronized(locker) {
+        try {
+          locker.wait(10000);
+        } catch (Exception e) {
+          log.info(e.getMessage());
+        }
+      }
+      return "ThreadPool";
+    }
+  }
+
+  private static class TestCustomizeThreadPoolApplication extends Application<TestRestConfig> {
+    static Properties props = null;
+
+    public TestCustomizeThreadPoolApplication() {
+      super(createConfig());
+    }
+    public TestCustomizeThreadPoolApplication(Properties props) {
+      super(new TestRestConfig(props));
+      this.props = props;
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
+      config.register(new RestResource());
+    }
+
+    public String getUri() {
+      return (String)props.get(RestConfig.LISTENERS_CONFIG);
+    }
+
+    private static TestRestConfig createConfig() {
+      props = new Properties();
+      String uri = "http://localhost:8080";
+      props.put(RestConfig.LISTENERS_CONFIG, uri);
+      props.put(RestConfig.THREAD_POOL_MIN_CONFIG, "2");
+      props.put(RestConfig.THREAD_POOL_MAX_CONFIG, "10");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG, "2");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG, "8");
+      props.put(RestConfig.REQUEST_QUEUE_CAPACITY_GROWBY_CONFIG, "2");
+      return new TestRestConfig(props);
+    }
+  }
+}
+
+
+


### PR DESCRIPTION
* Ability to customize the thread pool and size of request queue.

**Why**
Backporting the change as we have customers who are asking for this for older supported versions of C3