### PR TITLE
APIF-2005: Change the Maven repository protocol: http → https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,9 +16,9 @@
     <name>rest-utils-parent</name>
     <organization>
         <name>Confluent, Inc.</name>
-        <url>http://confluent.io</url>
+        <url>https://confluent.io</url>
     </organization>
-    <url>http://confluent.io</url>
+    <url>https://confluent.io</url>
     <description>
         Confluent REST Utils provides a small framework and utilities for writing Java
         REST APIs using Jersey, Jackson, Jetty, and Hibernate Validator.
@@ -49,7 +49,7 @@
     <properties>
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.34</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <jetty.version>9.4.43.v20210629</jetty.version>


### PR DESCRIPTION
### What
`rest-utils` uses http maven url in pom.xml. Downloading of artifacts over an interceptable channel like http is dangerous.

This PR pretty much copies the changes from #300 to `5.2.x` branch.