### PR TITLE
APIF-1690: Fix CVE-2021-28170

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,13 @@
                 </exclusions>
             </dependency>
 
+            <!-- https://mvnrepository.com/artifact/jakarta.el/jakarta.el-api -->
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>4.0.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jmx</artifactId>


### PR DESCRIPTION
Upgrade Jersey to fix vulnerable jakarta.el:jakarta.el-api.