### PR TITLE
SEC-2720: Add SecureRequestCustomizer for correct resolution of http vs https requests.

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -392,9 +392,6 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     final HttpConfiguration httpConfiguration = new HttpConfiguration();
     httpConfiguration.setSendServerVersion(false);
 
-    // we need to set below only if listener is https
-    httpConfiguration.addCustomizer(new SecureRequestCustomizer());
-
     final HttpConnectionFactory httpConnectionFactory =
             new HttpConnectionFactory(httpConfiguration);
 
@@ -407,6 +404,11 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
             config.getInt(RestConfig.PORT_CONFIG), Arrays.asList("http", "https"), "http");
 
     for (URI listener : listeners) {
+      if (listener.getScheme().equals("https")) {
+        if (httpConfiguration.getCustomizer(SecureRequestCustomizer.class) == null) {
+          httpConfiguration.addCustomizer(new SecureRequestCustomizer());
+        }
+      }
       addConnectorForListener(httpConfiguration, httpConnectionFactory, listener, http2Enabled);
     }
   }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -31,6 +31,7 @@ import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.NetworkTrafficServerConnector;
+import org.eclipse.jetty.server.SecureRequestCustomizer;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
@@ -390,6 +391,9 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
     final HttpConfiguration httpConfiguration = new HttpConfiguration();
     httpConfiguration.setSendServerVersion(false);
+
+    // we need to set below only if listener is https
+    httpConfiguration.addCustomizer(new SecureRequestCustomizer());
 
     final HttpConnectionFactory httpConnectionFactory =
             new HttpConnectionFactory(httpConfiguration);


### PR DESCRIPTION
This pull request adds a `SecureRequestCustomizer()` to the configuration in case SSL is set up. 
Without the `SecureRequestCustomizer()`, if a server-side application calls `.getScheme()` on incoming requests, it gets `http` even for HTTPS requests. 

Added a test to validate the behavior. 

Notes to reviewers: 
- This bug doesn't affect 6.2.x, which I have verified manually. The test passes when backported to 6.2.x without the need for an explicit customizer.
- The first commit in this PR is only the test but not the fix, so you can inspect that this is indeed an issue. The second commit adds the fix, so build no. 2 should pass.
- The exact reason that caused this change of behavior from `6.2.x` => `7.0.x` is still to be investigated. 

