### PR TITLE
KREST-860 Fix deprecated usages of org.apache.kafka.common.Metric.value() in master

### DIFF
--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -120,11 +120,14 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
+        Object metricValue = metric.metricValue();
+        assertTrue("Error rate metrics should be measurable", metricValue instanceof Double);
+        double errorRateValue = (double) metricValue;
         if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("5xx")) {
-          assertTrue("Actual: " + metric.value(), metric.value() > 0);
+          assertTrue("Actual: " + errorRateValue, errorRateValue > 0);
         } else if (!metric.metricName().tags().isEmpty()) {
-          assertTrue("Actual: " + metric.value() + metric.metricName(),
-              metric.value() == 0.0 || Double.isNaN(metric.value()));
+          assertTrue(String.format("Actual: %f (%s)", errorRateValue, metric.metricName()),
+              errorRateValue == 0.0 || Double.isNaN(errorRateValue));
         }
       }
     }


### PR DESCRIPTION
A follow-up to #239, addressing specifically a couple of usages that live just in `master`.