### PR TITLE
TRIVIAL: Change the Maven repository protocol: http → https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,9 +17,9 @@
     <version>7.2.0-0</version>
     <organization>
         <name>Confluent, Inc.</name>
-        <url>http://confluent.io</url>
+        <url>https://confluent.io</url>
     </organization>
-    <url>http://confluent.io</url>
+    <url>https://confluent.io</url>
     <description>
         Confluent REST Utils provides a small framework and utilities for writing Java
         REST APIs using Jersey, Jackson, Jetty, and Hibernate Validator.
@@ -50,7 +50,7 @@
     <properties>
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.34</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <jetty.version>9.4.43.v20210629</jetty.version>


### PR DESCRIPTION
From 3.8.1, maven blocks [the HTTP repositories for CVE-2021-26291](https://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291) so rest-utils the build fails (below).

![20220102-124129](https://user-images.githubusercontent.com/2375128/147868572-89429c13-2037-49e3-b990-8f3245d9d4b5.png)

This PR fixes this issue by updating the repository configuration from http to https.
