### PR TITLE
KREST-3148 enable ip based rate limiting

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -654,24 +654,20 @@ public abstract class Application<T extends RestConfig> {
     if (!config.isDosFilterEnabled()) {
       return;
     }
-    if (!config.getDosFilterRemotePort() && config.getDosFilterTrackGlobal()) {
-      configureGlobalDosFilter(context);
-    }
+    configureGlobalDosFilter(context);
     configureNonGlobalDosFilter(context);
   }
 
   private void configureNonGlobalDosFilter(ServletContextHandler context) {
     DoSFilter dosFilter = new DoSFilter();
     FilterHolder filterHolder = configureFilter(dosFilter,
-        String.valueOf(config.getDosFilterMaxRequestsPerSec()));
+        String.valueOf(config.getDosFilterMaxRequestsPerConnectionPerSec()));
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
   
   private void configureGlobalDosFilter(ServletContextHandler context) {
     DoSFilter dosFilter = new GlobalDosFilter();
-    String globalLimit = config.getDosFilterMaxRequestsGlobalPerSec() >= 0
-        ? String.valueOf(config.getDosFilterMaxRequestsGlobalPerSec())
-        : String.valueOf(config.getDosFilterMaxRequestsPerSec());
+    String globalLimit = String.valueOf(config.getDosFilterMaxRequestsGlobalPerSec());
     FilterHolder filterHolder = configureFilter(dosFilter, globalLimit);
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
@@ -697,7 +693,7 @@ public abstract class Application<T extends RestConfig> {
         "insertHeaders", String.valueOf(config.getDosFilterInsertHeaders()));
     filterHolder.setInitParameter("trackSessions", "false");
     filterHolder.setInitParameter(
-        "remotePort", String.valueOf(config.getDosFilterRemotePort()));
+        "remotePort", String.valueOf("false"));
     filterHolder.setInitParameter(
         "ipWhitelist", String.valueOf(config.getDosFilterIpWhitelist()));
     filterHolder.setInitParameter(

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -353,7 +353,7 @@ public abstract class Application<T extends RestConfig> {
       configureHttpResponseHeaderFilter(context);
     }
 
-    configureDosFilter(context);
+    configureDosFilters(context);
 
     configurePreResourceHandling(context);
     context.addFilter(servletHolder, "/*", null);
@@ -650,19 +650,37 @@ public abstract class Application<T extends RestConfig> {
     context.addFilter(headerFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
 
-  private void configureDosFilter(ServletContextHandler context) {
+  private void configureDosFilters(ServletContextHandler context) {
     if (!config.isDosFilterEnabled()) {
       return;
     }
-    DoSFilter dosFilter;
     if (!config.getDosFilterRemotePort() && config.getDosFilterTrackGlobal()) {
-      dosFilter = new GlobalDosFilter();
-    } else {
-      dosFilter = new DoSFilter();
+      configureGlobalDosFilter(context);
     }
+    configureNonGlobalDosFilter(context);
+  }
+
+  private void configureNonGlobalDosFilter(ServletContextHandler context) {
+    DoSFilter dosFilter = new DoSFilter();
+    FilterHolder filterHolder = configureFilter(dosFilter,
+        String.valueOf(config.getDosFilterMaxRequestsPerSec()));
+    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+  
+  private void configureGlobalDosFilter(ServletContextHandler context) {
+    DoSFilter dosFilter = new GlobalDosFilter();
+    String globalLimit = config.getDosFilterMaxRequestsGlobalPerSec() >= 0
+        ? String.valueOf(config.getDosFilterMaxRequestsGlobalPerSec())
+        : String.valueOf(config.getDosFilterMaxRequestsPerSec());
+    FilterHolder filterHolder = configureFilter(dosFilter, globalLimit);
+    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+
+  private FilterHolder configureFilter(DoSFilter dosFilter, String rate) {
+
     FilterHolder filterHolder = new FilterHolder(dosFilter);
     filterHolder.setInitParameter(
-        "maxRequestsPerSec", String.valueOf(config.getDosFilterMaxRequestsPerSec()));
+        "maxRequestsPerSec", rate);
     filterHolder.setInitParameter(
         "delayMs", String.valueOf(config.getDosFilterDelayMs().toMillis()));
     filterHolder.setInitParameter(
@@ -684,7 +702,8 @@ public abstract class Application<T extends RestConfig> {
         "ipWhitelist", String.valueOf(config.getDosFilterIpWhitelist()));
     filterHolder.setInitParameter(
         "managedAttr", String.valueOf(config.getDosFilterManagedAttr()));
-    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+    return filterHolder;
+
   }
 
   public T getConfiguration() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -371,17 +371,16 @@ public class RestConfig extends AbstractConfig {
   private static final String DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG =
       "dos.filter.max.requests.per.sec";
   private static final String DOS_FILTER_MAX_REQUESTS_PER_SEC_DOC =
-      "Maximum number of requests from a connection per second. Requests in excess of this are "
-          + "first delayed, then throttled. Default is 25.";
+      "Maximum number of requests per second for the REST instance. Requests in excess of this "
+          + "are first delayed, then throttled. Default is 25.";
   private static final int DOS_FILTER_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
-  private static final String DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG =
-      "dos.filter.max.requests.global.per.sec";
-  private static final String DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DOC =
-      "Maximum number of requests per second for the rest instance. Requests in excess of this are "
-          + "first delayed, then throttled. If set to the default value of -1, then the value of "
-          + "dos.filter.max.requests.per.sec is used.";
-  private static final int DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DEFAULT = -1;
+  private static final String DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_CONFIG =
+      "dos.filter.max.requests.per.connection.per.sec";
+  private static final String DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_DOC =
+      "Maximum number of requests per second per ipaddress for the rest instance. "
+          + "Requests in excess of this are first delayed, then throttled.";
+  private static final int DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_DEFAULT = 25;
 
   private static final String DOS_FILTER_DELAY_MS_CONFIG = "dos.filter.delay.ms";
   private static final String DOS_FILTER_DELAY_MS_DOC =
@@ -421,18 +420,6 @@ public class RestConfig extends AbstractConfig {
   private static final String DOS_FILTER_INSERT_HEADERS_DOC =
       "If true, insert the DoSFilter headers into the response. Defaults to true.";
   private static final boolean DOS_FILTER_INSERT_HEADERS_DEFAULT = true;
-
-  private static final String DOS_FILTER_REMOTE_PORT_CONFIG = "dos.filter.remote.port";
-  private static final String DOS_FILTER_REMOTE_PORT_DOC =
-      "If true, then rate is tracked by IP and port (effectively per connection). Defaults to "
-          + "false.";
-  private static final boolean DOS_FILTER_REMOTE_PORT_DEFAULT = false;
-
-  private static final String DOS_FILTER_TRACK_GLOBAL_CONFIG = "dos.filter.track.global";
-  private static final String DOS_FILTER_TRACK_GLOBAL_DOC =
-      "If true and remote port tracking is not used, then rate is tracked globally for all "
-          + "connections. Defaults to false.";
-  private static final boolean DOS_FILTER_TRACK_GLOBAL_DEFAULT = false;
 
   private static final String DOS_FILTER_IP_WHITELIST_CONFIG = "dos.filter.ip.whitelist";
   private static final String DOS_FILTER_IP_WHITELIST_DOC =
@@ -866,11 +853,11 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_MAX_REQUESTS_PER_SEC_DOC
         ).define(
-            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG,
+            DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_CONFIG,
             Type.INT,
-            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DEFAULT,
+            DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_DEFAULT,
             Importance.LOW,
-            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DOC
+            DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_DOC
         ).define(
             DOS_FILTER_DELAY_MS_CONFIG,
             Type.LONG,
@@ -913,18 +900,6 @@ public class RestConfig extends AbstractConfig {
             DOS_FILTER_INSERT_HEADERS_DEFAULT,
             Importance.LOW,
             DOS_FILTER_INSERT_HEADERS_DOC
-        ).define(
-            DOS_FILTER_REMOTE_PORT_CONFIG,
-            Type.BOOLEAN,
-            DOS_FILTER_REMOTE_PORT_DEFAULT,
-            Importance.LOW,
-            DOS_FILTER_REMOTE_PORT_DOC
-        ).define(
-            DOS_FILTER_TRACK_GLOBAL_CONFIG,
-            Type.BOOLEAN,
-            DOS_FILTER_TRACK_GLOBAL_DEFAULT,
-            Importance.LOW,
-            DOS_FILTER_TRACK_GLOBAL_DOC
         ).define(
             DOS_FILTER_IP_WHITELIST_CONFIG,
             Type.LIST,
@@ -1033,12 +1008,12 @@ public class RestConfig extends AbstractConfig {
     return getBoolean(DOS_FILTER_ENABLED_CONFIG);
   }
 
-  public final int getDosFilterMaxRequestsPerSec() {
-    return getInt(DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG);
+  public final int getDosFilterMaxRequestsPerConnectionPerSec() {
+    return getInt(DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC_CONFIG);
   }
 
   public final int getDosFilterMaxRequestsGlobalPerSec() {
-    return getInt(DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG);
+    return getInt(DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG);
   }
 
   public final Duration getDosFilterDelayMs() {
@@ -1067,14 +1042,6 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getDosFilterInsertHeaders() {
     return getBoolean(DOS_FILTER_INSERT_HEADERS_CONFIG);
-  }
-
-  public final boolean getDosFilterRemotePort() {
-    return getBoolean(DOS_FILTER_REMOTE_PORT_CONFIG);
-  }
-
-  public final boolean getDosFilterTrackGlobal() {
-    return getBoolean(DOS_FILTER_TRACK_GLOBAL_CONFIG);
   }
 
   public final List<String> getDosFilterIpWhitelist() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -375,6 +375,14 @@ public class RestConfig extends AbstractConfig {
           + "first delayed, then throttled. Default is 25.";
   private static final int DOS_FILTER_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
+  private static final String DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG =
+      "dos.filter.max.requests.global.per.sec";
+  private static final String DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DOC =
+      "Maximum number of requests per second for the rest instance. Requests in excess of this are "
+          + "first delayed, then throttled. If set to the default value of -1, then the value of "
+          + "dos.filter.max.requests.per.sec is used.";
+  private static final int DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DEFAULT = -1;
+
   private static final String DOS_FILTER_DELAY_MS_CONFIG = "dos.filter.delay.ms";
   private static final String DOS_FILTER_DELAY_MS_DOC =
       "Delay imposed on all requests over the rate limit, before they are considered at all: 100 "
@@ -858,6 +866,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_MAX_REQUESTS_PER_SEC_DOC
         ).define(
+            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG,
+            Type.INT,
+            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_DOC
+        ).define(
             DOS_FILTER_DELAY_MS_CONFIG,
             Type.LONG,
             DOS_FILTER_DELAY_MS_DEFAULT.toMillis(),
@@ -1021,6 +1035,10 @@ public class RestConfig extends AbstractConfig {
 
   public final int getDosFilterMaxRequestsPerSec() {
     return getInt(DOS_FILTER_MAX_REQUESTS_PER_SEC_CONFIG);
+  }
+
+  public final int getDosFilterMaxRequestsGlobalPerSec() {
+    return getInt(DOS_FILTER_MAX_REQUESTS_GLOBAL_PER_SEC_CONFIG);
   }
 
   public final Duration getDosFilterDelayMs() {

--- a/core/src/test/java/io/confluent/rest/DosFilterTest.java
+++ b/core/src/test/java/io/confluent/rest/DosFilterTest.java
@@ -49,106 +49,13 @@ public class DosFilterTest {
                 ImmutableMap.of(
                     "listeners", "http://localhost:0",
                     "dos.filter.enabled", "true",
-                    "dos.filter.max.requests.per.sec", "1",
+                    "dos.filter.max.requests.per.connection.per.sec", "1",
+                    "dos.filter.max.requests.per.sec", "1000",
                     "dos.filter.delay.ms", "-1")));
     Server server = application.createServer();
     server.start();
 
     HttpGet request = createRequest(server.getURI());
-
-    CloseableHttpClient ephemeralClient = createEphemeralClient();
-
-    // Request should succeed.
-    CloseableHttpResponse response1 = ephemeralClient.execute(request);
-    assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
-    response1.close();
-
-    // Following requests should all be throttled.
-    for (int i = 0; i < 100; i++) {
-      CloseableHttpResponse response2 = ephemeralClient.execute(request);
-      assertEquals(
-          Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatusLine().getStatusCode());
-      response2.close();
-    }
-
-    Thread.sleep(1000);
-
-    // Request should succeed again.
-    CloseableHttpResponse response3 = ephemeralClient.execute(request);
-    assertEquals(Status.OK.getStatusCode(), response3.getStatusLine().getStatusCode());
-    response3.close();
-
-    server.stop();
-  }
-
-  @Test
-  public void dosFilterEnabled_remotePort_throttlesRequestsPerConnection() throws Exception {
-    FooApplication application =
-        new FooApplication(
-            new FooConfig(
-                ImmutableMap.<String, String>builder()
-                    .put("listeners", "http://localhost:0")
-                    .put("dos.filter.enabled", "true")
-                    .put("dos.filter.max.requests.per.sec", "1")
-                    .put("dos.filter.delay.ms", "-1")
-                    .put("dos.filter.remote.port", "true")
-                    .build()));
-    Server server = application.createServer();
-    server.start();
-
-    HttpGet request = createRequest(server.getURI());
-
-    // Following requests should not be throttled, since they use different connections.
-    CloseableHttpClient ephemeralClient = createEphemeralClient();
-    for (int i = 0; i < 100; i++) {
-      CloseableHttpResponse response = ephemeralClient.execute(request);
-      assertEquals(Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
-      response.close();
-    }
-
-    CloseableHttpClient persistentClient = createPersistentClient();
-
-    // Request should succeed.
-    CloseableHttpResponse response1 = persistentClient.execute(request);
-    assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
-    response1.getEntity().getContent().close();
-    response1.close();
-
-    // Following requests should all be throttled since they all reuse the same connection.
-    for (int i = 0; i < 100; i++) {
-      CloseableHttpResponse response2 = persistentClient.execute(request);
-      assertEquals(
-          Status.TOO_MANY_REQUESTS.getStatusCode(), response2.getStatusLine().getStatusCode());
-      response2.getEntity().getContent().close();
-      response2.close();
-    }
-
-    Thread.sleep(1000);
-
-    // Request on the same connection should succeed again.
-    CloseableHttpResponse response3 = persistentClient.execute(request);
-    assertEquals(Status.OK.getStatusCode(), response3.getStatusLine().getStatusCode());
-  }
-
-  @Test
-  public void dosFilterEnabled_trackGlobal_throttlesRequestsGlobally() throws Exception {
-    FooApplication application =
-        new FooApplication(
-            new FooConfig(
-                ImmutableMap.<String, String>builder()
-                    .put("listeners", "http://localhost:0")
-                    .put("dos.filter.enabled", "true")
-                    .put("dos.filter.max.requests.per.sec", "1")
-                    .put("dos.filter.delay.ms", "-1")
-                    .put("dos.filter.track.global", "true")
-                    .build()));
-    Server server = application.createServer();
-    server.start();
-
-    HttpGet request = createRequest(server.getURI());
-
-    // There's no way for us to actually check throttling is happening across different IPs. We
-    // check here it behaves at least per-IP.
 
     CloseableHttpClient ephemeralClient = createEphemeralClient();
 
@@ -183,7 +90,7 @@ public class DosFilterTest {
                 ImmutableMap.of(
                     "listeners", "http://localhost:0",
                     "dos.filter.enabled", "false",
-                    "dos.filter.max.requests.per.sec", "1",
+                    "dos.filter.max.requests.per.connection.per.sec", "1",
                     "dos.filter.delay.ms", "-1")));
     Server server = application.createServer();
     server.start();
@@ -208,7 +115,7 @@ public class DosFilterTest {
   }
 
   @Test
-  public void dosFilterEnabled_throttlesRequestsPerConnection_AndGlobally()
+  public void dosFilterEnabled_throttlesRequestsGlobally()
       throws Exception {
     FooApplication application =
         new FooApplication(
@@ -216,9 +123,9 @@ public class DosFilterTest {
                 ImmutableMap.<String, String>builder()
                     .put("listeners", "http://localhost:0")
                     .put("dos.filter.enabled", "true")
-                    .put("dos.filter.max.requests.global.per.sec", "1")
+                    .put("dos.filter.max.requests.per.sec", "1")
+                    .put("dos.filter.max.requests.per.connection.per.sec", "100")
                     .put("dos.filter.delay.ms", "-1")
-                    .put("dos.filter.track.global", "true")
                     .build()));
     Server server = application.createServer();
     server.start();
@@ -228,7 +135,7 @@ public class DosFilterTest {
     CloseableHttpClient ephemeralClient = createEphemeralClient();
     CloseableHttpClient persistentClient = createPersistentClient();
 
-    // First request succeeds, everything else withing 1s fails
+    // First request succeeds, everything else within 1s fails
     CloseableHttpResponse response1 = ephemeralClient.execute(request);
     assertEquals(Status.OK.getStatusCode(), response1.getStatusLine().getStatusCode());
     response1.close();


### PR DESCRIPTION
Before this PR the code checked if the "global" rate limiter was turned on and if the "per port" configuration was set.  If so, the dos filters were applied globally, across all connections.  If not, a per connection rate limiter was created.

The global property is `dos.filter.track.global` which is set to true in cc-spec-kafka (although the in code default is false) and its intention is to do dos rate limiting across all connections, ie globally.

The per port property is `dos.filter.remote.port` which is set to false in cc-spec-kafka and also in code. The intent of this property is to apply the dos filters per ip-addres:port rather than just ip-address.

Before this PR, the dos filters were just applied globally, although the documentation for the `dos.filter.max.requests.per.sec` rate limit does state "per connection" this wasn't actually true in practice for our configuration

The intent of this code change is to have both a per connection `dos.filter.max.requests.per.sec` rate limit as well as the existing global rate limit across all connections.

The `dos.filter.max.requests.per.sec` filter is documented as applying per connection, so while it would be nice to use this for the global limit, as that is how it is already being used, I had to make a new global rate limiting property to maintain consistency.

If this is unset, it defaults to the existing value for `dos.filter.max.requests.per.sec`.

In all cases, the per ip address dos filter is applied (this is new, previously it was not in place if you had global rate limiting turned on).  If dos.filter.track.global is on and ip-addres:port is off, you also get the global limiter, as you did before.


This is all possible because of the `proxy.protocol.enabled` property (false in code, true in launch darkly), which was added to ensure that the ip address from the header is used for rate limiting.  This means that for both AWS and where a load balancer is used, the original ip address is used, not the load balancer one.