### PR TITLE
Switch from confluent-log4j to reload4j 

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -210,13 +210,13 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <artifactId>logredactor</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -213,7 +213,6 @@
             <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>logredactor</artifactId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -31,12 +31,11 @@
 
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
+            <artifactId>logredactor</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>


### PR DESCRIPTION
### What
Switch from confluent-log4j to reload4j. Used https://github.com/confluentinc/ksql/pull/9065/files as an example.

### Testing
```
➜  rest-utils git:(fix-slf4j-log4j123) mvn dependency:tree -Dincludes=org.slf4j:slf4j-log4j12
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: x86_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 10.15
[INFO] os.detected.version.major: 10
[INFO] os.detected.version.minor: 15
[INFO] os.detected.classifier: osx-x86_64
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO] 
[INFO] rest-utils-parent                                                  [pom]
[INFO] rest-utils                                                         [jar]
[INFO] rest-utils-test                                                    [jar]
[INFO] rest-utils-example                                                 [jar]
[INFO] rest-utils-package                                                 [pom]
[INFO] 
[INFO] -------------------< io.confluent:rest-utils-parent >-------------------
[INFO] Building rest-utils-parent 7.2.0-0                                 [1/5]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ rest-utils-parent ---
[INFO] 
[INFO] ----------------------< io.confluent:rest-utils >-----------------------
[INFO] Building rest-utils 7.2.0-0                                        [2/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ rest-utils ---
[INFO] 
[INFO] --------------------< io.confluent:rest-utils-test >--------------------
[INFO] Building rest-utils-test 7.2.0-0                                   [3/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ rest-utils-test ---
[INFO] 
[INFO] ------------------< io.confluent:rest-utils-examples >------------------
[INFO] Building rest-utils-example 7.2.0-0                                [4/5]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ rest-utils-examples ---
[INFO] 
[INFO] ------------------< io.confluent:rest-utils-package >-------------------
[INFO] Building rest-utils-package 7.2.0-0                                [5/5]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- maven-dependency-plugin:3.2.0:tree (default-cli) @ rest-utils-package ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for rest-utils-parent 7.2.0-0:
[INFO] 
[INFO] rest-utils-parent .................................. SUCCESS [  0.584 s]
[INFO] rest-utils ......................................... SUCCESS [  0.270 s]
[INFO] rest-utils-test .................................... SUCCESS [  0.054 s]
[INFO] rest-utils-example ................................. SUCCESS [  0.033 s]
[INFO] rest-utils-package ................................. SUCCESS [  0.023 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.444 s
[INFO] Finished at: 2022-05-09T10:42:17-07:00
[INFO] ------------------------------------------------------------------------
```