### PR TITLE
UIF-300: Upgrade org.apache.httpcomponents.httpclient 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
     <properties>
         <activation.version>1.1.1</activation.version>
-        <apache.httpclient.version>4.5.3</apache.httpclient.version>
+        <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.11.v20180605</jetty.version>
@@ -163,12 +163,12 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!--test-->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${apache.httpclient.version}</version>
             </dependency>
+            <!--test-->
             <dependency>
                 <groupId>org.glassfish.jersey.test-framework</groupId>
                 <artifactId>jersey-test-framework-core</artifactId>


### PR DESCRIPTION
Before: this transitive dependency version of httpclient has a CVE
After: Upgrade org.apache.httpcomponents.httpclient to 4.5.13
Ref: https://confluentinc.atlassian.net/browse/UIF-300