### PR TITLE
CIAM-526 Count error codes after ExceptionMappers and use actual status code for all exception classes

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -41,8 +41,6 @@ import java.util.concurrent.TimeUnit;
 
 import io.confluent.rest.annotations.PerformanceMetric;
 
-import javax.ws.rs.WebApplicationException;
-
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.stats.Avg;
@@ -62,7 +60,8 @@ import org.slf4j.LoggerFactory;
  * latency (average, 90th, 99th, etc).
  */
 public class MetricsResourceMethodApplicationListener implements ApplicationEventListener {
-  private static final Logger log = LoggerFactory.getLogger(MetricsResourceMethodApplicationListener.class);
+  private static final Logger log = LoggerFactory.getLogger(
+      MetricsResourceMethodApplicationListener.class);
 
   public static final String REQUEST_TAGS_PROP_KEY = "_request_tags";
 
@@ -281,7 +280,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
      * Indicate that a request has failed with an exception.
      */
     public void exception(final RequestEvent event) {
-      int idx = event.getContainerResponse() != null ? event.getContainerResponse().getStatus() / 100 : 5;
+      int idx = event.getContainerResponse() != null ?
+          event.getContainerResponse().getStatus() / 100 : 5;
 
       // Index 0 means "unknown" status codes.
       if (idx <= 0 || idx >= 6) {

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -280,6 +280,9 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
      * Indicate that a request has failed with an exception.
      */
     public void exception(final RequestEvent event) {
+      //map the http status codes down to their classes (2xx, 4xx, 5xx)
+      // use the containerResponse status as it has the http status after ExceptionMappers
+      // are applied
       int idx = event.getContainerResponse() != null
           ? event.getContainerResponse().getStatus() / 100 : 5;
 

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -280,8 +280,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
      * Indicate that a request has failed with an exception.
      */
     public void exception(final RequestEvent event) {
-      int idx = event.getContainerResponse() != null ?
-          event.getContainerResponse().getStatus() / 100 : 5;
+      int idx = event.getContainerResponse() != null
+          ? event.getContainerResponse().getStatus() / 100 : 5;
 
       // Index 0 means "unknown" status codes.
       if (idx <= 0 || idx >= 6) {

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -281,7 +281,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
      * Indicate that a request has failed with an exception.
      */
     public void exception(final RequestEvent event) {
-      int idx = event.getContainerResponse().getStatus() / 100;
+      int idx = event.getContainerResponse() != null ? event.getContainerResponse().getStatus() / 100 : 5;
 
       // Index 0 means "unknown" status codes.
       if (idx <= 0 || idx >= 6) {

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -1,10 +1,7 @@
 package io.confluent.rest.metrics;
 
-import io.confluent.rest.exceptions.GenericExceptionMapper;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import io.confluent.rest.TestMetricsReporter;
-import io.confluent.rest.annotations.PerformanceMetric;
-import io.confluent.rest.exceptions.RestNotFoundException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;


### PR DESCRIPTION
Why/How
-----
MDS in cloud is occasionally registering unknown exceptions. These were marked as "status unknown", and upon reading the kibana logs, they looked like 400s, not 500s. So I looked closer at how we emit this metric, and it looks like this accounting happens before any mappers are applied. Since a mapper could take any exception and set any status code, it's clear that this error accounting should happen after mappers (in the "Finished" event). Added bonus is now we can directly ask for the actual status code returned, rather than the weird type-casting.

Also added error logs in the event that we can't tell how to tag this exception, so we can study those cases in detail more easily.

