### PR TITLE
Fix all compiler warnings (including deprecated usages)

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -249,7 +249,7 @@ public abstract class Application<T extends RestConfig> {
     this.server = Objects.requireNonNull(server);
   }
 
-  final ApplicationServer getServer() {
+  final ApplicationServer<?> getServer() {
     return server;
   }
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -97,11 +97,12 @@ public abstract class Application<T extends RestConfig> {
   protected T config;
   private final String path;
 
-  protected ApplicationServer server;
+  protected ApplicationServer<T> server;
   protected Metrics metrics;
   protected final CustomRequestLog requestLog;
 
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
+  @SuppressWarnings("unchecked")
   protected final List<ResourceExtension> resourceExtensions = new ArrayList<>();
 
   private static final Logger log = LoggerFactory.getLogger(Application.class);
@@ -112,7 +113,7 @@ public abstract class Application<T extends RestConfig> {
 
   public Application(T config, String path) {
     this.config = config;
-    this.path = Objects.requireNonNull(path);;
+    this.path = Objects.requireNonNull(path);
 
     this.metrics = configureMetrics();
     this.getMetricsTags().putAll(
@@ -237,12 +238,13 @@ public abstract class Application<T extends RestConfig> {
   public Server createServer() throws ServletException {
     // CHECKSTYLE_RULES.ON: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
     if (server == null) {
-      server = new ApplicationServer(config);
+      server = new ApplicationServer<>(config);
       server.registerApplication(this);
     }
     return server;
   }
 
+  @SuppressWarnings("unchecked")
   final void setServer(ApplicationServer server) {
     this.server = Objects.requireNonNull(server);
   }

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -97,7 +97,7 @@ public abstract class Application<T extends RestConfig> {
   protected T config;
   private final String path;
 
-  protected ApplicationServer<T> server;
+  protected ApplicationServer<?> server;
   protected Metrics metrics;
   protected final CustomRequestLog requestLog;
 
@@ -228,7 +228,7 @@ public abstract class Application<T extends RestConfig> {
    * @return a Map of tags and values
    */
   public Map<String,String> getMetricsTags() {
-    return new LinkedHashMap<String, String>();
+    return new LinkedHashMap<>();
   }
 
   /**
@@ -244,8 +244,7 @@ public abstract class Application<T extends RestConfig> {
     return server;
   }
 
-  @SuppressWarnings("unchecked")
-  final void setServer(ApplicationServer server) {
+  final void setServer(ApplicationServer<?> server) {
     this.server = Objects.requireNonNull(server);
   }
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -32,9 +32,10 @@ import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -98,7 +99,7 @@ public abstract class Application<T extends RestConfig> {
 
   protected ApplicationServer server;
   protected Metrics metrics;
-  protected final Slf4jRequestLog requestLog;
+  protected final CustomRequestLog requestLog;
 
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
   protected final List<ResourceExtension> resourceExtensions = new ArrayList<>();
@@ -117,9 +118,9 @@ public abstract class Application<T extends RestConfig> {
     this.getMetricsTags().putAll(
             parseListToMap(config.getList(RestConfig.METRICS_TAGS_CONFIG)));
 
-    this.requestLog = new Slf4jRequestLog();
-    this.requestLog.setLoggerName(config.getString(RestConfig.REQUEST_LOGGER_NAME_CONFIG));
-    this.requestLog.setLogLatency(true);
+    Slf4jRequestLogWriter logWriter = new Slf4jRequestLogWriter();
+    logWriter.setLoggerName(config.getString(RestConfig.REQUEST_LOGGER_NAME_CONFIG));
+    requestLog = new CustomRequestLog(logWriter, CustomRequestLog.EXTENDED_NCSA_FORMAT + " %msT");
   }
 
   public final String getPath() {
@@ -353,7 +354,7 @@ public abstract class Application<T extends RestConfig> {
     configureSecurityHandler(webSocketContext);
 
     ServerContainer container =
-            WebSocketServerContainerInitializer.configureContext(webSocketContext);
+            WebSocketServerContainerInitializer.initialize(webSocketContext);
     registerWebSocketEndpoints(container);
 
     configureWebSocketPostResourceHandling(webSocketContext);

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -218,11 +218,10 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     applications.doStop();
   }
 
-  @SuppressWarnings("unchecked")
   protected final void doStart() throws Exception {
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();
-    for (Application app : applications.getApplications()) {
+    for (Application<?> app : applications.getApplications()) {
       attachMetricsListener(app.getMetrics(), app.getMetricsTags());
       addJettyThreadPoolMetrics(app.getMetrics(), app.getMetricsTags());
       handlers.addHandler(app.configureHandler());

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -377,6 +377,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     final HttpConnectionFactory httpConnectionFactory =
             new HttpConnectionFactory(httpConfiguration);
 
+    @SuppressWarnings("deprecation")
     List<URI> listeners = parseListeners(config.getList(RestConfig.LISTENERS_CONFIG),
             config.getInt(RestConfig.PORT_CONFIG), Arrays.asList("http", "https"), "http");
 

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -218,6 +218,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     applications.doStop();
   }
 
+  @SuppressWarnings("unchecked")
   protected final void doStart() throws Exception {
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -108,11 +108,11 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
               "DEPRECATION warning: `listeners` configuration is not configured. "
                       + "Falling back to the deprecated `port` configuration."
       );
-      listenersConfig = new ArrayList<String>(1);
+      listenersConfig = new ArrayList<>(1);
       listenersConfig.add(defaultScheme + "://0.0.0.0:" + deprecatedPort);
     }
 
-    List<URI> listeners = new ArrayList<URI>(listenersConfig.size());
+    List<URI> listeners = new ArrayList<>(listenersConfig.size());
     for (String listenerStr : listenersConfig) {
       URI uri;
       try {

--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -100,7 +100,8 @@ public class FileWatcher implements Runnable {
         log.debug("Watch event is OVERFLOW");
         continue;
       }
-      WatchEvent<Path> ev = (WatchEvent<Path>)event;
+      @SuppressWarnings("unchecked")
+      WatchEvent<Path> ev = (WatchEvent<Path>) event;
       Path changed = this.file.getParent().resolve(ev.context());
       log.info("Watch file change: " + ev.context() + "=>" + changed);
       // Need to use path equals than isSameFile

--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -102,8 +102,8 @@ public class FileWatcher implements Runnable {
       }
 
       if (event.context() != null && !(event.context() instanceof Path)) {
-        throw new ClassCastException("Expected `event.context()` to be an instance of `Path`, "
-            + "but it is " + event.context().getClass());
+        throw new ClassCastException("Expected `event.context()` to be an instance of " + Path.class
+            + ", but it is " + event.context().getClass());
       }
 
       Path context = (Path) event.context();

--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -100,10 +100,15 @@ public class FileWatcher implements Runnable {
         log.debug("Watch event is OVERFLOW");
         continue;
       }
-      @SuppressWarnings("unchecked")
-      WatchEvent<Path> ev = (WatchEvent<Path>) event;
-      Path changed = this.file.getParent().resolve(ev.context());
-      log.info("Watch file change: " + ev.context() + "=>" + changed);
+
+      if (event.context() != null && !(event.context() instanceof Path)) {
+        throw new ClassCastException("Expected `event.context()` to be an instance of `Path`, "
+            + "but it is " + event.context().getClass());
+      }
+
+      Path context = (Path) event.context();
+      Path changed = this.file.getParent().resolve(context);
+      log.info("Watch file change: " + context + "=>" + changed);
       // Need to use path equals than isSameFile
       if (Files.exists(changed) && changed.equals(this.file)) {
         log.debug("Watch matching file: " + file);

--- a/core/src/main/java/io/confluent/rest/MetricsListener.java
+++ b/core/src/main/java/io/confluent/rest/MetricsListener.java
@@ -22,11 +22,11 @@ import java.util.Map;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
 import org.apache.kafka.common.metrics.stats.Rate;
-import org.apache.kafka.common.metrics.stats.Total;
 import org.eclipse.jetty.io.NetworkTrafficListener;
 
-public class MetricsListener extends NetworkTrafficListener.Adapter {
+public class MetricsListener implements NetworkTrafficListener {
 
   /*
    * `NetworkTrafficListener` in Jetty 9.2 doesn't expose `accepted`
@@ -73,7 +73,7 @@ public class MetricsListener extends NetworkTrafficListener.Adapter {
         "Total number of active Jetty TCP connections",
         metricTags
     );
-    this.connections.add(metricName, new Total());
+    this.connections.add(metricName, new CumulativeSum());
   }
 
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -421,7 +421,6 @@ public class RestConfig extends AbstractConfig {
   }
 
   // CHECKSTYLE_RULES.OFF: MethodLength
-  @SuppressWarnings("deprecation")
   private static ConfigDef incompleteBaseConfigDef() {
     // CHECKSTYLE_RULES.ON: MethodLength
     return new ConfigDef()

--- a/core/src/main/java/io/confluent/rest/filters/CsrfTokenProtectionFilter.java
+++ b/core/src/main/java/io/confluent/rest/filters/CsrfTokenProtectionFilter.java
@@ -81,7 +81,7 @@ public class CsrfTokenProtectionFilter implements Filter {
   private LoadingCache<String, String> tokenSupplier;
 
   static {
-    HashSet<String> mti = new HashSet();
+    HashSet<String> mti = new HashSet<>();
     mti.add("GET");
     mti.add("OPTIONS");
     mti.add("HEAD");

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -377,6 +377,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       }
     }
 
+    @SuppressWarnings("unchecked")
     private MethodMetrics getMethodMetrics(RequestEvent event) {
       ResourceMethod method = event.getUriInfo().getMatchedResourceMethod();
       if (method == null) {

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -377,7 +377,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       }
     }
 
-    @SuppressWarnings("unchecked")
     private MethodMetrics getMethodMetrics(RequestEvent event) {
       ResourceMethod method = event.getUriInfo().getMatchedResourceMethod();
       if (method == null) {
@@ -389,10 +388,17 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
         return null;
       }
 
-      Map tags = (Map) event.getContainerRequest().getProperty(REQUEST_TAGS_PROP_KEY);
-      if (tags == null) {
+      Object tagsObj = event.getContainerRequest().getProperty(REQUEST_TAGS_PROP_KEY);
+
+      if (tagsObj == null) {
         return metrics.metrics();
       }
+      if (!(tagsObj instanceof Map<?, ?>)) {
+        throw new ClassCastException("Expected the value for property " + REQUEST_TAGS_PROP_KEY
+            + " to be a `Map`, but it is " + tagsObj.getClass());
+      }
+      @SuppressWarnings("unchecked")
+      Map<String, String> tags = (Map<String, String>) tagsObj;
 
       // we have additional tags, find the appropriate metrics holder
       return metrics.metrics(tags);

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -395,7 +395,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       }
       if (!(tagsObj instanceof Map<?, ?>)) {
         throw new ClassCastException("Expected the value for property " + REQUEST_TAGS_PROP_KEY
-            + " to be a `Map`, but it is " + tagsObj.getClass());
+            + " to be a " + Map.class + ", but it is " + tagsObj.getClass());
       }
       @SuppressWarnings("unchecked")
       Map<String, String> tags = (Map<String, String>) tagsObj;

--- a/core/src/main/java/io/confluent/rest/validation/ConstraintViolations.java
+++ b/core/src/main/java/io/confluent/rest/validation/ConstraintViolations.java
@@ -47,6 +47,6 @@ public class ConstraintViolations {
   }
 
   public static ConstraintViolationException simpleException(String msg) {
-    return new ConstraintViolationException(msg, new HashSet<ConstraintViolation<?>>());
+    return new ConstraintViolationException(msg, new HashSet<>());
   }
 }

--- a/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationGroupTest.java
@@ -31,7 +31,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 public class ApplicationGroupTest {
 
   static TestRestConfig testConfig;
-  private static ApplicationServer server;
+  private static ApplicationServer<TestRestConfig> server;
 
   @Before
   public void setup() throws Exception {
@@ -39,7 +39,7 @@ public class ApplicationGroupTest {
     props.setProperty(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
 
     testConfig = new TestRestConfig(props);
-    server = new ApplicationServer(testConfig);
+    server = new ApplicationServer<>(testConfig);
   }
 
   @After

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -96,7 +96,7 @@ public class ApplicationTest {
   @Test
   public void testParseListToMap() {
     assertEquals(
-        new HashMap(){
+        new HashMap<String, String>(){
           {
             put("k1","v1");
             put("k2","v2");

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -109,7 +109,7 @@ public class ApplicationTest {
   @Test
   public void testParseEmptyListToMap() {
     assertEquals(
-        new HashMap(),
+        new HashMap<String, String>(),
         Application.parseListToMap(new ArrayList<>())
     );
   }
@@ -117,14 +117,14 @@ public class ApplicationTest {
   @Test(expected = ConfigException.class)
   public void testParseBadListToMap() {
     assertEquals(
-        new HashMap(),
+        new HashMap<String, String>(),
         Application.parseListToMap(Arrays.asList("k1:v1:what", "k2:v2"))
     );
   }
 
   @Test
   public void testParseListenersDeprecated() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     List<URI> listeners = Application.parseListeners(listenersConfig, RestConfig.PORT_CONFIG_DEFAULT,
             Arrays.asList("http", "https"), "http");
     assertEquals("Should have only one listener.", 1, listeners.size());
@@ -133,10 +133,10 @@ public class ApplicationTest {
 
   @Test
   public void testParseListenersHttpAndHttps() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost:123");
     listenersConfig.add("https://localhost:124");
-    List<URI> listeners = application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
     assertEquals("Should have two listeners.", 2, listeners.size());
     assertExpectedUri(listeners.get(0), "http", "localhost", 123);
     assertExpectedUri(listeners.get(1), "https", "localhost", 124);
@@ -144,14 +144,14 @@ public class ApplicationTest {
 
   @Test(expected = ConfigException.class)
   public void testParseListenersUnparseableUri() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("!");
     Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
   }
 
   @Test
   public void testParseListenersUnsupportedScheme() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost:8080");
     listenersConfig.add("foo://localhost:8081");
     List<URI> listeners = Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
@@ -161,7 +161,7 @@ public class ApplicationTest {
 
   @Test(expected = ConfigException.class)
   public void testParseListenersNoSupportedListeners() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("foo://localhost:8080");
     listenersConfig.add("bar://localhost:8081");
     Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
@@ -169,7 +169,7 @@ public class ApplicationTest {
 
   @Test(expected = ConfigException.class)
   public void testParseListenersNoPort() {
-    List<String> listenersConfig = new ArrayList<String>();
+    List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost");
     Application.parseListeners(listenersConfig, -1, Arrays.asList("http", "https"), "http");
   }
@@ -262,7 +262,7 @@ public class ApplicationTest {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
 
-    Application app = new TestApp(config) {
+    Application<?> app = new TestApp(config) {
       @Override
       protected LoginService createLoginService() {
         return new JAASLoginService("realm");
@@ -276,7 +276,7 @@ public class ApplicationTest {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
 
-    Application app = new TestApp(config) {
+    Application<?> app = new TestApp(config) {
       @Override
       protected LoginAuthenticator createAuthenticator() {
         return new BasicAuthenticator();
@@ -290,7 +290,7 @@ public class ApplicationTest {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
 
-    Application app = new TestApp(config);
+    Application<?> app = new TestApp(config);
     app.createBearerSecurityHandler();
   }
 
@@ -350,7 +350,7 @@ public class ApplicationTest {
   }
 
   @Test
-  public void testMetricsContextJMXPrefixPropagation() throws Exception  {
+  public void testMetricsContextJMXPrefixPropagation() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
 

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
@@ -68,16 +69,11 @@ import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ApplicationTest {
 
   private static final String REALM = "realm";
-
-  @Rule
-  public final ExpectedException expectedException = ExpectedException.none();
 
   @Before
   public void setUp() {
@@ -306,11 +302,9 @@ public class ApplicationTest {
   }
 
   @Test
-  public void shouldThrowIfResourceExtensionThrows() throws Exception {
-    expectedException.expectMessage(
-        containsString("Exception throw by resource extension. ext:"));
-
-    new TestApp(TestRegistryExtension.class, BadRegistryExtension.class);
+  public void shouldThrowIfResourceExtensionThrows() {
+    Exception e = assertThrows(Exception.class, () -> new TestApp(TestRegistryExtension.class, BadRegistryExtension.class));
+    assertThat(e.getMessage(), containsString("Exception throw by resource extension. ext:"));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
@@ -62,7 +62,7 @@ public class CsrfHandlingTest {
 
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path("ping")
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_BY, requestedBy)
@@ -80,7 +80,7 @@ public class CsrfHandlingTest {
 
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path("ping")
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_BY, requestedBy)
@@ -100,7 +100,7 @@ public class CsrfHandlingTest {
 
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path("ping")
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_WITH, token)
@@ -119,7 +119,7 @@ public class CsrfHandlingTest {
 
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path("ping")
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_BY, requestedBy)
@@ -137,7 +137,7 @@ public class CsrfHandlingTest {
   public void testGetByPassesCheck() {
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path("ping")
             .request()
             .get();
@@ -151,7 +151,7 @@ public class CsrfHandlingTest {
   public void testCsrfTokenFetchRequest() {
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path(RestConfig.CSRF_PREVENTION_TOKEN_FETCH_ENDPOINT_DEFAULT)
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_BY, "test-session")
@@ -166,7 +166,7 @@ public class CsrfHandlingTest {
   public void testCsrfTokenFetchMissingRequester() {
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path(RestConfig.CSRF_PREVENTION_TOKEN_FETCH_ENDPOINT_DEFAULT)
             .request()
             .get();
@@ -183,7 +183,7 @@ public class CsrfHandlingTest {
   private String getToken(String requestedBy) {
     Response response =
         ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-            .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+            .target("http://localhost:" + config.getPort())
             .path(RestConfig.CSRF_PREVENTION_TOKEN_FETCH_ENDPOINT_DEFAULT)
             .request()
             .header(CsrfTokenProtectionFilter.Headers.REQUESTED_BY, requestedBy)

--- a/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
@@ -123,7 +123,7 @@ public class ExceptionHandlingTest {
 
   @Test
   public void testUnrecognizedField() {
-    Map<String, String> m = new HashMap<String, String>();
+    Map<String, String> m = new HashMap<>();
     m.put("something", "something");
     m.put("something-else", "something-else");
     testPostException(

--- a/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
@@ -65,7 +65,7 @@ public class ExceptionHandlingTest {
   private void testGetException(String path, int expectedStatus, int expectedErrorCode,
       String expectedMessage) {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path(path)
         .request()
         .get();
@@ -79,7 +79,7 @@ public class ExceptionHandlingTest {
   private void testPostException(String path, Entity entity, int expectedStatus, int expectedErrorCode,
       String expectedMessage) {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-      .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+      .target("http://localhost:" + config.getPort())
       .path(path)
       .request()
       .post(entity);

--- a/core/src/test/java/io/confluent/rest/GzipHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/GzipHandlerIntegrationTest.java
@@ -55,7 +55,7 @@ public class GzipHandlerIntegrationTest {
   @Test
   public void testGzip() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/test/zeros")
         .request(MediaType.APPLICATION_OCTET_STREAM)
         .acceptEncoding("gzip")

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -227,9 +227,8 @@ public class SaslTest {
             "Request latency metrics should be measurable",
             metricValue instanceof Double);
         double latencyMaxValue = (double) metricValue;
-        assertTrue(
-            "Metrics should be collected (max latency shouldn't be 0)",
-            latencyMaxValue != 0.0);
+        assertNotEquals("Metrics should be collected (max latency shouldn't be 0)",
+            0.0, metricValue);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -227,8 +227,10 @@ public class SaslTest {
             "Request latency metrics should be measurable",
             metricValue instanceof Double);
         double latencyMaxValue = (double) metricValue;
-        assertNotEquals("Metrics should be collected (max latency shouldn't be 0)",
-            0.0, metricValue);
+        assertNotEquals(
+            "Metrics should be collected (max latency shouldn't be 0)",
+            0.0,
+            metricValue);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/ShutdownTest.java
+++ b/core/src/test/java/io/confluent/rest/ShutdownTest.java
@@ -125,11 +125,11 @@ public class ShutdownTest {
   };
 
   private static class RequestThread extends Thread {
-    RestConfig config;
+    TestRestConfig config;
     volatile boolean finished = false;
     String response = null;
 
-    RequestThread(RestConfig config) {
+    RequestThread(TestRestConfig config) {
       this.config = config;
     }
     @Override
@@ -142,7 +142,7 @@ public class ShutdownTest {
           log.info("Starting client");
           Client client = ClientBuilder.newClient();
           response = client
-              .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+              .target("http://localhost:" + config.getPort())
               .path("/")
               .request()
               .get(String.class);

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -49,7 +49,6 @@ import java.util.Properties;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
-import javax.net.ssl.SSLHandshakeException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -117,7 +116,7 @@ public class SslTest {
   }
 
   private void enableSslClientAuth(Properties props) {
-    props.put(RestConfig.SSL_CLIENT_AUTH_CONFIG, true);
+    props.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, true);
   }
 
   private void createWrongKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
@@ -256,9 +255,8 @@ public class SslTest {
             "Request latency metrics should be measurable",
             metricValue instanceof Double);
         double latencyMaxValue = (double) metricValue;
-        assertTrue(
-            "Metrics should be collected (max latency shouldn't be 0)",
-            latencyMaxValue != 0.0);
+        assertNotEquals("Metrics should be collected (max latency shouldn't be 0)", 0.0,
+          latencyMaxValue);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -393,7 +393,7 @@ public class SslTest {
 
     @Override
     public Map<String, String> getMetricsTags() {
-      Map<String, String> tags = new LinkedHashMap<String, String>();
+      Map<String, String> tags = new LinkedHashMap<>();
       tags.put("instance-id", "1");
       return tags;
     }

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -190,11 +190,9 @@ public class SslTest {
       statusCode = makeGetRequest(httpsUri + "/test",
                                   clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
       assertEquals(EXPECTED_200_MSG, 200, statusCode); 
-      assertEquals("expect hit error with new server cert", true, hitError); 
+      assertTrue("expect hit error with new server cert", hitError);
     } finally {
-      if (app != null) {
-        app.stop();
-      }
+      app.stop();
     }
   }
 

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -116,7 +116,7 @@ public class SslTest {
   }
 
   private void enableSslClientAuth(Properties props) {
-    props.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, true);
+    props.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
   }
 
   private void createWrongKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -255,8 +255,10 @@ public class SslTest {
             "Request latency metrics should be measurable",
             metricValue instanceof Double);
         double latencyMaxValue = (double) metricValue;
-        assertNotEquals("Metrics should be collected (max latency shouldn't be 0)", 0.0,
-          latencyMaxValue);
+        assertNotEquals(
+            "Metrics should be collected (max latency shouldn't be 0)",
+            0.0,
+            latencyMaxValue);
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/StaticResourcesTest.java
+++ b/core/src/test/java/io/confluent/rest/StaticResourcesTest.java
@@ -83,7 +83,7 @@ public class StaticResourcesTest {
 
   private void testGet(String path, int expectedStatus, String expectedMessage) {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path(path)
         .request()
         .get();

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -263,7 +263,7 @@ public class TestCustomizeThreadPool {
     }
     public TestCustomizeThreadPoolApplication(Properties props) {
       super(new TestRestConfig(props));
-      this.props = props;
+      TestCustomizeThreadPoolApplication.props = props;
     }
 
     @Override

--- a/core/src/test/java/io/confluent/rest/TestCustomizedHttpResponseHeaders.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizedHttpResponseHeaders.java
@@ -184,7 +184,6 @@ public class TestCustomizedHttpResponseHeaders {
 
     private static TestRestConfig createConfig() {
       props = new Properties();
-      String uri = "http://localhost:8080";
       return new TestRestConfig(props);
     }
   }

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -25,7 +25,7 @@ import java.util.Map;
 
 public class TestMetricsReporter implements MetricsReporter {
 
-  private static List<KafkaMetric> metricTimeseries = new LinkedList<KafkaMetric>();
+  private static List<KafkaMetric> metricTimeseries = new LinkedList<>();
 
   private Map<String, ?> configs;
 

--- a/core/src/test/java/io/confluent/rest/TestRestConfig.java
+++ b/core/src/test/java/io/confluent/rest/TestRestConfig.java
@@ -47,4 +47,10 @@ public class TestRestConfig extends RestConfig {
             getString(METRICS_JMX_PREFIX_CONFIG),
             originalsWithPrefix(METRICS_CONTEXT_PREFIX)).metricsContext();
   }
+
+  @SuppressWarnings("deprecation")
+  public int getPort() {
+    return getInt(RestConfig.PORT_CONFIG);
+  }
+
 }

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -67,7 +67,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     // RequestEvent.Type.FINISHED before RequestEvent.Type.RESP_FILTERS_START
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/private/endpoint")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();
@@ -88,7 +88,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   @Test
   public void testExceptionMetrics() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/private/fake")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();
@@ -112,7 +112,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   @Test
   public void testMapped500sAreCounted() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/public/caught")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();

--- a/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
@@ -54,7 +54,7 @@ public class RequestScopedMetricsIntegrationTest {
 
     // this request should create a new metric with runtime tags
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/public/ts")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();
@@ -70,7 +70,7 @@ public class RequestScopedMetricsIntegrationTest {
 
     // this request should reuse the previously created metrics
     response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-        .target("http://localhost:" + config.getInt(RestConfig.PORT_CONFIG))
+        .target("http://localhost:" + config.getPort())
         .path("/public/ts")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();

--- a/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldApplication.java
+++ b/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldApplication.java
@@ -56,7 +56,7 @@ public class HelloWorldApplication extends Application<HelloWorldRestConfig> {
 
   @Override
   public Map<String, String> getMetricsTags() {
-    Map<String, String> tags = new LinkedHashMap<String, String>();
+    Map<String, String> tags = new LinkedHashMap<>();
     // In a real app, you might have or generate a unique ID for this instance and add other
     // tags like data center, app version, etc.
     tags.put("instance-id", "1");
@@ -74,7 +74,7 @@ public class HelloWorldApplication extends Application<HelloWorldRestConfig> {
       // the format of the message returned by the API, e.g.
       // java -jar rest-utils-examples.jar \
       //    io.confluent.rest.examples.helloworld.HelloWorldApplication 'Goodbye, %s'
-      TreeMap<String,String> settings = new TreeMap<String,String>();
+      TreeMap<String,String> settings = new TreeMap<>();
       if (args.length > 0) {
         settings.put(HelloWorldRestConfig.GREETING_CONFIG, args[0]);
       }

--- a/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldResource.java
+++ b/examples/src/main/java/io/confluent/rest/examples/helloworld/HelloWorldResource.java
@@ -18,8 +18,7 @@ package io.confluent.rest.examples.helloworld;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import org.hibernate.validator.constraints.NotEmpty;
-
+import javax.validation.constraints.NotEmpty;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;

--- a/test/src/main/java/io/confluent/rest/EmbeddedServerTestHarness.java
+++ b/test/src/main/java/io/confluent/rest/EmbeddedServerTestHarness.java
@@ -32,8 +32,8 @@ import java.util.Vector;
 
 public abstract class
     EmbeddedServerTestHarness<C extends RestConfig, T extends io.confluent.rest.Application<C>> {
-  private List<Object> resources = new Vector<Object>();
-  private List<Class<?>> resourceClasses = new Vector<Class<?>>();
+  private List<Object> resources = new Vector<>();
+  private List<Class<?>> resourceClasses = new Vector<>();
 
   protected C config;
   protected T app;

--- a/test/src/main/java/io/confluent/rest/Generics.java
+++ b/test/src/main/java/io/confluent/rest/Generics.java
@@ -49,7 +49,6 @@ public class Generics {
    * @param <T>      the type bound
    * @return the class's type parameter
    */
-  @SuppressWarnings("unchecked")
   public static <T> Class<T> getTypeParameter(Class<?> klass, Class<? super T> bound) {
     if (klass == null)
       throw new NullPointerException();


### PR DESCRIPTION
Deprecation changes:
* `Slf4jRequestLog` ->  `CustomRequestLog`
* `configureContext` -> `initialize`
* `NetworkTrafficListener.Adapter` -> `NetworkTrafficListener`
* `ExpectedException` -> `assertThrows`
* `SSL_CLIENT_AUTH_CONFIG` -> `SSL_CLIENT_AUTHENTICATION_CONFIG`
* `Total` -> `CumulativeSum`

Other warnings/clean-ups:
* Various unchecked warnings: fixed the easy ones and added suppression for the rest
* Introduce `getPort` so that we can suppress usage of deprecated config in one place
* Use `assertNotEquals` instead of `assertTrue`
* Use `assertTrue` instead of `assertEquals` when expected result is `true`
* Remove unused variable
* Don't use static field as non-static
* Use diamond operator
* Remove unnecessary null check