### PR TITLE
ST-4542: Upgrade jetty to address CVE-2020-27216

### DIFF
--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -4,6 +4,7 @@ import io.confluent.common.metrics.KafkaMetric;
 import io.confluent.rest.TestMetricsReporter;
 import io.confluent.rest.annotations.PerformanceMetric;
 import io.confluent.rest.exceptions.RestNotFoundException;
+import javax.servlet.ServletException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -138,7 +139,14 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
             HttpServletResponse response
         ) throws IOException {
           handledException = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
-          super.handle(target, baseRequest, request, response);
+          try {
+            super.handle(target, baseRequest, request, response);
+          } catch (ServletException e) {
+            // Silently ignore ServletException -- because this will never be thrown, at least
+            // for jetty 9.4.33.v20201020. Notice that in the code here, doError() only throws
+            // IOException, and not ServletException.
+            // https://github.com/eclipse/jetty.project/blob/jetty-9.4.33.v20201020/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ErrorHandler.java#L91
+          }
         }
       });
     }

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.3</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.28</jersey.version>
-        <jetty.version>9.4.20.v20190813</jetty.version>
+        <jersey.version>2.31</jersey.version>
+        <jetty.version>9.4.33.v20201020</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <guava.version>24.0-jre</guava.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>


### PR DESCRIPTION
Note that Jersey needs to be upgraded as well to ensure compatibility. 
See this word of caution that was included in AK before this upgrade was applied https://github.com/apache/kafka/blob/dbdd1b1bb72ab0e012f7a746cefb6e593da44683/gradle/dependencies.gradle#L71

Note that the CI build fails because of a few downstream repositories using Jersey's private Base64 for some tests. Those fixes will come later. 