### PR TITLE
KREST-661: Add support for HTTP/2 on Java 11 and later

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -61,6 +61,19 @@
             <artifactId>jetty-server</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-java-server</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
         </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -127,6 +127,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-client</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.http2</groupId>
+            <artifactId>http2-http-client-transport</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_${kafka.scala.version}</artifactId>
             <classifier>test</classifier>

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -72,7 +72,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   private static final Logger log = LoggerFactory.getLogger(ApplicationServer.class);
 
-  private static boolean isJava11Compatible() {
+  // Package-visible for tests
+  static boolean isJava11Compatible() {
     final String versionString = System.getProperty("java.specification.version");
   
     final StringTokenizer st = new StringTokenizer(versionString, ".");
@@ -405,7 +406,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   private void addConnectorForListener(HttpConfiguration httpConfiguration,
                                        HttpConnectionFactory httpConnectionFactory,
-                                       URI listener, boolean http2Enabled) {
+                                       URI listener,
+                                       boolean http2Enabled) {
     NetworkTrafficServerConnector connector;
 
     // Default to supporting HTTP/2 for Java 11 and later

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -393,7 +393,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     final HttpConnectionFactory httpConnectionFactory =
             new HttpConnectionFactory(httpConfiguration);
 
-    final boolean http2Enabled = config.getBoolean(RestConfig.HTTP2_ENABLED_CONFIG);
+    // Default to supporting HTTP/2 for Java 11 and later
+    final boolean http2Enabled = isJava11Compatible() && config.getBoolean(RestConfig.HTTP2_ENABLED_CONFIG);
 
     @SuppressWarnings("deprecation")
     List<URI> listeners = parseListeners(config.getList(RestConfig.LISTENERS_CONFIG),
@@ -410,8 +411,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
                                        boolean http2Enabled) {
     NetworkTrafficServerConnector connector;
 
-    // Default to supporting HTTP/2 for Java 11 and later
-    if (http2Enabled && isJava11Compatible()) {
+    if (http2Enabled) {
       log.info("Adding listener with HTTP/2: " + listener.toString());
       if (listener.getScheme().equals("http")) {
         // HTTP2C is HTTP/2 Clear text

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -77,12 +77,6 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   
     final StringTokenizer st = new StringTokenizer(versionString, ".");
     int majorVersion = Integer.parseInt(st.nextToken());
-    int minorVersion;
-    if (st.hasMoreTokens()) {
-      minorVersion = Integer.parseInt(st.nextToken());
-    } else {
-      minorVersion = 0;
-    }
   
     return majorVersion >= 11;
   }

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -421,6 +421,13 @@ public class RestConfig extends AbstractConfig {
           + "Default is false.";
   private static final boolean DOS_FILTER_MANAGED_ATTR_DEFAULT = false;
 
+  public static final String HTTP2_ENABLED_CONFIG = "http2.enabled";
+  protected static final String HTTP2_ENABLED_DOC =
+      "If true, enable HTTP/2 connections. Connections will default to HTTP/2 not HTTP/1.1 "
+          + "for clients that support it. Only takes effect if the server is running on a "
+          + "Java 11 JVM or later. Default is true.";
+  protected static final boolean HTTP2_ENABLED_DEFAULT = true;
+
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
         PORT_CONFIG_DEFAULT,
@@ -877,6 +884,12 @@ public class RestConfig extends AbstractConfig {
             DOS_FILTER_MANAGED_ATTR_DEFAULT,
             Importance.LOW,
             DOS_FILTER_MANAGED_ATTR_DOC
+        ).define(
+            HTTP2_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            HTTP2_ENABLED_DEFAULT,
+            Importance.LOW,
+            HTTP2_ENABLED_DOC
         );
   }
 

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -1,0 +1,390 @@
+/**
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.rest;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.test.TestSslUtils;
+import org.apache.kafka.test.TestSslUtils.CertificateBuilder;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.ssl.SslContextFactory.Client;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.net.SocketException;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.StringTokenizer;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Configurable;
+
+import org.apache.kafka.common.metrics.KafkaMetric;
+import io.confluent.rest.annotations.PerformanceMetric;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test is a bit unusual because of the way that multiple Java versions are handled.
+ * Essentially, the HTTP/2 support is only properly viable in Java 9 and later. Actually,
+ * Java 11 is the first LTS version after that. Because we do not want to have a variable
+ * set of dependencies based on which version of Java was used to build and package,
+ * this test is packaged to exploit HTTP/2 on Java 11 and then conditionally avoid that
+ * code on earlier versions of Java. This is the client equivalent of how the HTTP/2
+ * support works in the server.
+ **/
+public class Http2Test {
+  private static final Logger log = LoggerFactory.getLogger(Http2Test.class);
+
+  private File trustStore;
+  private File clientKeystore;
+  private File serverKeystore;
+  private File serverKeystoreBak;
+  private File serverKeystoreErr;
+
+  public static final String SSL_PASSWORD = "test1234";
+  public static final String EXPECTED_200_MSG = "Response status must be 200.";
+  public static final int CERT_RELOAD_WAIT_TIME = 20000;
+
+  private static boolean isJava11Compatible() {
+    final String versionString = System.getProperty("java.specification.version");
+  
+    final StringTokenizer st = new StringTokenizer(versionString, ".");
+    int majorVersion = Integer.parseInt(st.nextToken());
+    int minorVersion;
+    if (st.hasMoreTokens()) {
+      minorVersion = Integer.parseInt(st.nextToken());
+    } else {
+      minorVersion = 0;
+    }
+  
+    return majorVersion >= 11;
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    try {
+      trustStore = File.createTempFile("Http2Test-truststore", ".jks");
+      clientKeystore = File.createTempFile("Http2Test-client-keystore", ".jks");
+      serverKeystore = File.createTempFile("Http2Test-server-keystore", ".jks");
+      serverKeystoreBak = File.createTempFile("Http2Test-server-keystore", ".jks.bak");
+      serverKeystoreErr = File.createTempFile("Http2Test-server-keystore", ".jks.err");
+    } catch (IOException ioe) {
+      throw new RuntimeException("Unable to create temporary files for trust stores and keystores.");
+    }
+    Map<String, X509Certificate> certs = new HashMap<>();
+    createKeystoreWithCert(clientKeystore, "client", certs);
+    createKeystoreWithCert(serverKeystore, "server", certs);
+    TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(SSL_PASSWORD), certs);
+
+    Files.copy(serverKeystore.toPath(), serverKeystoreBak.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    certs = new HashMap<>();
+    createWrongKeystoreWithCert(serverKeystoreErr, "server", certs);
+  }
+
+  private void createKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
+    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
+    CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
+    X509Certificate cCert = certificateBuilder.sanDnsNames("localhost")
+        .generate("CN=mymachine.local, O=A client", keypair);
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD),alias, keypair.getPrivate(), cCert);
+    certs.put(alias, cCert);
+  }
+
+  private void configServerKeystore(Properties props) {
+    props.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, serverKeystore.getAbsolutePath());
+    props.put(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
+    props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, SSL_PASSWORD);
+  }
+
+  private void configServerTruststore(Properties props) {
+    props.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore.getAbsolutePath());
+    props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
+  }
+
+  private void enableSslClientAuth(Properties props) {
+    props.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+  }
+
+  private void createWrongKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
+    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
+    CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
+    X509Certificate cCert = certificateBuilder.sanDnsNames("fail")
+        .generate("CN=mymachine.local, O=A client", keypair);
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    certs.put(alias, cCert);
+  }
+
+
+  @Test
+  public void testHttp2() throws Exception {
+    TestMetricsReporter.reset();
+    Properties props = new Properties();
+    String httpUri = "http://localhost:8080";
+    String httpsUri = "https://localhost:8081";
+    props.put(RestConfig.LISTENERS_CONFIG, httpUri + "," + httpsUri);
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    configServerKeystore(props);
+    TestRestConfig config = new TestRestConfig(props);
+    Http2TestApplication app = new Http2TestApplication(config);
+    try {
+      app.start();
+
+      int statusCode;
+
+      // Just skip HTTP/2 for earlier than Java 11
+      if (isJava11Compatible()) {
+        statusCode = makeGetRequestHttp2(httpUri + "/test");
+        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        statusCode = makeGetRequestHttp2(httpsUri + "/test",
+                                         clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
+        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      }
+
+      // HTTP/1.1 should work whether HTTP/2 is available or not
+      statusCode = makeGetRequestHttp(httpUri + "/test");
+      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      statusCode = makeGetRequestHttp(httpsUri + "/test",
+                                      clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
+      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      assertMetricsCollected();
+    } finally {
+      app.stop();
+    }
+  }
+
+  @Test
+  public void testHttp2CNotEnabled() throws Exception {
+    TestMetricsReporter.reset();
+    Properties props = new Properties();
+    String httpUri = "http://localhost:8080";
+    props.put(RestConfig.LISTENERS_CONFIG, httpUri);
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
+    configServerKeystore(props);
+    TestRestConfig config = new TestRestConfig(props);
+    Http2TestApplication app = new Http2TestApplication(config);
+    try {
+      app.start();
+
+      int statusCode;
+      try {
+        statusCode = makeGetRequestHttp2(httpUri + "/test");
+        fail("HTTP/2 Cleartext should not be enabled");
+      } catch (java.util.concurrent.ExecutionException exc) {
+        // Fall back to HTTP/1.1 once we've seen HTTP/2C fail
+        assertTrue(exc.getCause() instanceof java.net.ConnectException);
+        statusCode = makeGetRequestHttp(httpUri + "/test");
+        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      }
+      assertMetricsCollected();
+    } finally {
+      app.stop();
+    }
+  }
+
+  @Test
+  public void testHttp2NotEnabled() throws Exception {
+    TestMetricsReporter.reset();
+    Properties props = new Properties();
+    String httpsUri = "https://localhost:8081";
+    props.put(RestConfig.LISTENERS_CONFIG, httpsUri);
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
+    configServerKeystore(props);
+    TestRestConfig config = new TestRestConfig(props);
+    Http2TestApplication app = new Http2TestApplication(config);
+    try {
+      app.start();
+
+      int statusCode;
+      try {
+        statusCode = makeGetRequestHttp2(httpsUri + "/test",
+                                         clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
+        fail("HTTP/2 Cleartext should not be enabled");
+      } catch (java.util.concurrent.ExecutionException exc) {
+        // Fall back to HTTP/1.1 once we've seen HTTP/2 fail
+        assertTrue(exc.getCause() instanceof java.net.ConnectException);
+        statusCode = makeGetRequestHttp(httpsUri + "/test",
+                                        clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
+        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      }
+      assertMetricsCollected();
+    } finally {
+      app.stop();
+    }
+  }
+
+  private void assertMetricsCollected() {
+    assertNotEquals(
+        "Expected to have metrics.",
+        0,
+        TestMetricsReporter.getMetricTimeseries().size());
+    for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
+      if (metric.metricName().name().equals("request-latency-max")) {
+        Object metricValue = metric.metricValue();
+        assertTrue(
+            "Request latency metrics should be measurable",
+            metricValue instanceof Double);
+        double latencyMaxValue = (double) metricValue;
+        assertNotEquals(
+            "Metrics should be collected (max latency shouldn't be 0)",
+            0.0,
+            latencyMaxValue);
+      }
+    }
+  }
+
+  // returns the http response status code.
+  private int makeGetRequestHttp(String url) throws Exception {
+    log.debug("Making GET using HTTP " + url);
+    HttpClient httpClient = new HttpClient();
+    httpClient.start();
+
+    int statusCode = httpClient.GET(url).getStatus();
+    httpClient.stop();
+    return statusCode;
+  }
+
+  // returns the http response status code.
+  private int makeGetRequestHttp(String url, String clientKeystoreLocation, String clientKeystorePassword,
+                                String clientKeyPassword)
+      throws Exception {
+    log.debug("Making GET using HTTPS " + url);
+    SslContextFactory sslContextFactory = new SslContextFactory.Client();
+    // trust all self-signed certs.
+    SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+            .loadTrustMaterial(new TrustSelfSignedStrategy());
+
+    // add the client keystore if it's configured.
+    if (clientKeystoreLocation != null) {
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystoreLocation),
+              clientKeystorePassword.toCharArray(),
+              clientKeyPassword.toCharArray());
+    }
+    SSLContext sslContext = sslContextBuilder.build();
+    sslContextFactory.setSslContext(sslContext);
+
+    HttpClient httpClient = new HttpClient(sslContextFactory);
+    httpClient.start();
+
+    int statusCode = httpClient.GET(url).getStatus();
+    httpClient.stop();
+    return statusCode;
+  }
+
+  // returns the http response status code.
+  private int makeGetRequestHttp2(String url) throws Exception {
+    log.debug("Making GET using HTTP over HTTP/2 Cleartext " + url);
+    HTTP2Client http2Client = new HTTP2Client();
+    HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client));
+    httpClient.start();
+
+    int statusCode = httpClient.GET(url).getStatus();
+    httpClient.stop();
+    return statusCode;
+  }
+
+  // returns the http response status code.
+  private int makeGetRequestHttp2(String url, String clientKeystoreLocation, String clientKeystorePassword,
+                                  String clientKeyPassword)
+      throws Exception {
+    log.debug("Making GET using HTTP/2 " + url);
+    HTTP2Client http2Client = new HTTP2Client();
+
+    SslContextFactory sslContextFactory = new SslContextFactory.Client();
+    // trust all self-signed certs.
+    SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+            .loadTrustMaterial(new TrustSelfSignedStrategy());
+
+    // add the client keystore if it's configured.
+    if (clientKeystoreLocation != null) {
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystoreLocation),
+              clientKeystorePassword.toCharArray(),
+              clientKeyPassword.toCharArray());
+    }
+    SSLContext sslContext = sslContextBuilder.build();
+    sslContextFactory.setSslContext(sslContext);
+
+    HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), sslContextFactory);
+    httpClient.start();
+
+    int statusCode = httpClient.GET(url).getStatus();
+    httpClient.stop();
+    return statusCode;
+  }
+
+  private static class Http2TestApplication extends Application<TestRestConfig> {
+    public Http2TestApplication(TestRestConfig props) {
+      super(props);
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, TestRestConfig appConfig) {
+      config.register(new Http2TestResource());
+    }
+
+    @Override
+    public Map<String, String> getMetricsTags() {
+      Map<String, String> tags = new LinkedHashMap<>();
+      tags.put("instance-id", "1");
+      return tags;
+    }
+  }
+
+  @Path("/test")
+  @Produces("application/test.v1+json")
+  public static class Http2TestResource {
+    public static class Http2TestResponse {
+      @JsonProperty
+      public String getMessage() {
+        return "foo";
+      }
+    }
+
+    @GET
+    @PerformanceMetric("test")
+    public Http2TestResponse hello() {
+      return new Http2TestResponse();
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -212,7 +212,6 @@ public class Http2Test {
         fail("HTTP/2 Cleartext should not be enabled");
       } catch (java.util.concurrent.ExecutionException exc) {
         // Fall back to HTTP/1.1 once we've seen HTTP/2C fail
-        assertTrue(exc.getCause() instanceof java.net.ConnectException);
         statusCode = makeGetRequestHttp(httpUri + "/test");
         assertEquals(EXPECTED_200_MSG, 200, statusCode);
       }
@@ -243,7 +242,6 @@ public class Http2Test {
         fail("HTTP/2 Cleartext should not be enabled");
       } catch (java.util.concurrent.ExecutionException exc) {
         // Fall back to HTTP/1.1 once we've seen HTTP/2 fail
-        assertTrue(exc.getCause() instanceof java.net.ConnectException);
         statusCode = makeGetRequestHttp(httpsUri + "/test",
                                         clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
         assertEquals(EXPECTED_200_MSG, 200, statusCode);

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -116,23 +116,11 @@ public class Http2Test {
     props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, SSL_PASSWORD);
   }
 
-  private TestRestConfig buildTestConfig(boolean httpListener,
-                                         boolean httpsListener,
-                                        boolean disableHttp2) {
+  private TestRestConfig buildTestConfig(boolean enableHttp2) {
     Properties props = new Properties();
-    if (httpListener) {
-      if (httpsListener) {
-        props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI + "," + HTTPS_URI);
-      } else {
-        props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI);
-      }
-    }
-    else {
-      assertTrue(httpsListener);
-      props.put(RestConfig.LISTENERS_CONFIG, HTTPS_URI);
-    }
+    props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI + "," + HTTPS_URI);
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
-    if (disableHttp2) {
+    if (!enableHttp2) {
       props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
     }
     configServerKeystore(props);
@@ -141,7 +129,7 @@ public class Http2Test {
 
   @Test
   public void testHttp2() throws Exception {
-    TestRestConfig config = buildTestConfig(true, true, false);
+    TestRestConfig config = buildTestConfig(true);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();
@@ -171,7 +159,7 @@ public class Http2Test {
 
   @Test
   public void testHttp2CNotEnabled() throws Exception {
-    TestRestConfig config = buildTestConfig(true, false, true);
+    TestRestConfig config = buildTestConfig(false);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();
@@ -193,7 +181,7 @@ public class Http2Test {
 
   @Test
   public void testHttp2NotEnabled() throws Exception {
-    TestRestConfig config = buildTestConfig(false, true, true);
+    TestRestConfig config = buildTestConfig(false);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -78,27 +78,11 @@ public class Http2Test {
   private File trustStore;
   private File clientKeystore;
   private File serverKeystore;
-  private File serverKeystoreBak;
-  private File serverKeystoreErr;
 
-  public static final String SSL_PASSWORD = "test1234";
-  public static final String EXPECTED_200_MSG = "Response status must be 200.";
-  public static final int CERT_RELOAD_WAIT_TIME = 20000;
-
-  private static boolean isJava11Compatible() {
-    final String versionString = System.getProperty("java.specification.version");
-  
-    final StringTokenizer st = new StringTokenizer(versionString, ".");
-    int majorVersion = Integer.parseInt(st.nextToken());
-    int minorVersion;
-    if (st.hasMoreTokens()) {
-      minorVersion = Integer.parseInt(st.nextToken());
-    } else {
-      minorVersion = 0;
-    }
-  
-    return majorVersion >= 11;
-  }
+  private static final String HTTP_URI = "http://localhost:8080";
+  private static final String HTTPS_URI = "https://localhost:8081";
+  private static final String SSL_PASSWORD = "test1234";
+  private static final String EXPECTED_200_MSG = "Response status must be 200.";
 
   @Before
   public void setUp() throws Exception {
@@ -106,8 +90,6 @@ public class Http2Test {
       trustStore = File.createTempFile("Http2Test-truststore", ".jks");
       clientKeystore = File.createTempFile("Http2Test-client-keystore", ".jks");
       serverKeystore = File.createTempFile("Http2Test-server-keystore", ".jks");
-      serverKeystoreBak = File.createTempFile("Http2Test-server-keystore", ".jks.bak");
-      serverKeystoreErr = File.createTempFile("Http2Test-server-keystore", ".jks.err");
     } catch (IOException ioe) {
       throw new RuntimeException("Unable to create temporary files for trust stores and keystores.");
     }
@@ -116,9 +98,7 @@ public class Http2Test {
     createKeystoreWithCert(serverKeystore, "server", certs);
     TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(SSL_PASSWORD), certs);
 
-    Files.copy(serverKeystore.toPath(), serverKeystoreBak.toPath(), StandardCopyOption.REPLACE_EXISTING);
-    certs = new HashMap<>();
-    createWrongKeystoreWithCert(serverKeystoreErr, "server", certs);
+    TestMetricsReporter.reset();
   }
 
   private void createKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
@@ -136,35 +116,32 @@ public class Http2Test {
     props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, SSL_PASSWORD);
   }
 
-  private void configServerTruststore(Properties props) {
-    props.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore.getAbsolutePath());
-    props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
+  private TestRestConfig buildTestConfig(boolean httpListener,
+                                         boolean httpsListener,
+                                        boolean disableHttp2) {
+    Properties props = new Properties();
+    if (httpListener) {
+      if (httpsListener) {
+        props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI + "," + HTTPS_URI);
+      } else {
+        props.put(RestConfig.LISTENERS_CONFIG, HTTP_URI);
+      }
+    }
+    else {
+      assertTrue(httpsListener);
+      props.put(RestConfig.LISTENERS_CONFIG, HTTPS_URI);
+    }
+    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+    if (disableHttp2) {
+      props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
+    }
+    configServerKeystore(props);
+    return new TestRestConfig(props);
   }
-
-  private void enableSslClientAuth(Properties props) {
-    props.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
-  }
-
-  private void createWrongKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
-    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
-    CertificateBuilder certificateBuilder = new CertificateBuilder(30, "SHA1withRSA");
-    X509Certificate cCert = certificateBuilder.sanDnsNames("fail")
-        .generate("CN=mymachine.local, O=A client", keypair);
-    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD), new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
-    certs.put(alias, cCert);
-  }
-
 
   @Test
   public void testHttp2() throws Exception {
-    TestMetricsReporter.reset();
-    Properties props = new Properties();
-    String httpUri = "http://localhost:8080";
-    String httpsUri = "https://localhost:8081";
-    props.put(RestConfig.LISTENERS_CONFIG, httpUri + "," + httpsUri);
-    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
-    configServerKeystore(props);
-    TestRestConfig config = new TestRestConfig(props);
+    TestRestConfig config = buildTestConfig(true, true, false);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();
@@ -172,18 +149,18 @@ public class Http2Test {
       int statusCode;
 
       // Just skip HTTP/2 for earlier than Java 11
-      if (isJava11Compatible()) {
-        statusCode = makeGetRequestHttp2(httpUri + "/test");
+      if (ApplicationServer.isJava11Compatible()) {
+        statusCode = makeGetRequestHttp2(HTTP_URI + "/test");
         assertEquals(EXPECTED_200_MSG, 200, statusCode);
-        statusCode = makeGetRequestHttp2(httpsUri + "/test",
+        statusCode = makeGetRequestHttp2(HTTPS_URI + "/test",
                                          clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
         assertEquals(EXPECTED_200_MSG, 200, statusCode);
       }
 
       // HTTP/1.1 should work whether HTTP/2 is available or not
-      statusCode = makeGetRequestHttp(httpUri + "/test");
+      statusCode = makeGetRequestHttp(HTTP_URI + "/test");
       assertEquals(EXPECTED_200_MSG, 200, statusCode);
-      statusCode = makeGetRequestHttp(httpsUri + "/test",
+      statusCode = makeGetRequestHttp(HTTPS_URI + "/test",
                                       clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
       assertEquals(EXPECTED_200_MSG, 200, statusCode);
       assertMetricsCollected();
@@ -194,25 +171,18 @@ public class Http2Test {
 
   @Test
   public void testHttp2CNotEnabled() throws Exception {
-    TestMetricsReporter.reset();
-    Properties props = new Properties();
-    String httpUri = "http://localhost:8080";
-    props.put(RestConfig.LISTENERS_CONFIG, httpUri);
-    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
-    props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
-    configServerKeystore(props);
-    TestRestConfig config = new TestRestConfig(props);
+    TestRestConfig config = buildTestConfig(true, false, true);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();
 
       int statusCode;
       try {
-        statusCode = makeGetRequestHttp2(httpUri + "/test");
+        statusCode = makeGetRequestHttp2(HTTP_URI + "/test");
         fail("HTTP/2 Cleartext should not be enabled");
       } catch (java.util.concurrent.ExecutionException exc) {
         // Fall back to HTTP/1.1 once we've seen HTTP/2C fail
-        statusCode = makeGetRequestHttp(httpUri + "/test");
+        statusCode = makeGetRequestHttp(HTTP_URI + "/test");
         assertEquals(EXPECTED_200_MSG, 200, statusCode);
       }
       assertMetricsCollected();
@@ -223,26 +193,19 @@ public class Http2Test {
 
   @Test
   public void testHttp2NotEnabled() throws Exception {
-    TestMetricsReporter.reset();
-    Properties props = new Properties();
-    String httpsUri = "https://localhost:8081";
-    props.put(RestConfig.LISTENERS_CONFIG, httpsUri);
-    props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
-    props.put(RestConfig.HTTP2_ENABLED_CONFIG, false);
-    configServerKeystore(props);
-    TestRestConfig config = new TestRestConfig(props);
+    TestRestConfig config = buildTestConfig(false, true, true);
     Http2TestApplication app = new Http2TestApplication(config);
     try {
       app.start();
 
       int statusCode;
       try {
-        statusCode = makeGetRequestHttp2(httpsUri + "/test",
+        statusCode = makeGetRequestHttp2(HTTPS_URI + "/test",
                                          clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
         fail("HTTP/2 Cleartext should not be enabled");
       } catch (java.util.concurrent.ExecutionException exc) {
         // Fall back to HTTP/1.1 once we've seen HTTP/2 fail
-        statusCode = makeGetRequestHttp(httpsUri + "/test",
+        statusCode = makeGetRequestHttp(HTTPS_URI + "/test",
                                         clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
         assertEquals(EXPECTED_200_MSG, 200, statusCode);
       }
@@ -272,6 +235,24 @@ public class Http2Test {
     }
   }
 
+  private SslContextFactory buildSslContextFactory(String clientKeystoreLocation, String clientKeystorePassword,
+                                                   String clientKeyPassword) {
+    SslContextFactory sslContextFactory = new SslContextFactory.Client();
+    // trust all self-signed certs.
+    SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+            .loadTrustMaterial(new TrustSelfSignedStrategy());
+
+    // add the client keystore if it's configured.
+    if (clientKeystoreLocation != null) {
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystoreLocation),
+              clientKeystorePassword.toCharArray(),
+              clientKeyPassword.toCharArray());
+    }
+    SSLContext sslContext = sslContextBuilder.build();
+    sslContextFactory.setSslContext(sslContext);
+    return sslContextFactory;
+  }
+
   // returns the http response status code.
   private int makeGetRequestHttp(String url) throws Exception {
     log.debug("Making GET using HTTP " + url);
@@ -288,21 +269,7 @@ public class Http2Test {
                                 String clientKeyPassword)
       throws Exception {
     log.debug("Making GET using HTTPS " + url);
-    SslContextFactory sslContextFactory = new SslContextFactory.Client();
-    // trust all self-signed certs.
-    SSLContextBuilder sslContextBuilder = SSLContexts.custom()
-            .loadTrustMaterial(new TrustSelfSignedStrategy());
-
-    // add the client keystore if it's configured.
-    if (clientKeystoreLocation != null) {
-      sslContextBuilder.loadKeyMaterial(new File(clientKeystoreLocation),
-              clientKeystorePassword.toCharArray(),
-              clientKeyPassword.toCharArray());
-    }
-    SSLContext sslContext = sslContextBuilder.build();
-    sslContextFactory.setSslContext(sslContext);
-
-    HttpClient httpClient = new HttpClient(sslContextFactory);
+    HttpClient httpClient = new HttpClient(buildSslContextFactory());
     httpClient.start();
 
     int statusCode = httpClient.GET(url).getStatus();
@@ -328,22 +295,7 @@ public class Http2Test {
       throws Exception {
     log.debug("Making GET using HTTP/2 " + url);
     HTTP2Client http2Client = new HTTP2Client();
-
-    SslContextFactory sslContextFactory = new SslContextFactory.Client();
-    // trust all self-signed certs.
-    SSLContextBuilder sslContextBuilder = SSLContexts.custom()
-            .loadTrustMaterial(new TrustSelfSignedStrategy());
-
-    // add the client keystore if it's configured.
-    if (clientKeystoreLocation != null) {
-      sslContextBuilder.loadKeyMaterial(new File(clientKeystoreLocation),
-              clientKeystorePassword.toCharArray(),
-              clientKeyPassword.toCharArray());
-    }
-    SSLContext sslContext = sslContextBuilder.build();
-    sslContextFactory.setSslContext(sslContext);
-
-    HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), sslContextFactory);
+    HttpClient httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client), buildSslContextFactory());
     httpClient.start();
 
     int statusCode = httpClient.GET(url).getStatus();

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,21 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-java-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlet</artifactId>
                 <version>${jetty.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,6 +199,16 @@
                 <artifactId>httpclient</artifactId>
                 <version>${apache.httpclient.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.http2</groupId>
+                <artifactId>http2-http-client-transport</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
             <!--test-->
             <dependency>
                 <groupId>org.glassfish.jersey.test-framework</groupId>


### PR DESCRIPTION
Added support for HTTP/2 on Java 11 and later. Because HTTP/2 and ALPN are newer than Java 8, adding support for Java 8 as well is not practical. So, the behaviour is:

* If java 11 compatible
  * if (http)
    * configure HTTP and HTTP/2 Clear text connection factories
  * else (https)
    * configure SSL, ALPN, HTTP/2 and HTTP connection factories
* else as before

This means that when the code is running on a Java 11 JVM or later, connections will default to HTTP/2 not HTTP/1.1 if the client can support it. This change in behaviour is appropriate for the major version bump to CP 7.0 but not CP 6.x.

PR is marked as WIP because investigating the best way to introduce the dependency on the `jetty-alpn-java-server` package into the repos that depend on rest-utils.