### PR TITLE
KREST-1403: Set RFC7230 mode for connections

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -22,6 +22,7 @@ import org.apache.kafka.common.metrics.Metrics;
 
 import org.apache.kafka.common.config.ConfigException;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
@@ -436,6 +437,16 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
                 sslConnectionFactory, alpnConnectionFactory, h2ConnectionFactory,
                 httpConnectionFactory);
       }
+
+      // In Jetty 9.4.37, there was a change in behaviour to implement RFC 7230 more
+      // rigorously and remove support for ambiguous URIs, such as escaping
+      // . and / characters. While this is a good idea because it prevents clever
+      // path-manipulation tricks in URIs, it breaks certain existing systems including
+      // the Schema Registry. Jetty behaviour was then reverted specifying the compliance mode
+      // in the HttpConnectionFactory class using the HttpCompliance.RFC7230 enum. This has
+      // the problem that it applies onto to HTTP/1.1. The following sets this compliance mode
+      // explicitly when HTTP/2 is enabled.
+      connector.addBean(HttpCompliance.RFC7230);
     } else {
       log.info("Adding listener: " + listener.toString());
       if (listener.getScheme().equals("http")) {

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -444,7 +444,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
       // path-manipulation tricks in URIs, it breaks certain existing systems including
       // the Schema Registry. Jetty behaviour was then reverted specifying the compliance mode
       // in the HttpConnectionFactory class using the HttpCompliance.RFC7230 enum. This has
-      // the problem that it applies onto to HTTP/1.1. The following sets this compliance mode
+      // the problem that it applies only to HTTP/1.1. The following sets this compliance mode
       // explicitly when HTTP/2 is enabled.
       connector.addBean(HttpCompliance.RFC7230);
     } else {


### PR DESCRIPTION
There is a difference in URI handled between HTTP/1.1 and HTTP/2 in Jetty 9.4. Essentially, this is related to security and preventing malicious HTTP clients from using clever URIs containing / and .. from discovering information they have no right to obtain. So, Jetty 9.4 changed its behaviour to prevent use of these characters in URIs which then caused compatibility problems.

As a result, Jetty changed again so that HTTP/1.1 connections by default use a legacy HTTP compliance mode, implemented as a parameter to a constructor. HTTP/2 connections are not constructed in the same way and do not benefit from the same mechanism.

Nowadays rest-utils supports both HTTP/1.1 and HTTP/2. Any client that can support HTTP/2 gets that in preference to HTTP/1.1. Schema Registry users sometimes use URI-encoded / characters in subject names, and this breaks with HTTP/2 so far.

The resolution to the issue is to use the same HTTP compliance mode for HTTP/2 as is already used for HTTP/1.1.

This problem was originally reported as https://confluentinc.atlassian.net/browse/ESCALATION-5329.