### PR TITLE
ST-5293: Cleanup of netty version property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>6.2.0-0</io.confluent.rest-utils.version>
-        <netty.version>4.1.63.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This netty version property is now defined in common so no need to have it defined here as well.