### PR TITLE
Fix request logger to print request time in milliseconds

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -131,7 +131,9 @@ public abstract class Application<T extends RestConfig> {
 
     Slf4jRequestLogWriter logWriter = new Slf4jRequestLogWriter();
     logWriter.setLoggerName(config.getString(RestConfig.REQUEST_LOGGER_NAME_CONFIG));
-    requestLog = new CustomRequestLog(logWriter, CustomRequestLog.EXTENDED_NCSA_FORMAT + " %msT");
+
+    // %{ms}T logs request time in milliseconds
+    requestLog = new CustomRequestLog(logWriter, CustomRequestLog.EXTENDED_NCSA_FORMAT + " %{ms}T");
   }
 
   public final String getPath() {


### PR DESCRIPTION
manually verified
request log changes from `GETsT` to a number that looks like request time


```
from
GET /test/endpoint HTTP/1.1" 200 21 "-" "curl/7.64.1" GETsT (io.confluent.rest-utils.requests:62)
to
GET /test/endpoint HTTP/1.1" 200 21 "-" "curl/7.64.1" 2 (io.confluent.rest-utils.requests:62)
```

I think `%{ms}T` is probably what was meant.   Request time in milliseconds.
* https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/CustomRequestLog.html

```
%{UNIT}T	The time taken to serve the request, in a time unit given by UNIT. Valid units are ms for milliseconds, us for microseconds, and s for seconds. Using s gives the same result as %T without any format; using us gives the same result as %D.
```