### PR TITLE
MMA-9930: Use compatible version of Guava

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.11.v20180605</jetty.version>
+        <guava.version>24.1.1-jre</guava.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
5.1.x ---- 5.5.x all use 24.1.1-jre version of Guava. Although Common uses 28.1, for the purpose of fixing Guava CVE, we do want to enforce all consumers of Rest-Utils to use 24.1.1-jre for now. It can be future work to sync Guava version.

This will only be in 5.0.x.