### PR TITLE
ff-3928: bump version of Guava in parent of schema-registry.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jersey.version>2.31</jersey.version>
         <jetty.version>9.4.33.v20201020</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
-        <guava.version>24.0-jre</guava.version>
+        <guava.version>24.1.1-jre</guava.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 


### PR DESCRIPTION
https://github.com/confluentinc/schema-registry takes Guava version from this parent. 
There is a CVE related to Guava: https://confluentinc.atlassian.net/jira/software/c/projects/FF/issues/FF-3928