### PR TITLE
KREST-1671 remove cumulative metric counts as we aren't using them

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -16,7 +16,6 @@
 
 package io.confluent.rest.metrics;
 
-import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.Resource;
@@ -194,10 +193,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           "The request count using a windowed counter", metricTags);
       this.requestSizeSensor.add(metricName, new WindowedCount());
       metricName = new MetricName(
-          getName(method, annotation, "request-count-cumulative"), metricGrpName,
-          "The request count using a cumulative counter", metricTags);
-      this.requestSizeSensor.add(metricName, new CumulativeCount());
-      metricName = new MetricName(
           getName(method, annotation, "request-rate"), metricGrpName,
           "The average number of HTTP requests per second.", metricTags);
       this.requestSizeSensor.add(metricName, new Rate(new WindowedCount()));
@@ -271,11 +266,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
             "A windowed count of requests that resulted in an HTTP error response with code - "
                 + HTTP_STATUS_CODE_TEXT[i], tags);
         errorSensorByStatus[i].add(metricName, new WindowedCount());
-        metricName = new MetricName(getName(method, annotation, "request-error-count-cumulative"),
-            metricGrpName,
-            "A cumulative count of requests that resulted in an HTTP error response with code -  "
-                + HTTP_STATUS_CODE_TEXT[i], tags);
-        errorSensorByStatus[i].add(metricName, new CumulativeCount());
 
       }
 
@@ -294,12 +284,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           "A windowed count of requests that resulted in HTTP error responses",
           metricTags);
       this.errorSensor.add(metricName, new WindowedCount());
