### PR TITLE
KREST-4450 500 error when topic not present

### DIFF
--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -35,6 +35,7 @@ import org.apache.kafka.common.errors.NotEnoughReplicasException;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.errors.SecurityDisabledException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
@@ -55,6 +56,7 @@ import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_BAD_REQUES
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_ERROR_ERROR_CODE;
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_RETRIABLE_ERROR_ERROR_CODE;
 import static io.confluent.rest.exceptions.KafkaExceptionMapper.KAFKA_UNKNOWN_TOPIC_PARTITION_CODE;
+import static io.confluent.rest.exceptions.KafkaExceptionMapper.TOPIC_NOT_FOUND_ERROR_CODE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -123,6 +125,10 @@ public class KafkaExceptionMapperTest {
         KAFKA_RETRIABLE_ERROR_ERROR_CODE);
     verifyMapperResponse(new NotEnoughReplicasException("some message"), Status.INTERNAL_SERVER_ERROR,
         KAFKA_RETRIABLE_ERROR_ERROR_CODE);
+    //Including the special case of a topic not being present (eg because it's not been defined yet)
+    //not returning a 500 error
+    verifyMapperResponse(new TimeoutException("Topic topic1 not present in metadata "
+        + "after 60000 ms."), Status.NOT_FOUND, TOPIC_NOT_FOUND_ERROR_CODE);
 
     //test couple of kafka exception
     verifyMapperResponse(new CommitFailedException(), Status.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
This is a user error - they've specified a topic that doesn't exist, not a server error

So the return code should be a 4xx variant, not a 5xx variant.

Tested in a running kafka-rest

< HTTP/1.1 200 OK
< Date: Thu, 14 Apr 2022 12:41:17 GMT
< Content-Type: application/json
< Vary: Accept-Encoding, User-Agent
< Transfer-Encoding: chunked
<
{"error_code":40401,"message":"Topic eric not present in metadata after 60000 ms."}
* Connection #0 to host localhost left intact
* Closing connection 0