### PR TITLE
KREST-3660 Remove junit 4 dependencies that come in via jersey test

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.containers</groupId>
             <artifactId>jersey-container-servlet</artifactId>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.inject</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.35</jersey.version>
+        <jersey.version>2.34</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
-        <jersey.version>2.34</jersey.version>
+        <jersey.version>2.35</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
@@ -87,6 +87,12 @@
                 <groupId>org.glassfish.jersey.containers</groupId>
                 <artifactId>jersey-container-servlet</artifactId>
                 <version>${jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <!-- Jersey dependency that was available in the JDK before Java 9 -->
             <dependency>
@@ -221,11 +227,23 @@
                 <groupId>org.glassfish.jersey.test-framework</groupId>
                 <artifactId>jersey-test-framework-core</artifactId>
                 <version>${jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.test-framework.providers</groupId>
                 <artifactId>jersey-test-framework-provider-jetty</artifactId>
                 <version>${jersey.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>junit</groupId>
+                        <artifactId>junit</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.junit.jupiter</groupId>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -24,6 +24,13 @@
         <dependency>
             <groupId>org.glassfish.jersey.test-framework</groupId>
             <artifactId>jersey-test-framework-core</artifactId>
+            <version>${jersey.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>


### PR DESCRIPTION
Running mvn dependency:tree shows that jersey pulls in junit 4.

There's no version of jersey that ships junit 5, but compatibility for using it came in at jersey 2.35, so I've updated the version and excluded junit4

https://github.com/eclipse-ee4j/jersey/pull/4824
