### PR TITLE
KREST-3660-Junit5-ify rest-utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 *.iml
 .idea/
 .ipr
+.DS_Store
+core/.DS_Store

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,11 +112,6 @@
         </dependency>
         <!--test-->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>
@@ -215,6 +210,18 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
+++ b/core/src/test/java/io/confluent/rest/ApiHeadersTest.java
@@ -43,9 +43,9 @@ import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.test.TestSslUtils;
 import org.apache.kafka.test.TestSslUtils.CertificateBuilder;
 import org.eclipse.jetty.server.Server;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ApiHeadersTest {
 
@@ -54,7 +54,7 @@ public class ApiHeadersTest {
   private static String clientKeystoreLocation;
   private static Server server;
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() throws Exception {
     final File trustStore = File.createTempFile("ApiHeadersTest-truststore", ".jks");
     final File clientKeystore = File.createTempFile("ApiHeadersTest-client-keystore", ".jks");
@@ -78,7 +78,7 @@ public class ApiHeadersTest {
     server.start();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     if (server != null) {
       server.stop();

--- a/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
@@ -15,9 +15,9 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.eclipse.jetty.server.ServerConnector;
 import org.glassfish.jersey.servlet.ServletProperties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -39,16 +39,17 @@ import javax.ws.rs.ext.ExceptionMapper;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ApplicationServerTest {
 
   static TestRestConfig testConfig;
   private static ApplicationServer<TestRestConfig> server;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Properties props = new Properties();
     props.setProperty(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
@@ -57,7 +58,7 @@ public class ApplicationServerTest {
     server = new ApplicationServer<>(testConfig);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
   }
@@ -183,17 +184,19 @@ public class ApplicationServerTest {
     assertEquals(new URI("http://0.0.0.0:443"), listeners.get(1).getUri());
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testParseDuplicateNamedListeners() throws URISyntaxException {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENERS_CONFIG, "INTERNAL://0.0.0.0:4000,INTERNAL://0.0.0.0:443");
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
+    assertThrows(ConfigException.class,
+        () ->
     ApplicationServer.parseListeners(
       config.getList(RestConfig.LISTENERS_CONFIG),
       config.getListenerProtocolMap(),
-      0, ApplicationServer.SUPPORTED_URI_SCHEMES, "");
+      0, ApplicationServer.SUPPORTED_URI_SCHEMES, ""));
   }
 
   @Test

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -21,12 +21,12 @@ import static org.apache.kafka.common.metrics.MetricsContext.NAMESPACE;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.extension.ResourceExtension;
@@ -68,15 +68,15 @@ import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class ApplicationTest {
 
   private static final String REALM = "realm";
 
-  @Before
+  @BeforeEach
   public void setUp() {
     TestApp.SHUTDOWN_CALLED.set(false);
     TestRegistryExtension.CLOSE_CALLED.set(false);
@@ -84,12 +84,12 @@ public class ApplicationTest {
 
   private TestApp application;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     application = new TestApp();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     application.stop();
   }
@@ -97,9 +97,10 @@ public class ApplicationTest {
   @Test
   public void testParseListenersDeprecated() {
     List<String> listenersConfig = new ArrayList<>();
-    List<URI> listeners = Application.parseListeners(listenersConfig, RestConfig.PORT_CONFIG_DEFAULT,
-            ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
-    assertEquals("Should have only one listener.", 1, listeners.size());
+    List<URI> listeners = Application.parseListeners(listenersConfig,
+        RestConfig.PORT_CONFIG_DEFAULT,
+        ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertEquals(1, listeners.size(), "Should have only one listener.");
     assertExpectedUri(listeners.get(0), "http", "0.0.0.0", RestConfig.PORT_CONFIG_DEFAULT);
   }
 
@@ -108,40 +109,52 @@ public class ApplicationTest {
     List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost:123");
     listenersConfig.add("https://localhost:124");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
-    assertEquals("Should have two listeners.", 2, listeners.size());
+    List<URI> listeners = Application.parseListeners(listenersConfig, -1,
+        ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertEquals(2, listeners.size(), "Should have two listeners.");
     assertExpectedUri(listeners.get(0), "http", "localhost", 123);
     assertExpectedUri(listeners.get(1), "https", "localhost", 124);
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testParseListenersUnparseableUri() {
     List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("!");
-    Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertThrows(ConfigException.class,
+        () ->
+            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+                "http"));
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testParseListenersUnsupportedScheme() {
     List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost:8080");
     listenersConfig.add("foo://localhost:8081");
-    List<URI> listeners = Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertThrows(ConfigException.class,
+        () ->
+            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+                "http"));
   }
 
-  @Test(expected = ConfigException.class)
   public void testParseListenersNoSupportedListeners() {
     List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("foo://localhost:8080");
     listenersConfig.add("bar://localhost:8081");
-    Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertThrows(ConfigException.class,
+        () ->
+            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+                "http"));
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testParseListenersNoPort() {
     List<String> listenersConfig = new ArrayList<>();
     listenersConfig.add("http://localhost");
-    Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+    assertThrows(ConfigException.class,
+        () ->
+            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+                "http"));
   }
 
   @Test
@@ -266,7 +279,7 @@ public class ApplicationTest {
   }
 
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testBearerNoAuthenticator() {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
@@ -277,10 +290,12 @@ public class ApplicationTest {
         return new JAASLoginService("realm");
       }
     };
-    app.createBearerSecurityHandler();
+    assertThrows(UnsupportedOperationException.class,
+        () ->
+            app.createBearerSecurityHandler());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testBearerNoLoginService() {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
@@ -291,20 +306,24 @@ public class ApplicationTest {
         return new BasicAuthenticator();
       }
     };
-    app.createBearerSecurityHandler();
+    assertThrows(UnsupportedOperationException.class,
+        () ->
+            app.createBearerSecurityHandler());
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test
   public void testBearerNoAuthenticatorNoLoginService() {
     final Map<String, Object> config = ImmutableMap.of(
         RestConfig.AUTHENTICATION_METHOD_CONFIG, RestConfig.AUTHENTICATION_METHOD_BEARER);
 
     Application<?> app = new TestApp(config);
-    app.createBearerSecurityHandler();
+    assertThrows(UnsupportedOperationException.class,
+        () ->
+            app.createBearerSecurityHandler());
   }
 
   @Test
-  public void shouldInitializeResourceExtensions()throws Exception {
+  public void shouldInitializeResourceExtensions() throws Exception {
     try (TestApp testApp = new TestApp(TestRegistryExtension.class)) {
       assertThat(makeGetRequest(testApp, "/custom/resource"), is(Code.OK));
     }
@@ -312,12 +331,13 @@ public class ApplicationTest {
 
   @Test
   public void shouldThrowIfResourceExtensionThrows() {
-    Exception e = assertThrows(Exception.class, () -> new TestApp(TestRegistryExtension.class, BadRegistryExtension.class));
+    Exception e = assertThrows(Exception.class,
+        () -> new TestApp(TestRegistryExtension.class, BadRegistryExtension.class));
     assertThat(e.getMessage(), containsString("Exception throw by resource extension. ext:"));
   }
 
   @Test
-  public void shouldCloseResourceExtensions() throws Exception{
+  public void shouldCloseResourceExtensions() throws Exception {
     new TestApp(TestRegistryExtension.class).stop();
     assertThat("close called", TestRegistryExtension.CLOSE_CALLED.get(), is(true));
   }
@@ -335,23 +355,24 @@ public class ApplicationTest {
     TestApp testApp = new TestApp();
 
     assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE),
-            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+        RestConfig.METRICS_JMX_PREFIX_DEFAULT);
     assertEquals(testApp.metricsContext().getLabel(NAMESPACE),
-            RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+        RestConfig.METRICS_JMX_PREFIX_DEFAULT);
   }
 
   @Test
-  public void testMetricsContextResourceOverride() throws Exception  {
+  public void testMetricsContextResourceOverride() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put("metrics.context.resource.type", "FooApp");
 
     TestApp testApp = new TestApp(props);
 
     assertEquals(testApp.metricsContext().getLabel(RESOURCE_LABEL_TYPE), "FooApp");
-    assertEquals(testApp.metricsContext().getLabel(NAMESPACE), RestConfig.METRICS_JMX_PREFIX_DEFAULT);
+    assertEquals(testApp.metricsContext().getLabel(NAMESPACE),
+        RestConfig.METRICS_JMX_PREFIX_DEFAULT);
 
     /* Only NameSpace should be propagated to JMX */
-    String jmx_domain =  RestConfig.METRICS_JMX_PREFIX_DEFAULT;
+    String jmx_domain = RestConfig.METRICS_JMX_PREFIX_DEFAULT;
     String mbean_name = String.format("%s:type=kafka-metrics-count", jmx_domain);
 
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
@@ -370,7 +391,7 @@ public class ApplicationTest {
   }
 
   @Test
-  public void testMetricsContextJMXBeanRegistration() throws Exception  {
+  public void testMetricsContextJMXBeanRegistration() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.METRICS_JMX_PREFIX_CONFIG, "FooApp");
 
@@ -381,9 +402,9 @@ public class ApplicationTest {
   }
 
   private void assertExpectedUri(URI uri, String scheme, String host, int port) {
-    assertEquals("Scheme should be " + scheme, scheme, uri.getScheme());
-    assertEquals("Host should be " + host, host, uri.getHost());
-    assertEquals("Port should be " + port, port, uri.getPort());
+    assertEquals(scheme, uri.getScheme(), "Scheme should be " + scheme);
+    assertEquals(host, uri.getHost(), "Host should be " + host);
+    assertEquals(port, uri.getPort(), "Port should be " + port);
   }
 
   @SuppressWarnings("SameParameterValue")
@@ -455,7 +476,8 @@ public class ApplicationTest {
           .map(Class::getName)
           .collect(Collectors.joining(","));
 
-      return createConfig(Collections.singletonMap(RestConfig.RESOURCE_EXTENSION_CLASSES_CONFIG, extensionList));
+      return createConfig(
+          Collections.singletonMap(RestConfig.RESOURCE_EXTENSION_CLASSES_CONFIG, extensionList));
     }
 
     private static TestRestConfig createConfig(final Map<String, Object> props) {

--- a/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
@@ -16,10 +16,10 @@
 
 package io.confluent.rest;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
 import java.util.Properties;
@@ -32,9 +32,9 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Response;
 
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CsrfHandlingTest {
 
@@ -42,7 +42,7 @@ public class CsrfHandlingTest {
   CsrfApplication app;
   private Server server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty(RestConfig.CSRF_PREVENTION_ENABLED, "true");
@@ -53,7 +53,7 @@ public class CsrfHandlingTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();

--- a/core/src/test/java/io/confluent/rest/CustomInitTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomInitTest.java
@@ -18,8 +18,8 @@ package io.confluent.rest;
 
 import static javax.ws.rs.core.Response.Status.FORBIDDEN;
 import static javax.ws.rs.core.Response.Status.OK;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Collections;
 import java.util.List;
@@ -55,9 +55,9 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
 import org.eclipse.jetty.util.security.Password;
 import org.eclipse.jetty.websocket.jsr356.server.ServerContainer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -70,7 +70,7 @@ public class CustomInitTest {
   private Server server;
   private CloseableHttpClient httpclient;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     httpclient = HttpClients.createDefault();
 
@@ -89,7 +89,7 @@ public class CustomInitTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void cleanup() throws Exception {
     httpclient.close();
     server.stop();

--- a/core/src/test/java/io/confluent/rest/CustomMethodsTest.java
+++ b/core/src/test/java/io/confluent/rest/CustomMethodsTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.rest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Properties;
 import javax.ws.rs.GET;
@@ -28,9 +28,9 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Purpose : To test rest-utils / java.ws.rs code's ability to support
@@ -43,7 +43,7 @@ public class CustomMethodsTest {
   private TestRestConfig config;
   private Server server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty("listeners", "http://localhost:0");
@@ -53,7 +53,7 @@ public class CustomMethodsTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();

--- a/core/src/test/java/io/confluent/rest/DosFilterTest.java
+++ b/core/src/test/java/io/confluent/rest/DosFilterTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.rest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 
@@ -34,11 +34,8 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.eclipse.jetty.server.Server;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
+import org.junit.jupiter.api.Test;
 
-@RunWith(JUnit4.class)
 public class DosFilterTest {
 
   @Test

--- a/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/ExceptionHandlingTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.rest;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -33,9 +33,9 @@ import javax.ws.rs.core.Response;
 
 import io.confluent.rest.exceptions.RestTimeoutException;
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.RestNotFoundException;
@@ -50,7 +50,7 @@ public class ExceptionHandlingTest {
   private Server server;
   private ExceptionApplication application;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty("debug", "false");
@@ -61,7 +61,7 @@ public class ExceptionHandlingTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();

--- a/core/src/test/java/io/confluent/rest/GzipHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/GzipHandlerIntegrationTest.java
@@ -17,9 +17,9 @@
 package io.confluent.rest;
 
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -31,13 +31,13 @@ import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GzipHandlerIntegrationTest {
   private TestRestConfig config;
   private Server server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty("debug", "false");
@@ -49,7 +49,7 @@ public class GzipHandlerIntegrationTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();

--- a/core/src/test/java/io/confluent/rest/Http2Test.java
+++ b/core/src/test/java/io/confluent/rest/Http2Test.java
@@ -28,28 +28,21 @@ import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.http2.client.HTTP2Client;
 import org.eclipse.jetty.http2.client.http.HttpClientTransportOverHTTP2;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
-import org.eclipse.jetty.util.ssl.SslContextFactory.Client;
-
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
-import java.net.SocketException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Properties;
-import java.util.StringTokenizer;
 
 import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -58,10 +51,10 @@ import javax.ws.rs.core.Configurable;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import io.confluent.rest.annotations.PerformanceMetric;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * This test is a bit unusual because of the way that multiple Java versions are handled.
@@ -84,7 +77,7 @@ public class Http2Test {
   private static final String SSL_PASSWORD = "test1234";
   private static final String EXPECTED_200_MSG = "Response status must be 200.";
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     try {
       trustStore = File.createTempFile("Http2Test-truststore", ".jks");
@@ -139,18 +132,18 @@ public class Http2Test {
       // Just skip HTTP/2 for earlier than Java 11
       if (ApplicationServer.isJava11Compatible()) {
         statusCode = makeGetRequestHttp2(HTTP_URI + "/test");
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
         statusCode = makeGetRequestHttp2(HTTPS_URI + "/test",
                                          clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
       }
 
       // HTTP/1.1 should work whether HTTP/2 is available or not
       statusCode = makeGetRequestHttp(HTTP_URI + "/test");
-      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      assertEquals(200, statusCode, EXPECTED_200_MSG);
       statusCode = makeGetRequestHttp(HTTPS_URI + "/test",
                                       clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      assertEquals(200, statusCode, EXPECTED_200_MSG);
       assertMetricsCollected();
     } finally {
       app.stop();
@@ -170,18 +163,18 @@ public class Http2Test {
       // Just skip HTTP/2 for earlier than Java 11
       if (ApplicationServer.isJava11Compatible()) {
         statusCode = makeGetRequestHttp2(HTTP_URI + "/test%2fambiguous%2fsegment");
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
         statusCode = makeGetRequestHttp2(HTTPS_URI + "/test%2fambiguous%2fsegment",
                                          clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
       }
 
       // HTTP/1.1 should work whether HTTP/2 is available or not
       statusCode = makeGetRequestHttp(HTTP_URI + "/test%2fambiguous%2fsegment");
-      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      assertEquals(200, statusCode, EXPECTED_200_MSG);
       statusCode = makeGetRequestHttp(HTTPS_URI + "/test%2fambiguous%2fsegment",
                                       clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-      assertEquals(EXPECTED_200_MSG, 200, statusCode);
+      assertEquals(200, statusCode, EXPECTED_200_MSG);
       assertMetricsCollected();
     } finally {
       app.stop();
@@ -202,7 +195,7 @@ public class Http2Test {
       } catch (java.util.concurrent.ExecutionException exc) {
         // Fall back to HTTP/1.1 once we've seen HTTP/2C fail
         statusCode = makeGetRequestHttp(HTTP_URI + "/test");
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
       }
       assertMetricsCollected();
     } finally {
@@ -226,7 +219,7 @@ public class Http2Test {
         // Fall back to HTTP/1.1 once we've seen HTTP/2 fail
         statusCode = makeGetRequestHttp(HTTPS_URI + "/test",
                                         clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD);
-        assertEquals(EXPECTED_200_MSG, 200, statusCode);
+        assertEquals(200, statusCode, EXPECTED_200_MSG);
       }
       assertMetricsCollected();
     } finally {
@@ -236,20 +229,20 @@ public class Http2Test {
 
   private void assertMetricsCollected() {
     assertNotEquals(
-        "Expected to have metrics.",
         0,
-        TestMetricsReporter.getMetricTimeseries().size());
+        TestMetricsReporter.getMetricTimeseries().size(),
+        "Expected to have metrics.");
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-latency-max")) {
         Object metricValue = metric.metricValue();
         assertTrue(
-            "Request latency metrics should be measurable",
-            metricValue instanceof Double);
+            metricValue instanceof Double,
+            "Request latency metrics should be measurable");
         double latencyMaxValue = (double) metricValue;
         assertNotEquals(
-            "Metrics should be collected (max latency shouldn't be 0)",
             0.0,
-            latencyMaxValue);
+            latencyMaxValue,
+            "Metrics should be collected (max latency shouldn't be 0)");
       }
     }
   }

--- a/core/src/test/java/io/confluent/rest/IdleTimeoutConfigTest.java
+++ b/core/src/test/java/io/confluent/rest/IdleTimeoutConfigTest.java
@@ -1,8 +1,9 @@
 package io.confluent.rest;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import org.eclipse.jetty.server.Server;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,7 +27,7 @@ public class IdleTimeoutConfigTest {
     Server server = new TestApp(config).createServer();
     server.start();
     // then
-    Assert.assertEquals(expectedIdleTimeout, server.getConnectors()[0].getIdleTimeout());
+    assertEquals(expectedIdleTimeout, server.getConnectors()[0].getIdleTimeout());
     server.stop();
   }
 

--- a/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
@@ -20,19 +20,20 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class JsonMappingExceptionMapperTest {
 
   private JsonMappingExceptionMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     mapper = new JsonMappingExceptionMapper();
   }

--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -41,8 +41,8 @@ import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
 import org.apache.kafka.common.errors.UnknownServerException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -55,14 +55,14 @@ import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_BAD_REQUES
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_ERROR_ERROR_CODE;
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_RETRIABLE_ERROR_ERROR_CODE;
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_UNKNOWN_TOPIC_PARTITION_CODE;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class KafkaExceptionMapperTest {
 
   private KafkaExceptionMapper exceptionMapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     exceptionMapper = new KafkaExceptionMapper(null);
   }

--- a/core/src/test/java/io/confluent/rest/ProxyProtocolTest.java
+++ b/core/src/test/java/io/confluent/rest/ProxyProtocolTest.java
@@ -29,9 +29,9 @@ import org.apache.kafka.test.TestSslUtils;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.server.ConnectionFactory;
 import org.eclipse.jetty.server.ProxyConnectionFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLContext;
 import javax.ws.rs.GET;
@@ -60,7 +60,7 @@ public class ProxyProtocolTest {
 
   public static final String SSL_PASSWORD = "test1234";
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     props = new Properties();
     props.setProperty(RestConfig.PROXY_PROTOCOL_ENABLED_CONFIG, "true");
@@ -86,7 +86,7 @@ public class ProxyProtocolTest {
     props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
   }

--- a/core/src/test/java/io/confluent/rest/RestConfigTest.java
+++ b/core/src/test/java/io/confluent/rest/RestConfigTest.java
@@ -1,16 +1,18 @@
 package io.confluent.rest;
 
-import org.eclipse.jetty.server.Server;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-
-import javax.ws.rs.core.Configurable;
 
 import org.apache.kafka.common.config.ConfigException;
 
@@ -24,95 +26,99 @@ public class RestConfigTest {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    Map<String,String> protocolMap = config.getListenerProtocolMap();
-    Assert.assertEquals(0, protocolMap.size());
+    Map<String, String> protocolMap = config.getListenerProtocolMap();
+    assertEquals(0, protocolMap.size());
 
     // LISTENER_PROTOCOL_MAP_CONFIG not set
     props = new HashMap<>();
     config = new RestConfig(RestConfig.baseConfigDef(), props);
     protocolMap = config.getListenerProtocolMap();
-    Assert.assertNotNull(protocolMap);
-    Assert.assertEquals(0, protocolMap.size());
+    assertNotNull(protocolMap);
+    assertEquals(0, protocolMap.size());
 
     // single mapping
     props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http");
     config = new RestConfig(RestConfig.baseConfigDef(), props);
     protocolMap = config.getListenerProtocolMap();
-    Assert.assertEquals(1, protocolMap.size());
-    Assert.assertTrue(protocolMap.containsKey("internal"));
-    Assert.assertEquals("http", protocolMap.get("internal"));
+    assertEquals(1, protocolMap.size());
+    assertTrue(protocolMap.containsKey("internal"));
+    assertEquals("http", protocolMap.get("internal"));
 
     // multiple mappings
     props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http,EXTERNAL:https");
     config = new RestConfig(RestConfig.baseConfigDef(), props);
     protocolMap = config.getListenerProtocolMap();
-    Assert.assertEquals(2, protocolMap.size());
-    Assert.assertTrue(protocolMap.containsKey("internal"));
-    Assert.assertEquals("http", protocolMap.get("internal"));
-    Assert.assertTrue(protocolMap.containsKey("external"));
-    Assert.assertEquals("https", protocolMap.get("external"));
+    assertEquals(2, protocolMap.size());
+    assertTrue(protocolMap.containsKey("internal"));
+    assertEquals("http", protocolMap.get("internal"));
+    assertTrue(protocolMap.containsKey("external"));
+    assertEquals("https", protocolMap.get("external"));
 
     // listener name is a protocol
     props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "http:http,EXTERNAL:https");
     config = new RestConfig(RestConfig.baseConfigDef(), props);
     protocolMap = config.getListenerProtocolMap();
-    Assert.assertEquals(2, protocolMap.size());
-    Assert.assertTrue(protocolMap.containsKey("http"));
-    Assert.assertEquals("http", protocolMap.get("http"));
-    Assert.assertTrue(protocolMap.containsKey("external"));
-    Assert.assertEquals("https", protocolMap.get("external"));
+    assertEquals(2, protocolMap.size());
+    assertTrue(protocolMap.containsKey("http"));
+    assertEquals("http", protocolMap.get("http"));
+    assertTrue(protocolMap.containsKey("external"));
+    assertEquals("https", protocolMap.get("external"));
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testHttpSetToHttps() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "HTTP:https");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    config.getListenerProtocolMap();
-  }  
+    assertThrows(ConfigException.class,
+        () -> config.getListenerProtocolMap());
+  }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testInvalidProtocolMapping() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "internal");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    config.getListenerProtocolMap();
+    assertThrows(ConfigException.class,
+        () -> config.getListenerProtocolMap());
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testInvalidProtocolMappingList() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http;EXTERNAL:https");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    config.getListenerProtocolMap();
+    assertThrows(ConfigException.class,
+        () -> config.getListenerProtocolMap());
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testEmptyProtocolMappingListenerName() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http,:https");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    config.getListenerProtocolMap();
+    assertThrows(ConfigException.class,
+        () -> config.getListenerProtocolMap());
   }
 
-  @Test(expected = ConfigException.class)
+  @Test
   public void testDuplicateProtocolMappingListenerName() {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http,INTERNAL:https");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
-    config.getListenerProtocolMap();
+    assertThrows(ConfigException.class,
+        () -> config.getListenerProtocolMap());
   }
-
 
   // getInstanceConfig tests
 
   public static final String CONFIG_PREFIX = "my.config.prefix.";
   public static final Set<String> EMPTY_LISTENER_NAME_SET = new HashSet<>();
   public static final Set<String> THREE_LISTENER_NAMES_SET =
-                                        new HashSet<>(Arrays.asList("a", "b", "c"));
+      new HashSet<>(Arrays.asList("a", "b", "c"));
 
   @Test
   public void testEmptyProtocolMapNamedInstanceConfig() {
@@ -122,12 +128,12 @@ public class RestConfigTest {
     original.put(CONFIG_PREFIX + "a.bar", "1");
     Map<String, Map<String, Object>> conf =
         RestConfig.getInstanceConfig(CONFIG_PREFIX, EMPTY_LISTENER_NAME_SET, original);
-    Assert.assertEquals(1, conf.size());
+    assertEquals(1, conf.size());
     // application should bind to all listeners.
-    Assert.assertTrue(conf.containsKey(""));
-    Assert.assertEquals(2, conf.get("").size());
-    Assert.assertTrue(conf.get("").containsKey("foo"));
-    Assert.assertTrue(conf.get("").containsKey("a.bar"));
+    assertTrue(conf.containsKey(""));
+    assertEquals(2, conf.get("").size());
+    assertTrue(conf.get("").containsKey("foo"));
+    assertTrue(conf.get("").containsKey("a.bar"));
   }
 
   @Test
@@ -141,27 +147,27 @@ public class RestConfigTest {
     Map<String, Map<String, Object>> conf =
         RestConfig.getInstanceConfig(CONFIG_PREFIX, THREE_LISTENER_NAMES_SET, original);
 
-    Assert.assertEquals(3, conf.size());
-    Assert.assertFalse(conf.containsKey(""));
+    assertEquals(3, conf.size());
+    assertFalse(conf.containsKey(""));
 
-    Assert.assertEquals(2, conf.get("a").size());
-    Assert.assertTrue(conf.get("a").containsKey("foo"));
-    Assert.assertTrue(conf.get("a").containsKey("bar"));
-    Assert.assertFalse(conf.get("a").containsKey("baz"));
-    Assert.assertEquals("1", conf.get("a").get("foo"));
-    Assert.assertEquals("2", conf.get("a").get("bar"));
+    assertEquals(2, conf.get("a").size());
+    assertTrue(conf.get("a").containsKey("foo"));
+    assertTrue(conf.get("a").containsKey("bar"));
+    assertFalse(conf.get("a").containsKey("baz"));
+    assertEquals("1", conf.get("a").get("foo"));
+    assertEquals("2", conf.get("a").get("bar"));
 
-    Assert.assertEquals(1, conf.get("b").size());
-    Assert.assertFalse(conf.get("b").containsKey("foo"));
-    Assert.assertTrue(conf.get("b").containsKey("bar"));
-    Assert.assertFalse(conf.get("b").containsKey("baz"));
-    Assert.assertEquals("3", conf.get("b").get("bar"));
+    assertEquals(1, conf.get("b").size());
+    assertFalse(conf.get("b").containsKey("foo"));
+    assertTrue(conf.get("b").containsKey("bar"));
+    assertFalse(conf.get("b").containsKey("baz"));
+    assertEquals("3", conf.get("b").get("bar"));
 
-    Assert.assertEquals(1, conf.get("c").size());
-    Assert.assertFalse(conf.get("c").containsKey("foo"));
-    Assert.assertFalse(conf.get("c").containsKey("bar"));
-    Assert.assertTrue(conf.get("c").containsKey("baz"));
-    Assert.assertEquals("4", conf.get("c").get("baz"));
+    assertEquals(1, conf.get("c").size());
+    assertFalse(conf.get("c").containsKey("foo"));
+    assertFalse(conf.get("c").containsKey("bar"));
+    assertTrue(conf.get("c").containsKey("baz"));
+    assertEquals("4", conf.get("c").get("baz"));
   }
 
   @Test
@@ -173,17 +179,17 @@ public class RestConfigTest {
     Map<String, Map<String, Object>> conf =
         RestConfig.getInstanceConfig(CONFIG_PREFIX, THREE_LISTENER_NAMES_SET, original);
 
-    Assert.assertEquals(1, conf.size());
-    Assert.assertFalse(conf.containsKey(""));
-    Assert.assertFalse(conf.containsKey("b"));
-    Assert.assertFalse(conf.containsKey("c"));
+    assertEquals(1, conf.size());
+    assertFalse(conf.containsKey(""));
+    assertFalse(conf.containsKey("b"));
+    assertFalse(conf.containsKey("c"));
 
-    Assert.assertEquals(2, conf.get("a").size());
-    Assert.assertTrue(conf.get("a").containsKey("foo"));
-    Assert.assertTrue(conf.get("a").containsKey("bar"));
-    Assert.assertFalse(conf.get("a").containsKey("baz"));
-    Assert.assertEquals("1", conf.get("a").get("foo"));
-    Assert.assertEquals("2", conf.get("a").get("bar"));
+    assertEquals(2, conf.get("a").size());
+    assertTrue(conf.get("a").containsKey("foo"));
+    assertTrue(conf.get("a").containsKey("bar"));
+    assertFalse(conf.get("a").containsKey("baz"));
+    assertEquals("1", conf.get("a").get("foo"));
+    assertEquals("2", conf.get("a").get("bar"));
   }
 
   @Test
@@ -193,8 +199,8 @@ public class RestConfigTest {
     Map<String, Map<String, Object>> conf =
         RestConfig.getInstanceConfig(CONFIG_PREFIX, THREE_LISTENER_NAMES_SET, original);
 
-    Assert.assertEquals(1, conf.size());
-    Assert.assertTrue(conf.containsKey(""));
-    Assert.assertEquals(0, conf.get("").size());
+    assertEquals(1, conf.size());
+    assertTrue(conf.containsKey(""));
+    assertEquals(0, conf.get("").size());
   }
 }

--- a/core/src/test/java/io/confluent/rest/ShutdownTest.java
+++ b/core/src/test/java/io/confluent/rest/ShutdownTest.java
@@ -17,7 +17,7 @@
 package io.confluent.rest;
 
 import org.eclipse.jetty.server.Server;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +33,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Configurable;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ShutdownTest {
   private static final Logger log = LoggerFactory.getLogger(ShutdownTest.class);

--- a/core/src/test/java/io/confluent/rest/StaticResourcesTest.java
+++ b/core/src/test/java/io/confluent/rest/StaticResourcesTest.java
@@ -20,9 +20,9 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceCollection;
 import org.glassfish.jersey.servlet.ServletProperties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
@@ -36,7 +36,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.Response;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class StaticResourcesTest {
 
@@ -46,7 +46,7 @@ public class StaticResourcesTest {
 
   String staticContent;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     try (
         InputStreamReader isr = new InputStreamReader(ClassLoader.getSystemResourceAsStream("static/index.html"), StandardCharsets.UTF_8);
@@ -63,7 +63,7 @@ public class StaticResourcesTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();

--- a/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
+++ b/core/src/test/java/io/confluent/rest/TestCustomizeThreadPool.java
@@ -24,8 +24,8 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.test.TestUtils;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 import java.util.Optional;
@@ -45,8 +45,9 @@ import org.slf4j.LoggerFactory;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestCustomizeThreadPool {
 
@@ -69,11 +70,11 @@ public class TestCustomizeThreadPool {
     } catch (Exception e) {
     } finally {
       log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
-      assertTrue("Total number of running threads is less than maximum number of threads " + app.getServer().getMaxThreads(),
-              app.getServer().getThreads() - app.getServer().getMaxThreads() < 0);
+      assertTrue(app.getServer().getThreads() - app.getServer().getMaxThreads() < 0,
+          "Total number of running threads is less than maximum number of threads " + app.getServer().getMaxThreads());
       log.info("Total jobs in queue {}, capacity of queue {}.", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
-      assertTrue("Total number of jobs in queue is less than capacity of queue " + app.getServer().getQueueCapacity(),
-              app.getServer().getQueueSize() - app.getServer().getQueueCapacity() < 0);
+      assertTrue(app.getServer().getQueueSize() - app.getServer().getQueueCapacity() < 0,
+          "Total number of jobs in queue is less than capacity of queue " + app.getServer().getQueueCapacity());
       app.stop();
     }
   }
@@ -98,8 +99,8 @@ public class TestCustomizeThreadPool {
     } catch (Exception e) {
     } finally {
       log.info("Current running thread {}, maximum thread {}.", app.getServer().getThreads(), app.getServer().getMaxThreads());
-      assertEquals("Total number of running threads reach maximum number of threads.", app.getServer().getMaxThreads(),
-              app.getServer().getThreads());
+      assertEquals(app.getServer().getMaxThreads(), app.getServer().getThreads(),
+          "Total number of running threads reach maximum number of threads.");
       app.stop();
     }
   }
@@ -108,7 +109,6 @@ public class TestCustomizeThreadPool {
    * Simulate the case that the queue of thread pool is full. Http server will reject request if the queue is full and
    * throw RejectedExecutionException.
    **/
-  @Test(expected = RejectedExecutionException.class)
   public void testQueueFull() throws Exception {
     int numOfClients = 1;
     Properties props = new Properties();
@@ -122,14 +122,16 @@ public class TestCustomizeThreadPool {
     String uri = app.getUri();
     try {
       app.start();
-      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app);
+      assertThrows(RejectedExecutionException.class,
+          () ->
+      makeConcurrentGetRequests(uri + "/custom/resource", numOfClients, app));
     } finally {
       app.stop();
     }
   }
 
   @Test
-  @Ignore
+  @Disabled
   public void testJettyThreadPoolMetrics() throws Exception {
     RestResource.latch = new CountDownLatch(1);
     TestCustomizeThreadPoolApplication app = new TestCustomizeThreadPoolApplication();
@@ -188,7 +190,8 @@ public class TestCustomizeThreadPool {
     long startingTime = System.currentTimeMillis();
     while(System.currentTimeMillis() - startingTime < 360*1000) {
       log.info("Queue size {}, queue capacity {} ", app.getServer().getQueueSize(), app.getServer().getQueueCapacity());
-      assertTrue("Number of jobs in queue is not more than capacity of queue ", app.getServer().getQueueSize() <= app.getServer().getQueueCapacity());
+      assertTrue(app.getServer().getQueueSize() <= app.getServer().getQueueCapacity(),
+          "Number of jobs in queue is not more than capacity of queue ");
       Thread.sleep(2000);
       if (app.getServer().getQueueSize() == 0)
         break;

--- a/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/WebApplicationExceptionMapperTest.java
@@ -16,8 +16,8 @@
 
 package io.confluent.rest;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.Properties;
 
@@ -28,13 +28,13 @@ import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.RestException;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class WebApplicationExceptionMapperTest {
 
   private WebApplicationExceptionMapper mapper;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     Properties props = new Properties();
     props.setProperty("debug", "false");

--- a/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
+++ b/core/src/test/java/io/confluent/rest/auth/AuthUtilTest.java
@@ -19,7 +19,6 @@ package io.confluent.rest.auth;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.RestConfig;
 import java.util.Arrays;
@@ -27,14 +26,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.eclipse.jetty.security.ConstraintMapping;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class AuthUtilTest {
 
   private RestConfig config;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     config = restConfigWith(ImmutableMap.of());
   }

--- a/core/src/test/java/io/confluent/rest/filters/CsrfProtectionFilterTest.java
+++ b/core/src/test/java/io/confluent/rest/filters/CsrfProtectionFilterTest.java
@@ -16,7 +16,7 @@
 
 package io.confluent.rest.filters;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.RestConfig;
@@ -27,14 +27,15 @@ import java.util.Map;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
-import org.junit.Before;
-import org.junit.Test;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 public class CsrfProtectionFilterTest {
 
   private CsrfTokenProtectionFilter filter;
 
-  @Before
+  @BeforeEach
   public void setUp() {
     filter = new CsrfTokenProtectionFilter();
   }

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -1,16 +1,15 @@
 package io.confluent.rest.metrics;
 
 import io.confluent.rest.*;
-import java.util.List;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.jersey.server.ServerProperties;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Properties;
@@ -29,7 +28,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.HTTP_STATUS_CODE_TAG;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
@@ -38,7 +37,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   private Server server;
   volatile Throwable handledException = null;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     TestMetricsReporter.reset();
     Properties props = new Properties();
@@ -50,7 +49,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();
@@ -108,9 +107,9 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
         metricsCheckpointWindow++;
         Object metricValue = metric.metricValue();
-        assertTrue("Metrics should be measurable", metricValue instanceof Double);
+        assertTrue(metricValue instanceof Double, "Metrics should be measurable");
         double countValue = (double) metricValue;
-        assertTrue("Actual: " + countValue, countValue == 2.0);
+        assertTrue(countValue == 2.0, "Actual: " + countValue);
       }
     }
     assertEquals(1, metricsCheckpointWindow); //A single metric for the windowed count
@@ -143,15 +142,15 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       if (metric.metricName().name().equals("request-error-rate")) {
         assertTrue(metric.measurable().toString().toLowerCase().startsWith("rate"));
         Object metricValue = metric.metricValue();
-        assertTrue("Error rate metrics should be measurable", metricValue instanceof Double);
+        assertTrue(metricValue instanceof Double, "Error rate metrics should be measurable");
         double errorRateValue = (double) metricValue;
         if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("4xx")) {
           rateCheckpoint4xx++;
-          assertTrue("Actual: " + errorRateValue, errorRateValue > 0);
+          assertTrue(errorRateValue > 0, "Actual: " + errorRateValue);
         } else if (!metric.metricName().tags().isEmpty()) {
           rateCheckpointNot4xx++;
-          assertTrue(String.format("Actual: %f (%s)", errorRateValue, metric.metricName()),
-              errorRateValue == 0.0 || Double.isNaN(errorRateValue));
+          assertTrue(errorRateValue == 0.0 || Double.isNaN(errorRateValue),
+              String.format("Actual: %f (%s)", errorRateValue, metric.metricName()));
         } else {
           anyErrorRateCheckpoint++;
           //average rate is not consistently above 0 here, so not validating
@@ -160,18 +159,19 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       if (metric.metricName().name().equals("request-error-count")) {
         assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
         Object metricValue = metric.metricValue();
-        assertTrue("Error count metrics should be measurable", metricValue instanceof Double);
+        assertTrue(metricValue instanceof Double, "Error count metrics should be measurable");
         double errorCountValue = (double) metricValue;
         if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("4xx")) {
           windowCheckpoint4xx++;
-          assertTrue("Actual: " + errorCountValue, errorCountValue == 2.0);
+          assertTrue(errorCountValue == 2.0, "Actual: " + errorCountValue);
         } else if (!metric.metricName().tags().isEmpty()) {
           windowCheckpointNot4xx++;
-          assertTrue(String.format("Actual: %f (%s)", errorCountValue, metric.metricName()),
-              errorCountValue == 0.0 || Double.isNaN(errorCountValue));
+          assertTrue(
+              errorCountValue == 0.0 || Double.isNaN(errorCountValue),
+              String.format("Actual: %f (%s)", errorCountValue, metric.metricName()));
         } else {
           anyErrorWindowCheckpoint++;
-          assertTrue("Count for all errors actual: " + errorCountValue, errorCountValue == 2.0);
+          assertTrue(errorCountValue == 2.0, "Count for all errors actual: " + errorCountValue);
         }
       }
     }
@@ -197,13 +197,13 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")) {
         Object metricValue = metric.metricValue();
-        assertTrue("Error rate metrics should be measurable", metricValue instanceof Double);
+        assertTrue(metricValue instanceof Double, "Error rate metrics should be measurable");
         double errorRateValue = (double) metricValue;
         if (metric.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("5xx")) {
-          assertTrue("Actual: " + errorRateValue, errorRateValue > 0);
+          assertTrue(errorRateValue > 0, "Actual: " + errorRateValue);
         } else if (!metric.metricName().tags().isEmpty()) {
-          assertTrue(String.format("Actual: %f (%s)", errorRateValue, metric.metricName()),
-              errorRateValue == 0.0 || Double.isNaN(errorRateValue));
+          assertTrue(errorRateValue == 0.0 || Double.isNaN(errorRateValue),
+              String.format("Actual: %f (%s)", errorRateValue, metric.metricName()));
         }
       }
     }

--- a/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/RequestScopedMetricsIntegrationTest.java
@@ -1,10 +1,10 @@
 package io.confluent.rest.metrics;
 
 import org.eclipse.jetty.server.Server;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.experimental.categories.Category;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -19,13 +19,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
-import io.confluent.common.utils.IntegrationTest;
 import io.confluent.rest.Application;
 import io.confluent.rest.TestRestConfig;
 import io.confluent.rest.annotations.PerformanceMetric;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class RequestScopedMetricsIntegrationTest {
 
@@ -33,7 +32,7 @@ public class RequestScopedMetricsIntegrationTest {
   SimpleApplication app;
   private Server server;
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty("debug", "false");
@@ -43,14 +42,14 @@ public class RequestScopedMetricsIntegrationTest {
     server.start();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     server.stop();
     server.join();
   }
 
   @Test
-  @Category(IntegrationTest.class)
+  @Tag("IntegrationTest")
   public void testRequestScopedMetricsCreateAndLookup() throws InterruptedException {
     int numMetrics = app.numMetrics();
 
@@ -66,8 +65,9 @@ public class RequestScopedMetricsIntegrationTest {
     // finish.
     Thread.sleep(500);
 
-    assertTrue("numMetrics=" + numMetrics + ", app.numMetrics=" + app.numMetrics(),
-        numMetrics < app.numMetrics());
+    assertTrue(
+        numMetrics < app.numMetrics(),
+        "numMetrics=" + numMetrics + ", app.numMetrics=" + app.numMetrics());
     numMetrics = app.numMetrics();
 
     // this request should reuse the previously created metrics
@@ -77,8 +77,9 @@ public class RequestScopedMetricsIntegrationTest {
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();
     assertEquals(200, response.getStatus());
-    assertEquals("numMetrics=" + numMetrics + ", app.numMetrics=" + app.numMetrics(), numMetrics,
-        app.numMetrics());
+    assertEquals(numMetrics,
+        app.numMetrics(),
+        "numMetrics=" + numMetrics + ", app.numMetrics=" + app.numMetrics());
   }
 
   public class SimpleApplication extends Application<TestRestConfig> {

--- a/core/src/test/java/io/confluent/rest/metrics/RestMetricsContextTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/RestMetricsContextTest.java
@@ -19,14 +19,14 @@ package io.confluent.rest.metrics;
 import static io.confluent.rest.metrics.TestRestMetricsContext.RESOURCE_LABEL_TYPE;
 import static org.apache.kafka.clients.CommonClientConfigs.METRICS_CONTEXT_PREFIX;
 import static org.apache.kafka.common.metrics.MetricsContext.NAMESPACE;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import io.confluent.rest.RestConfig;
 import io.confluent.rest.TestRestConfig;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class RestMetricsContextTest {
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -38,6 +38,12 @@
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/examples/src/test/java/io/confluent/rest/examples/HelloWorldResourceTest.java
+++ b/examples/src/test/java/io/confluent/rest/examples/HelloWorldResourceTest.java
@@ -15,7 +15,7 @@
  */
 package io.confluent.rest.examples;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.ws.rs.core.Response;
 
@@ -25,7 +25,7 @@ import io.confluent.rest.examples.helloworld.HelloWorldApplication;
 import io.confluent.rest.examples.helloworld.HelloWorldRestConfig;
 import io.confluent.rest.examples.helloworld.HelloWorldResource;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * This tests a single resource by setting up a Jersey-based test server embedded in the application.

--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,17 @@
                 <artifactId>jersey-test-framework-provider-jetty</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.jupiter.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -22,17 +22,22 @@
             <version>${io.confluent.rest-utils.version}</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-core</artifactId>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-jetty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/test/src/main/java/io/confluent/rest/EmbeddedServerTestHarness.java
+++ b/test/src/main/java/io/confluent/rest/EmbeddedServerTestHarness.java
@@ -20,8 +20,8 @@ import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
 import org.glassfish.jersey.test.jetty.JettyTestContainerFactory;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.AfterEach;
 
 import javax.ws.rs.client.Invocation;
 import javax.ws.rs.core.Application;
@@ -99,7 +99,7 @@ public abstract class
     }
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     try {
       app = createApplication();
@@ -112,7 +112,7 @@ public abstract class
     getJerseyTest().setUp();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     test.tearDown();
     test = null;


### PR DESCRIPTION
Move to junit 5 only so that I can move kafka-rest to junit 5 (and that's because I need to move ce-kafka-rest to junit 5 only to address some failing tests caused by dependency mistmatches)

Downstream validation passes - eg https://jenkins.confluent.io/job/confluentinc-pr/job/rest-utils/job/PR-303/