### PR TITLE
KREST-1031 Upgrade Jetty and Jersey to address a number of CVEs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -50,6 +50,17 @@
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hibernate.validator</groupId>
+                    <artifactId>hibernate-validator</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate.validator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -141,7 +141,7 @@ public class CustomInitTest {
 
     WebSocket ws = Dsl.asyncHttpClient()
         .prepareGet(WS_URI + "/test")
-        .setRequestTimeout(5000)
+        .setRequestTimeout(10000)
         .execute(wsHandler)
         .get();
 

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -163,14 +163,14 @@ public class SaslTest {
   @Test
   public void testBadLoginAttempt() throws Exception {
     try (CloseableHttpResponse response =
-        makeGetRequest("/test", "this shouldnt work")) {
+        makeGetRequest("/test", "dGVzdA==")) {
       assertEquals(UNAUTHORIZED.getStatusCode(), response.getStatusLine().getStatusCode());
     }
   }
 
   @Test
   public void testBadLoginAttemptOnWs() throws Exception {
-    int statusCode = makeWsGetRequest("this shouldnt work");
+    int statusCode = makeWsGetRequest("dGVzdA==");
     assertEquals(UNAUTHORIZED.getStatusCode(), statusCode);
   }
 
@@ -272,7 +272,7 @@ public class SaslTest {
     }
 
     WebSocket ws = requestBuilder
-        .setRequestTimeout(5000)
+        .setRequestTimeout(10000)
         .execute(wsHandler)
         .get();
 

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.confluent.rest.metrics;
 
+import javax.servlet.ServletException;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
@@ -107,7 +108,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
             Request baseRequest,
             HttpServletRequest request,
             HttpServletResponse response
-        ) throws IOException {
+        ) throws IOException, ServletException {
           handledException = (Throwable) request.getAttribute(RequestDispatcher.ERROR_EXCEPTION);
           super.handle(target, baseRequest, request, response);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,9 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.27</jersey.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jersey.version>2.34</jersey.version>
+        <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
+        <jetty.version>9.4.40.v20210413</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <guava.version>30.1.1-jre</guava.version>
     </properties>
@@ -95,6 +96,17 @@
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
                 <version>${jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hibernate.validator</groupId>
+                        <artifactId>hibernate-validator</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.hibernate.validator</groupId>
+                <artifactId>hibernate-validator</artifactId>
+                <version>${hibernate.validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>


### PR DESCRIPTION
See #252 - this merges the changes from there to `5.3.x`, fixing the conflicts along the way. It should then be merged up with `-s ours`, as #246 and #249 have already introduced these changes in `5.4.x` and up.
- If #252 is merged with "Rebase and merge", we should be able to push the changes from here without further rebasing.