### PR TITLE
Bump netty-version 4.1.63

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>6.2.0-0</io.confluent.rest-utils.version>
-        <netty.version>4.1.62.Final</netty.version>
+        <netty.version>4.1.63.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
For
[cvss: 5.90 ] CVE-2021-21295 ['fixed in 4.1.60']
[cvss: 5.90 ] CVE-2021-21409 ['fixed in 4.1.61']
[cvss: 5.50 ] CVE-2021-21290 ['fixed in 4.1.59']