### PR TITLE
MMA-11901: Suppress json parse error if debug config is disabled

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -19,6 +19,7 @@ package io.confluent.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
+import io.confluent.rest.exceptions.SuppressedJsonParseExceptionMapper;
 import org.apache.kafka.common.config.ConfigException;
 import org.eclipse.jetty.jaas.JAASLoginService;
 import org.eclipse.jetty.security.ConstraintMapping;
@@ -497,7 +498,7 @@ public abstract class Application<T extends RestConfig> {
   public void configureBaseApplication(Configurable<?> config, Map<String, String> metricTags) {
     T restConfig = getConfiguration();
 
-    registerJsonProvider(config, restConfig, true);
+    registerJsonProvider(config, restConfig, restConfig.getBoolean(RestConfig.DEBUG_CONFIG));
     registerFeatures(config, restConfig);
     registerExceptionMappers(config, restConfig);
 
@@ -526,6 +527,8 @@ public abstract class Application<T extends RestConfig> {
     config.register(jsonProvider);
     if (registerExceptionMapper) {
       config.register(JsonParseExceptionMapper.class);
+    } else {
+      config.register(SuppressedJsonParseExceptionMapper.class);
     }
   }
 

--- a/core/src/main/java/io/confluent/rest/exceptions/SuppressedJsonParseExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/SuppressedJsonParseExceptionMapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.exceptions;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+
+public class SuppressedJsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
+  public SuppressedJsonParseExceptionMapper() {}
+
+  public Response toResponse(JsonParseException exception) {
+    return Response.status(Status.BAD_REQUEST)
+        .entity("Error parsing JSON")
+        .type("text/plain")
+        .build();
+  }
+}


### PR DESCRIPTION
Jira: https://confluentinc.atlassian.net/browse/MMA-11901

What
Rather than creating a new flag, this change piggybacks on the existing `debug` config to suppress the JSON parsing error message. We replace the actual message with a generic `Error parsing JSON` text.