### PR TITLE
KREST-1346: Add option to apply rate-limit globally across all connections.

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -397,16 +397,17 @@ public class RestConfig extends AbstractConfig {
       "If true, insert the DoSFilter headers into the response. Defaults to true.";
   private static final boolean DOS_FILTER_INSERT_HEADERS_DEFAULT = true;
 
-  private static final String DOS_FILTER_TRACK_SESSIONS_CONFIG = "dos.filter.track.sessions";
-  private static final String DOS_FILTER_TRACK_SESSIONS_DOC =
-      "If true, usage rate is tracked by session if a session exists. Defaults to true.";
-  private static final boolean DOS_FILTER_TRACK_SESSIONS_DEFAULT = true;
-
   private static final String DOS_FILTER_REMOTE_PORT_CONFIG = "dos.filter.remote.port";
   private static final String DOS_FILTER_REMOTE_PORT_DOC =
-      "If true and session tracking is not used, then rate is tracked by IP and port (effectively "
-          + "connection). Defaults to false.";
+      "If true, then rate is tracked by IP and port (effectively per connection). Defaults to "
+          + "false.";
   private static final boolean DOS_FILTER_REMOTE_PORT_DEFAULT = false;
+
+  private static final String DOS_FILTER_TRACK_GLOBAL_CONFIG = "dos.filter.track.global";
+  private static final String DOS_FILTER_TRACK_GLOBAL_DOC =
+      "If true and remote port tracking is not used, then rate is tracked globally for all "
+          + "connections. Defaults to false.";
+  private static final boolean DOS_FILTER_TRACK_GLOBAL_DEFAULT = false;
 
   private static final String DOS_FILTER_IP_WHITELIST_CONFIG = "dos.filter.ip.whitelist";
   private static final String DOS_FILTER_IP_WHITELIST_DOC =
@@ -861,17 +862,17 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_INSERT_HEADERS_DOC
         ).define(
-            DOS_FILTER_TRACK_SESSIONS_CONFIG,
-            Type.BOOLEAN,
-            DOS_FILTER_TRACK_SESSIONS_DEFAULT,
-            Importance.LOW,
-            DOS_FILTER_TRACK_SESSIONS_DOC
-        ).define(
             DOS_FILTER_REMOTE_PORT_CONFIG,
             Type.BOOLEAN,
             DOS_FILTER_REMOTE_PORT_DEFAULT,
             Importance.LOW,
             DOS_FILTER_REMOTE_PORT_DOC
+        ).define(
+            DOS_FILTER_TRACK_GLOBAL_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_TRACK_GLOBAL_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_TRACK_GLOBAL_DOC
         ).define(
             DOS_FILTER_IP_WHITELIST_CONFIG,
             Type.LIST,
@@ -1000,12 +1001,12 @@ public class RestConfig extends AbstractConfig {
     return getBoolean(DOS_FILTER_INSERT_HEADERS_CONFIG);
   }
 
-  public final boolean getDosFilterTrackSessions() {
-    return getBoolean(DOS_FILTER_TRACK_SESSIONS_CONFIG);
-  }
-
   public final boolean getDosFilterRemotePort() {
     return getBoolean(DOS_FILTER_REMOTE_PORT_CONFIG);
+  }
+
+  public final boolean getDosFilterTrackGlobal() {
+    return getBoolean(DOS_FILTER_TRACK_GLOBAL_CONFIG);
   }
 
   public final List<String> getDosFilterIpWhitelist() {

--- a/core/src/test/java/io/confluent/rest/DosFilterTest.java
+++ b/core/src/test/java/io/confluent/rest/DosFilterTest.java
@@ -27,6 +27,13 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.eclipse.jetty.server.Server;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -36,7 +43,7 @@ import org.junit.runners.JUnit4;
 public class DosFilterTest {
 
   @Test
-  public void dosFilterEnabled_throttlesRequests() throws Exception {
+  public void dosFilterEnabled_defaultTracking_throttlesRequestsPerIp() throws Exception {
     FooApplication application =
         new FooApplication(
             new FooConfig(
@@ -48,23 +55,142 @@ public class DosFilterTest {
     Server server = application.createServer();
     server.start();
 
-    Client client = ClientBuilder.newClient();
+    HttpGet request =
+        new HttpGet(UriBuilder.fromUri(server.getURI()).path("/foo").build());
+
+    CloseableHttpClient ephemeralClient =
+        HttpClients.custom()
+            .setConnectionManager(new BasicHttpClientConnectionManager())
+            .setKeepAliveStrategy((httpResponse, httpContext) -> -1)
+            .build();
 
     // Request should succeed.
-    Response response1 = client.target(server.getURI()).path("/foo").request().get();
-    assertEquals(Status.OK.getStatusCode(), response1.getStatus());
+    CloseableHttpResponse response1 = ephemeralClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
+    response1.close();
 
     // Following requests should all be throttled.
     for (int i = 0; i < 100; i++) {
-      Response response2 = client.target(server.getURI()).path("/foo").request().get();
-      assertEquals(Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatus());
+      CloseableHttpResponse response2 = ephemeralClient.execute(request);
+      assertEquals(
+          Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatusLine().getStatusCode());
+      response2.close();
     }
 
     Thread.sleep(1000);
 
     // Request should succeed again.
-    Response response3 = client.target(server.getURI()).path("/foo").request().get();
-    assertEquals(Status.OK.getStatusCode(), response3.getStatus());
+    CloseableHttpResponse response3 = ephemeralClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response3.getStatusLine().getStatusCode());
+    response3.close();
+
+    server.stop();
+  }
+
+  @Test
+  public void dosFilterEnabled_remotePort_throttlesRequestsPerConnection() throws Exception {
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.<String, String>builder()
+                    .put("listeners", "http://localhost:0")
+                    .put("dos.filter.enabled", "true")
+                    .put("dos.filter.max.requests.per.sec", "1")
+                    .put("dos.filter.delay.ms", "-1")
+                    .put("dos.filter.remote.port", "true")
+                    .build()));
+    Server server = application.createServer();
+    server.start();
+
+    HttpGet request =
+        new HttpGet(UriBuilder.fromUri(server.getURI()).path("/foo").build());
+
+    // Following requests should not be throttled, since they use different connections.
+    CloseableHttpClient ephemeralClient =
+        HttpClients.custom()
+            .setConnectionManager(new BasicHttpClientConnectionManager())
+            .setKeepAliveStrategy((httpResponse, httpContext) -> -1)
+            .build();
+    for (int i = 0; i < 100; i++) {
+      CloseableHttpResponse response = ephemeralClient.execute(request);
+      assertEquals(Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
+      response.close();
+    }
+
+    CloseableHttpClient persistentClient =
+        HttpClients.custom()
+            .setConnectionManager(new PoolingHttpClientConnectionManager())
+            .setKeepAliveStrategy((httpResponse, httpContext) -> 5000)
+            .build();
+
+    // Request should succeed.
+    CloseableHttpResponse response1 = persistentClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
+    response1.getEntity().getContent().close();
+    response1.close();
+
+    // Following requests should all be throttled since they all reuse the same connection.
+    for (int i = 0; i < 100; i++) {
+      CloseableHttpResponse response2 = persistentClient.execute(request);
+      assertEquals(
+          Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatusLine().getStatusCode());
+      response2.getEntity().getContent().close();
+      response2.close();
+    }
+
+    Thread.sleep(1000);
+
+    // Request on the same connection should succeed again.
+    CloseableHttpResponse response3 = persistentClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response3.getStatusLine().getStatusCode());
+  }
+
+  @Test
+  public void dosFilterEnabled_trackGlobal_throttlesRequestsGlobally() throws Exception {
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.<String, String>builder()
+                    .put("listeners", "http://localhost:0")
+                    .put("dos.filter.enabled", "true")
+                    .put("dos.filter.max.requests.per.sec", "1")
+                    .put("dos.filter.delay.ms", "-1")
+                    .put("dos.filter.track.global", "true")
+                    .build()));
+    Server server = application.createServer();
+    server.start();
+
+    HttpGet request =
+        new HttpGet(UriBuilder.fromUri(server.getURI()).path("/foo").build());
+
+    // There's no way for us to actually check throttling is happening across different IPs. We
+    // check here it behaves at least per-IP.
+
+    CloseableHttpClient ephemeralClient =
+        HttpClients.custom()
+            .setConnectionManager(new BasicHttpClientConnectionManager())
+            .setKeepAliveStrategy((httpResponse, httpContext) -> -1)
+            .build();
+
+    // Request should succeed.
+    CloseableHttpResponse response1 = ephemeralClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
+    response1.close();
+
+    // Following requests should all be throttled.
+    for (int i = 0; i < 100; i++) {
+      CloseableHttpResponse response2 = ephemeralClient.execute(request);
+      assertEquals(
+          Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatusLine().getStatusCode());
+      response2.close();
+    }
+
+    Thread.sleep(1000);
+
+    // Request should succeed again.
+    CloseableHttpResponse response3 = ephemeralClient.execute(request);
+    assertEquals(Status.OK.getStatusCode(), response3.getStatusLine().getStatusCode());
+    response3.close();
 
     server.stop();
   }


### PR DESCRIPTION
Also removes dos.filter.track.session option, since Kafka REST does not use sessions, so that option has no effect.