### PR TITLE
Enforce Netty for children

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             </dependency>
 
             <!--our actual deps-->
+
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+            </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>


### PR DESCRIPTION
This is to make sure that all children will enforce io.netty:netty-codec at 4.1.68.Final version.