-      metricName = new MetricName(
-          getName(method, annotation, "request-error-count-cumulative"),
-          metricGrpName,
-          "A cumulative count of requests that resulted in HTTP error responses",
-          metricTags);
-      this.errorSensor.add(metricName, new CumulativeCount());
     }
 
     /**

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -189,7 +189,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       this.requestSizeSensor = metrics.sensor(getName(method, annotation, "request-size"));
       MetricName metricName = new MetricName(
-          getName(method, annotation, "request-count-windowed"), metricGrpName,
+          getName(method, annotation, "request-count"), metricGrpName,
           "The request count using a windowed counter", metricTags);
       this.requestSizeSensor.add(metricName, new WindowedCount());
       metricName = new MetricName(
@@ -261,7 +261,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
             tags);
         errorSensorByStatus[i].add(metricName, new Rate());
 
-        metricName = new MetricName(getName(method, annotation, "request-error-count-windowed"),
+        metricName = new MetricName(getName(method, annotation, "request-error-count"),
             metricGrpName,
             "A windowed count of requests that resulted in an HTTP error response with code - "
                 + HTTP_STATUS_CODE_TEXT[i], tags);
@@ -279,7 +279,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       this.errorSensor = metrics.sensor(getName(method, annotation, "errors-count"));
       metricName = new MetricName(
-          getName(method, annotation, "request-error-count-windowed"),
+          getName(method, annotation, "request-error-count"),
           metricGrpName,
           "A windowed count of requests that resulted in HTTP error responses",
           metricTags);

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -102,7 +102,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     //checkpoint ensures that all the assertions are tested
     int metricsCheckpointWindow = 0;
-    int metricsCheckpointCumulative = 0;
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-count-windowed")) {
@@ -113,17 +112,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         double countValue = (double) metricValue;
         assertTrue("Actual: " + countValue, countValue == 2.0);
       }
-      if (metric.metricName().name().equals("request-count-cumulative")) {
-        assertTrue(metric.measurable().toString().toLowerCase().startsWith("cumulativesum"));
-        metricsCheckpointCumulative++;
-        Object metricValue = metric.metricValue();
-        assertTrue("Metrics should be measurable", metricValue instanceof Double);
-        double countValue = (double) metricValue;
-        assertTrue("Actual: " + countValue, countValue == 2.0);
-      }
     }
     assertEquals(1, metricsCheckpointWindow); //A single metric for the windowed count
-    assertEquals(1, metricsCheckpointCumulative); //A single metric for the cumulative count
   }
 
   @Test
@@ -144,13 +134,10 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     //checkpoints ensure that all the assertions are tested
     int rateCheckpoint4xx = 0;
     int windowCheckpoint4xx = 0;
-    int cumulativeCheckpoint4xx = 0;
     int rateCheckpointNot4xx = 0;
     int windowCheckpointNot4xx = 0;
-    int cumulativeCheckpointNot4xx = 0;
     int anyErrorRateCheckpoint = 0;
     int anyErrorWindowCheckpoint = 0;
-    int anyErrorCumulativeCheckpoint = 0;
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
@@ -187,34 +174,14 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
           assertTrue("Count for all errors actual: " + errorCountValue, errorCountValue == 2.0);
         }
       }
-      if (metric.metricName().name().equals("request-error-count-cumulative")) {
-          assertTrue(metric.measurable().toString().toLowerCase().startsWith("cumulativesum"));
-          Object metricValue = metric.metricValue();
-          assertTrue("Error count metrics should be measurable", metricValue instanceof Double);
-          double errorCountValue = (double) metricValue;
-          if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("4xx")) {
-            cumulativeCheckpoint4xx++;
-            assertTrue("Actual: " + errorCountValue, errorCountValue == 2.0);
-          } else if (!metric.metricName().tags().isEmpty()) {
-            cumulativeCheckpointNot4xx++;
-            assertTrue(String.format("Actual: %f (%s)", errorCountValue, metric.metricName()),
-                errorCountValue == 0.0 || Double.isNaN(errorCountValue));
-          } else {
-            anyErrorCumulativeCheckpoint++;
-            assertTrue("Count for all errors actual: " + errorCountValue, errorCountValue == 2.0);
-          }
-      }
     }
 
     assertEquals(1, anyErrorRateCheckpoint); //A Single rate metric for the two errors
     assertEquals(1, anyErrorWindowCheckpoint); //A single windowed metric for the two errors
-    assertEquals(1, anyErrorCumulativeCheckpoint); //A single cumulative metric for the two errors
     assertEquals(1, rateCheckpoint4xx); //Single rate metric for the two 4xx errors
     assertEquals(1, windowCheckpoint4xx); ///A single windowed metric for the two 4xx errors
-    assertEquals(1, cumulativeCheckpoint4xx); ///A single cumulative metric for the two 4xx errors,
     assertEquals(5, rateCheckpointNot4xx); //Metrics for each of unknown, 1xx, 2xx, 3xx, 5xx
     assertEquals(5, windowCheckpointNot4xx); //Metrics for each of unknown, 1xx, 2xx, 3xx, 5xx for windowed metrics
-    assertEquals(5, cumulativeCheckpointNot4xx); //Metrics for each of unknown, 1xx, 2xx, 3xx, 5xx for cumulative metrics
 
   }
 

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -104,7 +104,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     int metricsCheckpointWindow = 0;
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
-      if (metric.metricName().name().equals("request-count-windowed")) {
+      if (metric.metricName().name().equals("request-count")) {
         assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
         metricsCheckpointWindow++;
         Object metricValue = metric.metricValue();
@@ -157,7 +157,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
           //average rate is not consistently above 0 here, so not validating
         }
       }
-      if (metric.metricName().name().equals("request-error-count-windowed")) {
+      if (metric.metricName().name().equals("request-error-count")) {
         assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
         Object metricValue = metric.metricValue();
         assertTrue("Error count metrics should be measurable", metricValue instanceof Double);


### PR DESCRIPTION
When I first added the metrics I wasn't sure whether I needed the windowed count or the cumulative, so added both.

I can't think of an occasion where we want cumulative counts, and as suggested by Rigel, I'm removing them