### PR TITLE
fix checkstyle violations with newer checkstyle versions

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -215,7 +215,9 @@ public abstract class Application<T extends RestConfig> {
   /**
    * add any servlet filters that should be called before resource handling
    */
-  protected void configurePreResourceHandling(ServletContextHandler context) {}
+  protected void configurePreResourceHandling(ServletContextHandler context) {
+
+  }
 
   /**
    * expose SslContextFactory
@@ -228,13 +230,17 @@ public abstract class Application<T extends RestConfig> {
    * add any servlet filters that should be called after resource
    * handling but before falling back to the default servlet
    */
-  protected void configurePostResourceHandling(ServletContextHandler context) {}
+  protected void configurePostResourceHandling(ServletContextHandler context) {
+
+  }
 
   /**
    * add any servlet filters that should be called after resource
    * handling but before falling back to the default servlet
    */
-  protected void configureWebSocketPostResourceHandling(ServletContextHandler context) {}
+  protected void configureWebSocketPostResourceHandling(ServletContextHandler context) {
+
+  }
 
   /**
    * Returns a map of tag names to tag values to apply to metrics for this application.
@@ -477,7 +483,9 @@ public abstract class Application<T extends RestConfig> {
    * Used to register any websocket endpoints that will live under the path configured via
    * {@link io.confluent.rest.RestConfig#WEBSOCKET_PATH_PREFIX_CONFIG}
    */
-  protected void registerWebSocketEndpoints(ServerContainer container) { }
+  protected void registerWebSocketEndpoints(ServerContainer container) {
+
+  }
 
   static boolean enableBasicAuth(String authMethod) {
     return RestConfig.AUTHENTICATION_METHOD_BASIC.equals(authMethod);
@@ -727,7 +735,9 @@ public abstract class Application<T extends RestConfig> {
    * stopped accepting new connections, and tried to gracefully finish existing requests. At this
    * point it should be safe to clean up any resources used while processing requests.
    */
-  public void onShutdown() {}
+  public void onShutdown() {
+
+  }
 
   /**
    * A rate-limiter that applies a single limit to the entire server.

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/MetricsListener.java
+++ b/core/src/main/java/io/confluent/rest/MetricsListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/RestConfigException.java
+++ b/core/src/main/java/io/confluent/rest/RestConfigException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/annotations/PerformanceMetric.java
+++ b/core/src/main/java/io/confluent/rest/annotations/PerformanceMetric.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.annotations;
 

--- a/core/src/main/java/io/confluent/rest/entities/ErrorMessage.java
+++ b/core/src/main/java/io/confluent/rest/entities/ErrorMessage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/ConstraintViolationExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/ConstraintViolationExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/RestConstraintViolationException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestConstraintViolationException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.exceptions;
 

--- a/core/src/main/java/io/confluent/rest/exceptions/RestException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.exceptions;
 

--- a/core/src/main/java/io/confluent/rest/exceptions/RestNotAuthorizedException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestNotAuthorizedException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.exceptions;
 

--- a/core/src/main/java/io/confluent/rest/exceptions/RestNotFoundException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestNotFoundException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.exceptions;
 

--- a/core/src/main/java/io/confluent/rest/exceptions/RestServerErrorException.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/RestServerErrorException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/exceptions/WebApplicationExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/WebApplicationExceptionMapper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/filters/CsrfTokenProtectionFilter.java
+++ b/core/src/main/java/io/confluent/rest/filters/CsrfTokenProtectionFilter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -173,7 +173,9 @@ public class CsrfTokenProtectionFilter implements Filter {
   }
 
   @Override
-  public void destroy() {}
+  public void destroy() {
+
+  }
 
   @VisibleForTesting
   String getCsrfTokenEndpoint() {

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest.metrics;
 

--- a/core/src/main/java/io/confluent/rest/validation/ConstraintViolations.java
+++ b/core/src/main/java/io/confluent/rest/validation/ConstraintViolations.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/main/java/io/confluent/rest/validation/JacksonMessageBodyProvider.java
+++ b/core/src/main/java/io/confluent/rest/validation/JacksonMessageBodyProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2021 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/SaslTest.java
+++ b/core/src/test/java/io/confluent/rest/SaslTest.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/ShutdownTest.java
+++ b/core/src/test/java/io/confluent/rest/ShutdownTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2014 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/TestCustomizedHttpResponseHeaders.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizedHttpResponseHeaders.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/TestRestConfig.java
+++ b/core/src/test/java/io/confluent/rest/TestRestConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 

--- a/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2015 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.rest;
 


### PR DESCRIPTION
* fixes checkstyle violations for JavadocParagraph in license header
* fixes RightCurlyAlone issues for empty methods

see https://github.com/confluentinc/common/pull/364