### PR TITLE
UIF-298: Upgrade Jetty to 9.4.35.v20201120

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.31</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.33.v20201020</jetty.version>
+        <jetty.version>9.4.35.v20201120</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>24.1.1-jre</guava.version>


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/UIF-298 
This will fix 5.4.x and newer.
https://github.com/confluentinc/rest-utils/pull/219 will try to work on 5.3.x and older. 
