### PR TITLE
KREST-4958 Update codeowners to also include kafka-rest

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @confluentinc/cloud-foundations
+* @confluentinc/kafka-rest-eng


### PR DESCRIPTION
The official owners of rest-utils are cloud-foundations, however kafka-rest make many changes in this repo too, and have a good understanding of what's OK to PR and what isn't.

At the moment we need the cloud-foundations team to sign off any changes we make, I think kafka-rest need this ability too.

Updating codeowners file.