### PR TITLE
[Draft] UIF-304: Upgrade jetty-webapp.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <apache.httpclient.version>4.5.3</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.27</jersey.version>
-        <jetty.version>9.4.11.v20180605</jetty.version>
+        <jetty.version>9.4.33.v20201020</jetty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Upgrade Jetty to resolve https://nvd.nist.gov/vuln/detail/CVE-2020-27218. Previously, this change was made to 5.4.x and newer, this is to apply it to 5.3.x and earlier.