### PR TITLE
MMA-9930: Use Guava version defined in Common.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.12.v20180830</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
-        <guava.version>24.1.1-jre</guava.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
See the last comment in https://confluentinc.atlassian.net/browse/MMA-9930.
Common has been updated with Guava defined in all branches: https://github.com/confluentinc/common/pull/314
Removing Rest-Utils Guava property will inherit definition from Common.
Also Rest-utils 6.0.x and onwards do not have Guava definition.