### PR TITLE
KREST-3446 ensure there is always a minimum value for the thread pool queue

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -71,6 +71,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   private final List<Application<?>> applications;
   private final SslContextFactory sslContextFactory;
 
+  private static int threadPoolRequestQueueCapacity;
+
   private List<NetworkTrafficServerConnector> connectors = new ArrayList<>();
 
   private static final Logger log = LoggerFactory.getLogger(ApplicationServer.class);
@@ -573,7 +575,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
    * @return the capacity of the queue in the pool.
    */
   public int getQueueCapacity() {
-    return config.getInt(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG);
+    return threadPoolRequestQueueCapacity;
   }
 
   static Handler wrapWithGzipHandler(RestConfig config, Handler handler) {
@@ -603,8 +605,16 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     log.info("Initial capacity {}, increased by {}, maximum capacity {}.",
             initialCapacity, growBy, maxCapacity);
 
+    if (initialCapacity > maxCapacity) {
+      threadPoolRequestQueueCapacity = Math.max(initialCapacity, 8) * 1024;
+      log.warn("request.queue.capacity is less than request.queue.capacity.init, invalid config. "
+          + "Setting request.queue.capacity to at least 1024 * request.queue.capacity.init.");
+    } else {
+      threadPoolRequestQueueCapacity = maxCapacity;
+    }
+
     BlockingQueue<Runnable> requestQueue =
-            new BlockingArrayQueue<>(initialCapacity, growBy, maxCapacity);
+            new BlockingArrayQueue<>(initialCapacity, growBy, threadPoolRequestQueueCapacity);
     
     return new QueuedThreadPool(config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG),
             config.getInt(RestConfig.THREAD_POOL_MIN_CONFIG),

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -71,7 +71,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   private final List<Application<?>> applications;
   private final SslContextFactory sslContextFactory;
 
-  private static volatile  int threadPoolRequestQueueCapacity;
+  private static volatile int threadPoolRequestQueueCapacity;
 
   private List<NetworkTrafficServerConnector> connectors = new ArrayList<>();
 

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -71,7 +71,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   private final List<Application<?>> applications;
   private final SslContextFactory sslContextFactory;
 
-  private static int threadPoolRequestQueueCapacity;
+  private static volatile  int threadPoolRequestQueueCapacity;
 
   private List<NetworkTrafficServerConnector> connectors = new ArrayList<>();
 
@@ -606,9 +606,9 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
             initialCapacity, growBy, maxCapacity);
 
     if (initialCapacity > maxCapacity) {
-      threadPoolRequestQueueCapacity = Math.max(initialCapacity, 8) * 1024;
+      threadPoolRequestQueueCapacity = initialCapacity;
       log.warn("request.queue.capacity is less than request.queue.capacity.init, invalid config. "
-          + "Setting request.queue.capacity to at least 1024 * request.queue.capacity.init.");
+          + "Setting request.queue.capacity to request.queue.capacity.init.");
     } else {
       threadPoolRequestQueueCapacity = maxCapacity;
     }

--- a/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
@@ -250,7 +250,7 @@ public class ApplicationServerTest {
 
     ApplicationServer applicationServer = new ApplicationServer(config);
     applicationServer.start();
-    assertEquals( 1024*9, applicationServer.getQueueCapacity());
+    assertEquals( 9, applicationServer.getQueueCapacity());
     applicationServer.stop();
 
   }

--- a/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
@@ -41,7 +41,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class ApplicationServerTest {
@@ -238,6 +237,22 @@ public class ApplicationServerTest {
 
     assertNull(namedListeners.get(1).getName());
     assertEquals(new URI("https://0.0.0.0:443"), namedListeners.get(1).getUri());
+  }
+
+  @Test
+  public void testInvalidThreadPoolConfigQueueCapacityValid() throws Exception {
+    Map<String, Object> props = new HashMap<>();
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_CONFIG, "1");
+    props.put(RestConfig.REQUEST_QUEUE_CAPACITY_INITIAL_CONFIG, "9");
+    RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
+
+    server.stop();
+
+    ApplicationServer applicationServer = new ApplicationServer(config);
+    applicationServer.start();
+    assertEquals( 1024*9, applicationServer.getQueueCapacity());
+    applicationServer.stop();
+
   }
 
   // There is additional testing of parseListeners in ApplictionTest

--- a/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
@@ -250,7 +250,7 @@ public class ApplicationServerTest {
 
     ApplicationServer applicationServer = new ApplicationServer(config);
     applicationServer.start();
-    assertEquals( 9, applicationServer.getQueueCapacity());
+    assertEquals(9, applicationServer.getQueueCapacity());
     applicationServer.stop();
 
   }


### PR DESCRIPTION
This minimum calculation is copied for the jetty code which uses the same formula when no request queue is configured (which is actually the recommened way of starting up the application).