### PR TITLE
ST-5057: security patch release support for archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ ifndef VERSION
 VERSION=$(shell grep version pom.xml | head -n 1 | awk -F'>|<' '{ print $$3 }')
 endif
 
+ifndef SECURITY_SUFFIX
+SECURITY_SUFFIX=
+endif
+
 export PACKAGE_TITLE=rest-utils
 export FULL_PACKAGE_TITLE=confluent-rest-utils
 export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)$(SECURITY_SUFFIX)

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 
 export PACKAGE_TITLE=rest-utils
 export FULL_PACKAGE_TITLE=confluent-rest-utils
-export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)
+export PACKAGE_NAME=$(FULL_PACKAGE_TITLE)-$(VERSION)$(SECURITY_SUFFIX)
 
 # Defaults that are likely to vary by platform. These are cleanly separated so
 # it should be easy to maintain altered values on platform-specific branches

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -23,11 +23,8 @@ mkdir -p ${DESTDIR}${BINPATH}
 mkdir -p ${DESTDIR}${LIBPATH}
 mkdir -p ${DESTDIR}${SYSCONFDIR}
 
-if [[ -n ${SECURITY_PATCH} ]]; then
-PREPACKAGED="package/target/rest-utils-package-${VERSION}-${SECURITY_PATCH}-package"
-else
-PREPACKAGED="package/target/rest-utils-package-${VERSION}-package"
-fi
+
+PREPACKAGED="package/target/rest-utils-package-${VERSION}${SECURITY_SUFFIX}-package"
 pushd ${PREPACKAGED}
 find . -type f | grep -v README[.]rpm | xargs -I XXX ${INSTALL} -o root -g root XXX ${DESTDIR}${PREFIX}/XXX
 popd

--- a/create_archive.sh
+++ b/create_archive.sh
@@ -23,7 +23,11 @@ mkdir -p ${DESTDIR}${BINPATH}
 mkdir -p ${DESTDIR}${LIBPATH}
 mkdir -p ${DESTDIR}${SYSCONFDIR}
 
+if [[ -n ${SECURITY_PATCH} ]]; then
+PREPACKAGED="package/target/rest-utils-package-${VERSION}-${SECURITY_PATCH}-package"
+else
 PREPACKAGED="package/target/rest-utils-package-${VERSION}-package"
+fi
 pushd ${PREPACKAGED}
 find . -type f | grep -v README[.]rpm | xargs -I XXX ${INSTALL} -o root -g root XXX ${DESTDIR}${PREFIX}/XXX
 popd


### PR DESCRIPTION
# what
Support new security patch release pattern.

# how
Add new security suffix for packaging name.