### PR TITLE
bump guava version to 30.1.1-jre

### DIFF
--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -226,8 +226,8 @@ public class SslTest {
       try {
         makeGetRequest(uri + "/test",
                 untrustedClient.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-      } catch (SSLHandshakeException she) { // handle a transient failure.
-        throw new SocketException(she.getMessage());
+      } catch (SSLException e) { // handle exception from different JDK versions
+        throw new SocketException(e.getMessage());
       }
     } finally {
       app.stop();

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <jersey.version>2.27</jersey.version>
         <jetty.version>9.4.14.v20181114</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
-        <guava.version>24.1.1-jre</guava.version>
+        <guava.version>30.1.1-jre</guava.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
Jira ticket: https://confluentinc.atlassian.net/browse/MMA-10473

For
[cvss: 5.90 ] [CVE-2018-10237](https://github.com/advisories/GHSA-mvr2-9pj6-7w5j) ['fixed in 24.1.1']
[cvss: 3.30 ] [CVE-2020-8908](https://github.com/advisories/GHSA-5mg8-w23w-74h3) ['fixed in 30.0']