### PR TITLE
KREST-1671 Add counter metrics

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -16,6 +16,7 @@
 
 package io.confluent.rest.metrics;
 
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.Resource;
@@ -189,6 +190,14 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       this.requestSizeSensor = metrics.sensor(getName(method, annotation, "request-size"));
       MetricName metricName = new MetricName(
+          getName(method, annotation, "request-count-windowed"), metricGrpName,
+          "The request count using a windowed counter", metricTags);
+      this.requestSizeSensor.add(metricName, new WindowedCount());
+      metricName = new MetricName(
+          getName(method, annotation, "request-count-cumulative"), metricGrpName,
+          "The request count using a cumulative counter", metricTags);
+      this.requestSizeSensor.add(metricName, new WindowedCount());
+      metricName = new MetricName(
           getName(method, annotation, "request-rate"), metricGrpName,
           "The average number of HTTP requests per second.", metricTags);
       this.requestSizeSensor.add(metricName, new Rate(new WindowedCount()));
@@ -256,6 +265,18 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
                 + HTTP_STATUS_CODE_TEXT[i],
             tags);
         errorSensorByStatus[i].add(metricName, new Rate());
+
+        metricName = new MetricName(getName(method, annotation, "request-error-count-windowed"),
+            metricGrpName,
+            "A windowed count of requests that resulted in an HTTP error response with code - "
+                + HTTP_STATUS_CODE_TEXT[i], tags);
+        errorSensorByStatus[i].add(metricName, new WindowedCount());
+        metricName = new MetricName(getName(method, annotation, "request-error-count-cumulative"),
+            metricGrpName,
+            "A cumulative count of requests that resulted in an HTTP error response with code -  "
+                + HTTP_STATUS_CODE_TEXT[i], tags);
+        errorSensorByStatus[i].add(metricName, new CumulativeCount());
+
       }
 
       this.errorSensor = metrics.sensor(getName(method, annotation, "errors"));
@@ -265,6 +286,20 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           "The average number of requests per second that resulted in HTTP error responses",
           metricTags);
       this.errorSensor.add(metricName, new Rate());
+
+      this.errorSensor = metrics.sensor(getName(method, annotation, "errors-count"));
+      metricName = new MetricName(
+          getName(method, annotation, "request-error-count-windowed"),
+          metricGrpName,
+          "A windowed count of requests that resulted in HTTP error responses",
+          metricTags);
+      this.errorSensor.add(metricName, new WindowedCount());
+      metricName = new MetricName(
+          getName(method, annotation, "request-error-count-cumulative"),
+          metricGrpName,
+          "A cumulative count of requests that resulted in HTTP error responses",
+          metricTags);
+      this.errorSensor.add(metricName, new CumulativeCount());
     }
 
     /**

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -196,7 +196,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       metricName = new MetricName(
           getName(method, annotation, "request-count-cumulative"), metricGrpName,
           "The request count using a cumulative counter", metricTags);
-      this.requestSizeSensor.add(metricName, new WindowedCount());
+      this.requestSizeSensor.add(metricName, new CumulativeCount());
       metricName = new MetricName(
           getName(method, annotation, "request-rate"), metricGrpName,
           "The average number of HTTP requests per second.", metricTags);


### PR DESCRIPTION
At present, rest-utils only collects rate based metrics.  Absolute metrics will also be useful.

This commit adds metrics to count, both cumulatively and also on a windowed basis:
 - requests that finish successfully
 - error status responses (for any error response)
 - error status response, per grouping of errors.  The groupings are unknown, 1xx, 2xx, 3xx, 4xx and 5xx