### PR TITLE
MMA-11468: Add option to enable nosniff protection

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -348,6 +348,12 @@ public abstract class Application<T extends RestConfig> {
       context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
     }
 
+    if (isNoSniffProtectionEnabled()) {
+      FilterHolder filterHolder = new FilterHolder(new HeaderFilter());
+      filterHolder.setInitParameter("headerConfig", "set X-Content-Type-Options: nosniff");
+      context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+    }
+
     if (config.getString(RestConfig.RESPONSE_HTTP_HEADERS_CONFIG) != null
             && !config.getString(RestConfig.RESPONSE_HTTP_HEADERS_CONFIG).isEmpty()) {
       configureHttpResponseHeaderFilter(context);
@@ -416,6 +422,10 @@ public abstract class Application<T extends RestConfig> {
 
   private boolean isCsrfProtectionEnabled() {
     return config.getBoolean(RestConfig.CSRF_PREVENTION_ENABLED);
+  }
+
+  private boolean isNoSniffProtectionEnabled() {
+    return config.getBoolean(RestConfig.NOSNIFF_PROTECTION_ENABLED);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -345,6 +345,12 @@ public class RestConfig extends AbstractConfig {
   public static final boolean CSRF_PREVENTION_ENABLED_DEFAULT = false;
   protected static final String CSRF_PREVENTION_ENABLED_DOC = "Enable token based CSRF prevention";
 
+  public static final String NOSNIFF_PROTECTION_ENABLED = "nosniff.prevention.enable";
+  public static final boolean NOSNIFF_PROTECTION_ENABLED_DEFAULT = false;
+  protected static final String NOSNIFF_PROTECTION_ENABLED_DOC =
+          "Enable response to request be blocked due to nosniff. The header allows you to avoid "
+          + "MIME type sniffing by saying that the MIME types are deliberately configured.";
+
   public static final String CSRF_PREVENTION_TOKEN_FETCH_ENDPOINT =
       "csrf.prevention.token.endpoint";
   public static final String CSRF_PREVENTION_TOKEN_FETCH_ENDPOINT_DEFAULT = "/csrf";
@@ -941,6 +947,12 @@ public class RestConfig extends AbstractConfig {
             PROXY_PROTOCOL_ENABLED_DEFAULT,
             Importance.LOW,
             PROXY_PROTOCOL_ENABLED_DOC
+        ).define(
+            NOSNIFF_PROTECTION_ENABLED,
+            Type.BOOLEAN,
+            NOSNIFF_PROTECTION_ENABLED_DEFAULT,
+            Importance.LOW,
+            NOSNIFF_PROTECTION_ENABLED_DOC
         );
   }
 


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/MMA-11468

**What**
In general, we need to ensure that Content-Type response header is set correctly for ALL response types along with X-Content-Type-Options: nosniff header. Setting correct values for Content-Type along with X-Content-Type-Options: nosniff header helps to defend against attacks based on MIME sniffing in browser and helps in triggering default protections in browsers against side-channel attacks like Spectre. 