### PR TITLE
ST-5293: Explicit load of netty dependencies

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -130,6 +130,58 @@
             <artifactId>async-http-client</artifactId>
             <version>${asynchttpclient.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-buffer</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-http</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-codec-socks</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-resolver-dns</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns</artifactId>
+            <version>${netty.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The netty libraries are being loaded as a dependency of async-http-client, so I am excluding them from there and then explicitly loading the newer version we need to resolve the cve. I ran the tests several times to make sure they are all resolved. I also checked the dependency tree to make sure all netty libraries are on the same version.

[INFO] io.confluent:rest-utils-package:pom:6.2.0-0
[INFO] \- io.confluent:rest-utils:jar:6.2.0-0:compile
[INFO]    +- io.netty:netty-buffer:jar:4.1.63.Final:compile
[INFO]    |  \- io.netty:netty-common:jar:4.1.63.Final:compile
[INFO]    +- io.netty:netty-codec-http:jar:4.1.63.Final:compile
[INFO]    |  +- io.netty:netty-transport:jar:4.1.63.Final:compile
[INFO]    |  +- io.netty:netty-codec:jar:4.1.63.Final:compile
[INFO]    |  \- io.netty:netty-handler:jar:4.1.63.Final:compile
[INFO]    +- io.netty:netty-codec-socks:jar:4.1.63.Final:compile
[INFO]    +- io.netty:netty-transport-native-epoll:jar:4.1.63.Final:compile
[INFO]    |  \- io.netty:netty-transport-native-unix-common:jar:4.1.63.Final:compile
[INFO]    \- io.netty:netty-resolver-dns:jar:4.1.63.Final:compile
[INFO]       +- io.netty:netty-resolver:jar:4.1.63.Final:compile
[INFO]       \- io.netty:netty-codec-dns:jar:4.1.63.Final:compile
