### PR TITLE
Upgrade Jetty to 9.4.39.v20210325

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.31</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.36.v20210114</jetty.version>
+        <jetty.version>9.4.39.v20210325</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>24.1.1-jre</guava.version>


### PR DESCRIPTION
Catch up with 5.5.x on Jetty version https://github.com/confluentinc/rest-utils/commit/2af4448a290fdca8ffc159796260c5ea3a9adc78