### PR TITLE
APPSEC-725:Override netty in 7.1.x only

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,6 +16,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.websocket</groupId>
             <artifactId>javax-websocket-server-impl</artifactId>
         </dependency>


### PR DESCRIPTION
This is to override the netty version of two packages: 
-  io.netty:netty-codec
-  io.netty:netty-codec-http

This is to resolve CVEs:

- [CVE-2021-37136](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37136)
- [CVE-2021-37137](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-37136)
- CVE-2021-43797

These were packaged into confluent-security-plugins. 
