### PR TITLE
KREST-860 Fix deprecated usages of org.apache.kafka.common.Metric.value()

### DIFF
--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -216,10 +216,20 @@ public class SaslTest {
   }
 
   private void assertMetricsCollected() {
-    assertNotEquals("Expected to have metrics.", 0, TestMetricsReporter.getMetricTimeseries().size());
+    assertNotEquals(
+        "Expected to have metrics.",
+        0,
+        TestMetricsReporter.getMetricTimeseries().size());
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-latency-max")) {
-        assertTrue("Metrics should be collected (max latency shouldn't be 0)", metric.value() != 0.0);
+        Object metricValue = metric.metricValue();
+        assertTrue(
+            "Request latency metrics should be measurable",
+            metricValue instanceof Double);
+        double latencyMaxValue = (double) metricValue;
+        assertTrue(
+            "Metrics should be collected (max latency shouldn't be 0)",
+            latencyMaxValue != 0.0);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -245,10 +245,20 @@ public class SslTest {
   }
 
   private void assertMetricsCollected() {
-    assertNotEquals("Expected to have metrics.", 0, TestMetricsReporter.getMetricTimeseries().size());
+    assertNotEquals(
+        "Expected to have metrics.",
+        0,
+        TestMetricsReporter.getMetricTimeseries().size());
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-latency-max")) {
-        assertTrue("Metrics should be collected (max latency shouldn't be 0)", metric.value() != 0.0);
+        Object metricValue = metric.metricValue();
+        assertTrue(
+            "Request latency metrics should be measurable",
+            metricValue instanceof Double);
+        double latencyMaxValue = (double) metricValue;
+        assertTrue(
+            "Metrics should be collected (max latency shouldn't be 0)",
+            latencyMaxValue != 0.0);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -42,11 +42,11 @@ public class TestMetricsReporter implements MetricsReporter {
     return metricTimeseries;
   }
 
-  public static void reset() { metricTimeseries = new LinkedList<KafkaMetric>(); }
+  public static void reset() { metricTimeseries = new LinkedList<>(); }
 
   public static void print() {
     for (KafkaMetric metric : metricTimeseries) {
-      System.out.println("\t" + metric.metricName() + ": " + metric.value());
+      System.out.println("\t" + metric.metricName() + ": " + metric.metricValue());
     }
   }
 

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -13,8 +13,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Properties;
 
 import javax.servlet.RequestDispatcher;
@@ -100,12 +98,14 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     for (KafkaMetric metric: TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
+        Object metricValue = metric.metricValue();
+        assertTrue("Error rate metrics should be measurable", metricValue instanceof Double);
+        double errorRateValue = (double) metricValue;
         if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("4xx")) {
-          assertTrue("Actual: " + metric.value(),
-              metric.value() > 0);
+          assertTrue("Actual: " + errorRateValue, errorRateValue > 0);
         } else if (!metric.metricName().tags().isEmpty()) {
-          assertTrue("Actual: " + metric.value() + metric.metricName(),
-              metric.value() == 0.0 || Double.isNaN(metric.value()));
+          assertTrue(String.format("Actual: %f (%s)", errorRateValue, metric.metricName()),
+              errorRateValue == 0.0 || Double.isNaN(errorRateValue));
         }
       }
     }


### PR DESCRIPTION
This addresses the deprecated API usages in `6.0.x` that will break after the first wave of Kafka 3.0.0 changes are merged in (the relevant discussion is available in Confluent's Slack).
- AFAICS, there's another set of usages that live just in `master`, related to the `5xx` metrics - I'll address these with a separate PR.

Tested by running all `rest-utils` tests locally.