### PR TITLE
Allow disabling OPTIONS on REST proxy

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -452,6 +452,13 @@ public abstract class Application<T extends RestConfig> {
       context.setSecurityHandler(createBasicSecurityHandler());
     } else if (enableBearerAuth(authMethod)) {
       context.setSecurityHandler(createBearerSecurityHandler());
+    } else {
+      AuthUtil.createDisableOptionsConstraint(config)
+          .ifPresent(optionsConstraint -> {
+            ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
+            securityHandler.addConstraintMapping(optionsConstraint);
+            context.setSecurityHandler(securityHandler);
+          });
     }
   }
 
@@ -550,7 +557,9 @@ public abstract class Application<T extends RestConfig> {
     securityHandler.setIdentityService(createIdentityService());
     securityHandler.setRealmName(realm);
     AuthUtil.createUnsecuredConstraints(config)
-            .forEach(securityHandler::addConstraintMapping);
+        .forEach(securityHandler::addConstraintMapping);
+    AuthUtil.createDisableOptionsConstraint(config)
+        .ifPresent(securityHandler::addConstraintMapping);
 
     return securityHandler;
   }

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -97,6 +97,12 @@ public class RestConfig extends AbstractConfig {
           "Whether to skip authentication for OPTIONS requests";
   protected static final boolean ACCESS_CONTROL_SKIP_OPTIONS_DEFAULT = true;
 
+  public static final String REJECT_OPTIONS_REQUEST = "reject.options.request";
+  protected static final String REJECT_OPTIONS_REQUEST_DOC =
+      "Whether to reject OPTIONS requests";
+  protected static final boolean REJECT_OPTIONS_REQUEST_DEFAULT = false;
+
+
   public static final String ACCESS_CONTROL_ALLOW_METHODS = "access.control.allow.methods";
   protected static final String ACCESS_CONTROL_ALLOW_METHODS_DOC =
       "Set value to Jetty Access-Control-Allow-Origin header for specified methods";
@@ -557,6 +563,13 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             ACCESS_CONTROL_SKIP_OPTIONS_DOC
         ).define(
+            REJECT_OPTIONS_REQUEST,
+            Type.BOOLEAN,
+            REJECT_OPTIONS_REQUEST_DEFAULT,
+            Importance.LOW,
+            REJECT_OPTIONS_REQUEST_DOC
+        )
+        .define(
             REQUEST_LOGGER_NAME_CONFIG,
             Type.STRING,
             REQUEST_LOGGER_NAME_DEFAULT,

--- a/core/src/main/java/io/confluent/rest/auth/AuthUtil.java
+++ b/core/src/main/java/io/confluent/rest/auth/AuthUtil.java
@@ -181,6 +181,6 @@ public final class AuthUtil {
       return Optional.of(forbidMapping);
 
     }
-    return Optional.ofNullable(null);
+    return Optional.empty();
   }
 }

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -66,10 +66,12 @@ import org.eclipse.jetty.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.security.LoginService;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import scala.App;
 
 public class ApplicationTest {
 
@@ -225,6 +227,45 @@ public class ApplicationTest {
     assertThat(mappings.get(2).getPathSpec(), is("/path/2"));
     assertThat(mappings.get(2).getConstraint().getAuthenticate(), is(false));
   }
+
+  @Test
+  public void testConstraintsWhenOptionsRequestNotAllowedAndSecurityOn() {
+    final Map<String, Object> config = ImmutableMap.of(
+        RestConfig.REJECT_OPTIONS_REQUEST, true);
+
+    ConstraintSecurityHandler securityHandler = new TestApp(config).createBasicSecurityHandler();
+
+    final List<ConstraintMapping> mappings = securityHandler.getConstraintMappings();
+    assertThat(mappings.size(), is(2));
+    assertThat(mappings.get(0).getPathSpec(), is("/*"));
+    assertThat(mappings.get(0).getMethodOmissions(), is(new String[]{"OPTIONS"}));
+    assertThat(mappings.get(1).getPathSpec(), is("/*"));
+    assertThat(mappings.get(1).getConstraint().getAuthenticate(), is(true));
+    assertThat(mappings.get(1).getConstraint().isAnyRole(), is(false));
+    assertThat(mappings.get(1).getMethod(), is("OPTIONS"));
+
+  }
+
+  @Test
+  public void testConstraintsWhenOptionsRequestNotAllowedAndSecurityOff() {
+    final Map<String, Object> config = ImmutableMap.of(
+        RestConfig.REJECT_OPTIONS_REQUEST, true);
+
+    Application<TestRestConfig> app = new TestApp(config);
+    ServletContextHandler context = new ServletContextHandler();
+    app.configureSecurityHandler(context);
+
+    ConstraintSecurityHandler securityHandler = (ConstraintSecurityHandler) context.getSecurityHandler();
+
+    final List<ConstraintMapping> mappings = securityHandler.getConstraintMappings();
+    assertThat(mappings.size(), is(1));
+    assertThat(mappings.get(0).getPathSpec(), is("/*"));
+    assertThat(mappings.get(0).getConstraint().getAuthenticate(), is(true));
+    assertThat(mappings.get(0).getConstraint().isAnyRole(), is(false));
+    assertThat(mappings.get(0).getMethod(), is("OPTIONS"));
+
+  }
+
 
   @Test(expected = UnsupportedOperationException.class)
   public void testBearerNoAuthenticator() {

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -71,7 +71,6 @@ import org.eclipse.jetty.util.security.Constraint;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import scala.App;
 
 public class ApplicationTest {
 


### PR DESCRIPTION
Using the sample application

REJECT_OPTIONS_REQUEST set to default (false)
% curl http://localhost:8080/hello -X OPTIONS
HEAD, GET, OPTIONS%                                                                                                                                                                           

REJECT_OPTIONS_REQUEST set to true
% curl http://localhost:8080/hello -X OPTIONS
% 

Tested with both no auth and basic auth enabled, as the code path is slightly different between the two.