### PR TITLE
MMA-9580: Fix test failure

### DIFF
--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -16,6 +16,7 @@
  
 package io.confluent.rest;
 
+import java.nio.file.ClosedWatchServiceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,7 @@ public class FileWatcher implements Runnable {
         new ThreadFactory() {
           public Thread newThread(Runnable r) {
             Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setName("file-watcher");
             t.setDaemon(true);
             return t;
           }
@@ -80,8 +82,10 @@ public class FileWatcher implements Runnable {
           handleNextWatchNotification();
         } catch (InterruptedException e) {
           throw e;
+        } catch (ClosedWatchServiceException cwe) {
+          log.info("Watch service closed:" + cwe);
         } catch (Exception e) {
-          log.info("Watch service caught exception, will continue:" + e);
+          log.warn("Watch service caught exception, will continue:" + e);
         }
       }
     } catch (InterruptedException e) {

--- a/core/src/test/java/io/confluent/rest/IdleTimeoutConfigTest.java
+++ b/core/src/test/java/io/confluent/rest/IdleTimeoutConfigTest.java
@@ -23,11 +23,17 @@ public class IdleTimeoutConfigTest {
     props.put(RestConfig.IDLE_TIMEOUT_MS_CONFIG, String.valueOf(expectedIdleTimeout));
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
-    Server server = new TestApp(config).createServer();
-    server.start();
-    // then
-    Assert.assertEquals(expectedIdleTimeout, server.getConnectors()[0].getIdleTimeout());
-    server.stop();
+    Server server = null;
+    try {
+      server = new TestApp(config).createServer();
+      server.start();
+      // then
+      Assert.assertEquals(expectedIdleTimeout, server.getConnectors()[0].getIdleTimeout());
+    } finally {
+      if (server != null) {
+        server.stop();
+      }
+    }
   }
 
 


### PR DESCRIPTION
**What**
1. Don't rely on Thread.sleep. It can be flaky.
2. Shutdown the app even if the test has failed.
3. Minor refactoring