### PR TITLE
KC-1456: Update Jetty to 9.4.36.v20210114

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.31</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.35.v20201120</jetty.version>
+        <jetty.version>9.4.36.v20210114</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>24.1.1-jre</guava.version>


### PR DESCRIPTION
We have updated Jetty version to `9.4.36.v20210114` for kafka 2.4 and above versions.
This PR is to update Jetty version to `9.4.36.v20210114` to match with Kafka version.