### PR TITLE
KREST-578: Add configurable DosFilter support. (#238)

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.servlets.CrossOriginFilter;
+import org.eclipse.jetty.servlets.DoSFilter;
 import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
@@ -280,6 +281,8 @@ public abstract class Application<T extends RestConfig> {
 
       context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
     }
+
+    configureDosFilter(context);
 
     configurePreResourceHandling(context);
     context.addFilter(servletHolder, "/*", null);
@@ -534,6 +537,38 @@ public abstract class Application<T extends RestConfig> {
     config.register(ConstraintViolationExceptionMapper.class);
     config.register(new WebApplicationExceptionMapper(restConfig));
     config.register(new GenericExceptionMapper(restConfig));
+  }
+
+  private void configureDosFilter(ServletContextHandler context) {
+    if (!config.isDosFilterEnabled()) {
+      return;
+    }
+    FilterHolder filterHolder = new FilterHolder(new DoSFilter());
+    filterHolder.setInitParameter(
+        "maxRequestsPerSec", String.valueOf(config.getDosFilterMaxRequestsPerSec()));
+    filterHolder.setInitParameter(
+        "delayMs", String.valueOf(config.getDosFilterDelayMs().toMillis()));
+    filterHolder.setInitParameter(
+        "maxWaitMs", String.valueOf(config.getDosFilterMaxWaitMs().toMillis()));
+    filterHolder.setInitParameter(
+        "throttledRequests", String.valueOf(config.getDosFilterThrottledRequests()));
+    filterHolder.setInitParameter(
+        "throttleMs", String.valueOf(config.getDosFilterThrottleMs().toMillis()));
+    filterHolder.setInitParameter(
+        "maxRequestMs", String.valueOf(config.getDosFilterMaxRequestMs().toMillis()));
+    filterHolder.setInitParameter(
+        "maxIdleTrackerMs", String.valueOf(config.getDosFilterMaxIdleTrackerMs().toMillis()));
+    filterHolder.setInitParameter(
+        "insertHeaders", String.valueOf(config.getDosFilterInsertHeaders()));
+    filterHolder.setInitParameter(
+        "trackSessions", String.valueOf(config.getDosFilterTrackSessions()));
+    filterHolder.setInitParameter(
+        "remotePort", String.valueOf(config.getDosFilterRemotePort()));
+    filterHolder.setInitParameter(
+        "ipWhitelist", String.valueOf(config.getDosFilterIpWhitelist()));
+    filterHolder.setInitParameter(
+        "managedAttr", String.valueOf(config.getDosFilterManagedAttr()));
+    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
 
   public T getConfiguration() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -22,13 +22,16 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
-
 import io.confluent.rest.extension.ResourceExtension;
+
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+
+import static java.util.Collections.emptyList;
 
 public class RestConfig extends AbstractConfig {
   public static final String DEBUG_CONFIG = "debug";
@@ -328,6 +331,81 @@ public class RestConfig extends AbstractConfig {
   protected static final String CSRF_PREVENTION_TOKEN_MAX_ENTRIES_DOC =
       "Specifies the maximum number of entries the token cache may contain";
 
+  private static final String DOS_FILTER_ENABLED_CONFIG = "dos.filter.enabled";
+  private static final String DOS_FILTER_ENABLED_DOC =
+      "Whether to enable DosFilter for the application. Default is false.";
+  private static final boolean DOS_FILTER_ENABLED_DEFAULT = false;
+
+  private static final String DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG =
+      "dos.filter.max.requests.per.sec";
+  private static final String DOS_FILTER_MAX_REQUESTS_PER_SEC_DOC =
+      "Maximum number of requests from a connection per second. Requests in excess of this are "
+          + "first delayed, then throttled. Default is 25.";
+  private static final int DOS_FILTER_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
+
+  private static final String DOS_FILTER_DELAY_MS_CONFIG = "dos.filter.delay.ms";
+  private static final String DOS_FILTER_DELAY_MS_DOC =
+      "Delay imposed on all requests over the rate limit, before they are considered at all: 100 "
+          + "(ms) = Default, -1 = Reject request, 0 = No delay, any other value = Delay in ms";
+  private static final Duration DOS_FILTER_DELAY_MS_DEFAULT = Duration.ofMillis(100);
+
+  private static final String DOS_FILTER_MAX_WAIT_MS_CONFIG = "dos.filter.max.wait.ms";
+  private static final String DOS_FILTER_MAX_WAIT_MS_DOC =
+      "Length of time, in ms, to blocking wait for the throttle semaphore. Default is 50 ms.";
+  private static final Duration DOS_FILTER_MAX_WAIT_MS_DEFAULT = Duration.ofMillis(50);
+
+  private static final String DOS_FILTER_THROTTLED_REQUESTS_CONFIG =
+      "dos.filter.throttled.requests";
+  private static final String DOS_FILTER_THROTTLED_REQUESTS_DOC =
+      "Number of requests over the rate limit able to be considered at once. Default is 5.";
+  private static final int DOS_FILTER_THROTTLED_REQUESTS_DEFAULT = 5;
+
+  private static final String DOS_FILTER_THROTTLE_MS_CONFIG = "dos.filter.throttle.ms";
+  private static final String DOS_FILTER_THROTTLE_MS_DOC =
+      "Length of time, in ms, to async wait for semaphore. Default is 30000L.";
+  private static final Duration DOS_FILTER_THROTTLE_MS_DEFAULT = Duration.ofSeconds(30);
+
+  private static final String DOS_FILTER_MAX_REQUEST_MS_CONFIG = "dos.filter.max.requests.ms";
+  private static final String DOS_FILTER_MAX_REQUEST_MS_DOC =
+      "Length of time, in ms, to allow the request to run. Default is 30000L.";
+  private static final Duration DOS_FILTER_MAX_REQUEST_MS_DEFAULT = Duration.ofSeconds(30);
+
+  private static final String DOS_FILTER_MAX_IDLE_TRACKER_MS_CONFIG =
+      "dos.filter.max.idle.tracker.ms";
+  private static final String DOS_FILTER_MAX_IDLE_TRACKER_MS_DOC =
+      "Length of time, in ms, to keep track of request rates for a connection, before deciding "
+          + "that the user has gone away, and discarding it. Default is 30000L.";
+  private static final Duration DOS_FILTER_MAX_IDLE_TRACKER_MS_DEFAULT = Duration.ofSeconds(30);
+
+  private static final String DOS_FILTER_INSERT_HEADERS_CONFIG = "dos.filter.insert.headers";
+  private static final String DOS_FILTER_INSERT_HEADERS_DOC =
+      "If true, insert the DoSFilter headers into the response. Defaults to true.";
+  private static final boolean DOS_FILTER_INSERT_HEADERS_DEFAULT = true;
+
+  private static final String DOS_FILTER_TRACK_SESSIONS_CONFIG = "dos.filter.track.sessions";
+  private static final String DOS_FILTER_TRACK_SESSIONS_DOC =
+      "If true, usage rate is tracked by session if a session exists. Defaults to true.";
+  private static final boolean DOS_FILTER_TRACK_SESSIONS_DEFAULT = true;
+
+  private static final String DOS_FILTER_REMOTE_PORT_CONFIG = "dos.filter.remote.port";
+  private static final String DOS_FILTER_REMOTE_PORT_DOC =
+      "If true and session tracking is not used, then rate is tracked by IP and port (effectively "
+          + "connection). Defaults to false.";
+  private static final boolean DOS_FILTER_REMOTE_PORT_DEFAULT = false;
+
+  private static final String DOS_FILTER_IP_WHITELIST_CONFIG = "dos.filter.ip.whitelist";
+  private static final String DOS_FILTER_IP_WHITELIST_DOC =
+      "A comma-separated list of IP addresses that will not be rate limited.";
+  private static final List<String> DOS_FILTER_IP_WHITELIST_DEFAULT = emptyList();
+
+  private static final String DOS_FILTER_MANAGED_ATTR_CONFIG = "dos.filter.managed.attr";
+  private static final String DOS_FILTER_MANAGED_ATTR_DOC =
+      "If set to true, then this servlet is set as a ServletContext attribute with the filter "
+          + "name as the attribute name. This allows a context external mechanism (for example, "
+          + "JMX via ContextHandler.MANAGED_ATTRIBUTES) to manage the configuration of the filter."
+          + "Default is false.";
+  private static final boolean DOS_FILTER_MANAGED_ATTR_DEFAULT = false;
+
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
         PORT_CONFIG_DEFAULT,
@@ -626,19 +704,19 @@ public class RestConfig extends AbstractConfig {
         ).define(
             RESOURCE_EXTENSION_CLASSES_CONFIG,
             Type.LIST,
-            Collections.emptyList(),
+            emptyList(),
             Importance.LOW,
             RESOURCE_EXTENSION_CLASSES_DOC
         ).define(
             REST_SERVLET_INITIALIZERS_CLASSES_CONFIG,
             Type.LIST,
-            Collections.emptyList(),
+            emptyList(),
             Importance.LOW,
             REST_SERVLET_INITIALIZERS_CLASSES_DOC
         ).define(
             WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG,
             Type.LIST,
-            Collections.emptyList(),
+            emptyList(),
             Importance.LOW,
             WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_DOC
         ).define(
@@ -701,6 +779,84 @@ public class RestConfig extends AbstractConfig {
             CSRF_PREVENTION_TOKEN_MAX_ENTRIES_DEFAULT,
             Importance.LOW,
             CSRF_PREVENTION_TOKEN_MAX_ENTRIES_DOC
+        ).define(
+            DOS_FILTER_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_ENABLED_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_ENABLED_DOC
+        ).define(
+            DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG,
+            Type.INT,
+            DOS_FILTER_MAX_REQUESTS_PER_SEC_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_MAX_REQUESTS_PER_SEC_DOC
+        ).define(
+            DOS_FILTER_DELAY_MS_CONFIG,
+            Type.LONG,
+            DOS_FILTER_DELAY_MS_DEFAULT.toMillis(),
+            Importance.LOW,
+            DOS_FILTER_DELAY_MS_DOC
+        ).define(
+            DOS_FILTER_MAX_WAIT_MS_CONFIG,
+            Type.LONG,
+            DOS_FILTER_MAX_WAIT_MS_DEFAULT.toMillis(),
+            Importance.LOW,
+            DOS_FILTER_MAX_WAIT_MS_DOC
+        ).define(
+            DOS_FILTER_THROTTLED_REQUESTS_CONFIG,
+            Type.INT,
+            DOS_FILTER_THROTTLED_REQUESTS_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_THROTTLED_REQUESTS_DOC
+        ).define(
+            DOS_FILTER_THROTTLE_MS_CONFIG,
+            Type.LONG,
+            DOS_FILTER_THROTTLE_MS_DEFAULT.toMillis(),
+            Importance.LOW,
+            DOS_FILTER_THROTTLE_MS_DOC
+        ).define(
+            DOS_FILTER_MAX_REQUEST_MS_CONFIG,
+            Type.LONG,
+            DOS_FILTER_MAX_REQUEST_MS_DEFAULT.toMillis(),
+            Importance.LOW,
+            DOS_FILTER_MAX_REQUEST_MS_DOC
+        ).define(
+            DOS_FILTER_MAX_IDLE_TRACKER_MS_CONFIG,
+            Type.LONG,
+            DOS_FILTER_MAX_IDLE_TRACKER_MS_DEFAULT.toMillis(),
+            Importance.LOW,
+            DOS_FILTER_MAX_IDLE_TRACKER_MS_DOC
+        ).define(
+            DOS_FILTER_INSERT_HEADERS_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_INSERT_HEADERS_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_INSERT_HEADERS_DOC
+        ).define(
+            DOS_FILTER_TRACK_SESSIONS_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_TRACK_SESSIONS_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_TRACK_SESSIONS_DOC
+        ).define(
+            DOS_FILTER_REMOTE_PORT_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_REMOTE_PORT_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_REMOTE_PORT_DOC
+        ).define(
+            DOS_FILTER_IP_WHITELIST_CONFIG,
+            Type.LIST,
+            DOS_FILTER_IP_WHITELIST_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_IP_WHITELIST_DOC
+        ).define(
+            DOS_FILTER_MANAGED_ATTR_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_MANAGED_ATTR_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_MANAGED_ATTR_DOC
         );
   }
 
@@ -716,5 +872,57 @@ public class RestConfig extends AbstractConfig {
 
   public Time getTime() {
     return defaultTime;
+  }
+
+  public final boolean isDosFilterEnabled() {
+    return getBoolean(DOS_FILTER_ENABLED_CONFIG);
+  }
+
+  public final int getDosFilterMaxRequestsPerSec() {
+    return getInt(DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG);
+  }
+
+  public final Duration getDosFilterDelayMs() {
+    return Duration.ofMillis(getLong(DOS_FILTER_DELAY_MS_CONFIG));
+  }
+
+  public final Duration getDosFilterMaxWaitMs() {
+    return Duration.ofMillis(getLong(DOS_FILTER_MAX_WAIT_MS_CONFIG));
+  }
+
+  public final int getDosFilterThrottledRequests() {
+    return getInt(DOS_FILTER_THROTTLED_REQUESTS_CONFIG);
+  }
+
+  public final Duration getDosFilterThrottleMs() {
+    return Duration.ofMillis(getLong(DOS_FILTER_THROTTLE_MS_CONFIG));
+  }
+
+  public final Duration getDosFilterMaxRequestMs() {
+    return Duration.ofMillis(getLong(DOS_FILTER_MAX_REQUEST_MS_CONFIG));
+  }
+
+  public final Duration getDosFilterMaxIdleTrackerMs() {
+    return Duration.ofMillis(getLong(DOS_FILTER_MAX_IDLE_TRACKER_MS_CONFIG));
+  }
+
+  public final boolean getDosFilterInsertHeaders() {
+    return getBoolean(DOS_FILTER_INSERT_HEADERS_CONFIG);
+  }
+
+  public final boolean getDosFilterTrackSessions() {
+    return getBoolean(DOS_FILTER_TRACK_SESSIONS_CONFIG);
+  }
+
+  public final boolean getDosFilterRemotePort() {
+    return getBoolean(DOS_FILTER_REMOTE_PORT_CONFIG);
+  }
+
+  public final List<String> getDosFilterIpWhitelist() {
+    return getList(DOS_FILTER_IP_WHITELIST_CONFIG);
+  }
+
+  public final boolean getDosFilterManagedAttr() {
+    return getBoolean(DOS_FILTER_MANAGED_ATTR_CONFIG);
   }
 }

--- a/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
+++ b/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2019 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,19 +42,17 @@ import org.apache.http.ssl.SSLContexts;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestSslUtils.CertificateBuilder;
+import org.eclipse.jetty.server.Server;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ApiHeadersTest {
 
-  private static final String httpUri = "http://localhost:8080";
-  private static final String httpsUri = "https://localhost:8081";
-
   private static final String SSL_PASSWORD = "test1234";
 
   private static String clientKeystoreLocation;
-  private static TestApplication app;
+  private static Server server;
 
   @BeforeClass
   public static void setUp() throws Exception {
@@ -70,26 +68,27 @@ public class ApiHeadersTest {
     TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(SSL_PASSWORD), certs);
 
     final Properties props = new Properties();
-    props.put(RestConfig.LISTENERS_CONFIG, httpUri + "," + httpsUri);
+    props.put(RestConfig.LISTENERS_CONFIG, "http://localhost:0,https://localhost:0");
     props.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, serverKeystore.getAbsolutePath());
     props.put(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
     props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, SSL_PASSWORD);
 
-    app = new TestApplication(new TestRestConfig(props));
-    app.start();
+    TestApplication app = new TestApplication(new TestRestConfig(props));
+    server = app.createServer();
+    server.start();
   }
 
   @AfterClass
   public static void teardown() throws Exception {
-    if (app != null) {
-      app.stop();
+    if (server != null) {
+      server.stop();
     }
   }
 
   @Test
   public void testHttpDoesNotReturnJettyServerVersionHeader() throws Exception {
 
-    final HttpGet httpget = new HttpGet(httpUri +  "/test/endpoint");
+    final HttpGet httpget = new HttpGet(server.getURI() + "/test/endpoint");
 
     try ( CloseableHttpClient httpclient = HttpClients.createDefault();
         CloseableHttpResponse response = httpclient.execute(httpget) ) {
@@ -102,28 +101,34 @@ public class ApiHeadersTest {
   @Test
   public void testHttpsDoesNotReturnJettyServerVersionHeader() throws Exception {
 
-    final HttpGet httpget = new HttpGet(httpsUri +  "/test/endpoint");
+    final HttpGet httpget = new HttpGet(server.getURI() + "/test/endpoint");
 
     // trust all self-signed certs and add the client keystore if it's configured.
     final SSLContext sslContext = SSLContexts.custom()
         .loadTrustMaterial(new TrustSelfSignedStrategy())
-        .loadKeyMaterial(new File(clientKeystoreLocation),SSL_PASSWORD.toCharArray(),
+        .loadKeyMaterial(new File(clientKeystoreLocation), SSL_PASSWORD.toCharArray(),
             SSL_PASSWORD.toCharArray())
         .build();
 
-    final SSLConnectionSocketFactory sslSf = new SSLConnectionSocketFactory(sslContext, new String[]{"TLSv1.2"},
-        null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+    final SSLConnectionSocketFactory sslSf =
+        new SSLConnectionSocketFactory(
+            sslContext,
+            new String[]{"TLSv1.2"},
+            null,
+            SSLConnectionSocketFactory.getDefaultHostnameVerifier());
 
-    try ( CloseableHttpClient httpclient = HttpClients.custom().setSSLSocketFactory(sslSf).build();
-        CloseableHttpResponse response = httpclient.execute(httpget) ) {
+    try (
+        CloseableHttpClient httpclient = HttpClients.custom().setSSLSocketFactory(sslSf).build();
+        CloseableHttpResponse response = httpclient.execute(httpget)) {
 
       assertThat(response.getStatusLine().getStatusCode(), is(200));
-      assertThat(response.getFirstHeader( "Server" ), is(nullValue()));
+      assertThat(response.getFirstHeader("Server"), is(nullValue()));
     }
   }
 
 
-  private static void createKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs) throws Exception {
+  private static void createKeystoreWithCert(
+      File file, String alias, Map<String, X509Certificate> certs) throws Exception {
 
     final KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
 

--- a/core/src/test/java/io/confluent/rest/DosFilterTest.java
+++ b/core/src/test/java/io/confluent/rest/DosFilterTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2021 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.eclipse.jetty.server.Server;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class DosFilterTest {
+
+  @Test
+  public void dosFilterEnabled_throttlesRequests() throws Exception {
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.of(
+                    "listeners", "http://localhost:0",
+                    "dos.filter.enabled", "true",
+                    "dos.filter.max.requests.per.sec", "1",
+                    "dos.filter.delay.ms", "-1")));
+    Server server = application.createServer();
+    server.start();
+
+    Client client = ClientBuilder.newClient();
+
+    // Request should succeed.
+    Response response1 = client.target(server.getURI()).path("/foo").request().get();
+    assertEquals(Status.OK.getStatusCode(), response1.getStatus());
+
+    // Following requests should all be throttled.
+    for (int i = 0; i < 100; i++) {
+      Response response2 = client.target(server.getURI()).path("/foo").request().get();
+      assertEquals(Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatus());
+    }
+
+    Thread.sleep(1000);
+
+    // Request should succeed again.
+    Response response3 = client.target(server.getURI()).path("/foo").request().get();
+    assertEquals(Status.OK.getStatusCode(), response3.getStatus());
+
+    server.stop();
+  }
+
+  @Test
+  public void dosFilterDisabled_DoesNotThrottleRequests() throws Exception {
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.of(
+                    "listeners", "http://localhost:0",
+                    "dos.filter.enabled", "false",
+                    "dos.filter.max.requests.per.sec", "1",
+                    "dos.filter.delay.ms", "-1")));
+    Server server = application.createServer();
+    server.start();
+
+    Client client = ClientBuilder.newClient();
+
+    // Request should succeed.
+    Response response1 = client.target(server.getURI()).path("/foo").request().get();
+    assertEquals(Status.OK.getStatusCode(), response1.getStatus());
+
+    // Following requests should all also succeed.
+    for (int i = 0; i < 100; i++) {
+      Response response2 = client.target(server.getURI()).path("/foo").request().get();
+      assertEquals(Status.OK.getStatusCode(), response2.getStatus());
+    }
+
+    server.stop();
+  }
+
+  public static final class FooApplication extends Application<FooConfig> {
+
+    public FooApplication(FooConfig config) {
+      super(config);
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, FooConfig appConfig) {
+      config.register(FooResource.class);
+    }
+  }
+
+  public static final class FooConfig extends RestConfig {
+
+    public FooConfig(Map<String, String> configs) {
+      super(baseConfigDef(), configs);
+    }
+  }
+
+  @Path("/foo")
+  public static final class FooResource {
+
+    @GET
+    public String getFoo() {
+      return "bar";
+    }
+  }
+}


### PR DESCRIPTION
This PR exposes per-application DosFilter support. See https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/servlets/DoSFilter.html for more information about the options available.

Config names are kept equal to the ones in Jetty's DosFilter. That unfortunately includes a usage of "whitelist", which otherwise would not meet Confluent's bar.

This PR also changes several tests to use a random port, to avoid race conditions with port binding.