### PR TITLE
ST-4542: Upgrade jetty to address CVE-2020-27216

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,8 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.3</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.30</jersey.version>
-        <jetty.version>9.4.24.v20191120</jetty.version>
+        <jersey.version>2.31</jersey.version>
+        <jetty.version>9.4.33.v20201020</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>


### PR DESCRIPTION
Note that Jersey needs to be upgraded as well to ensure compatibility.
See this word of caution that was included in AK before this
upgrade was applied:
https://github.com/apache/kafka/blob/dbdd1b1bb72ab0e012f7a746cefb6e593da44683/gradle/dependencies.gradle#L71