### PR TITLE
UIF-302: Upgrade guava for 5.4.x and older.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
-        <guava.version>24.0-jre</guava.version>
+        <guava.version>24.1.1-jre</guava.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
We did it for 5.5.x and later: https://github.com/confluentinc/rest-utils/pull/215/files, this PR wants to fix back to 5.1.x when Guava first appears.
