### PR TITLE
Remove Redundant Netty Definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,6 @@
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>30.1.1-jre</guava.version>
-        <netty.version>4.1.68.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
- 5.4.x: https://github.com/confluentinc/common/blob/5.4.x/pom.xml#L83
- 5.5.x: https://github.com/confluentinc/common/blob/5.5.x/pom.xml#L84
- 6.0.x: https://github.com/confluentinc/common/blob/6.0.x/pom.xml#L88
- 6.1.x: https://github.com/confluentinc/common/blob/6.1.x/pom.xml#L88
- 6.2.x: https://github.com/confluentinc/common/blob/6.2.x/pom.xml#L88
- 7.0.x: https://github.com/confluentinc/common/blob/7.0.x/pom.xml#L88
- 7.1.x: https://github.com/confluentinc/common/blob/7.1.x/pom.xml#L89
- master:https://github.com/confluentinc/common/blob/master/pom.xml#L89

Its version has already been defined in common, which is parent for rest-utils. This will save future work on fixing netty versions.
