### PR TITLE
KREST-4977 Allow limiting the number of active connections.

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -28,6 +28,8 @@ import org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory;
 import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
 import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.server.ConnectionFactory;
+import org.eclipse.jetty.server.ConnectionLimit;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.HttpConnectionFactory;
@@ -112,6 +114,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
     this.sslContextFactory = createSslContextFactory(config);
     configureConnectors(sslContextFactory);
+    configureConnectionLimits();
   }
 
   static NamedURI constructNamedURI(
@@ -535,6 +538,17 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     }
 
     return connectionFactories.toArray(new ConnectionFactory[0]);
+  }
+
+  private void configureConnectionLimits() {
+    int serverConnectionLimit = config.getServerConnectionLimit();
+    if (serverConnectionLimit > 0) {
+      addBean(new ConnectionLimit(serverConnectionLimit, getServer()));
+    }
+    int connectorConnectionLimit = config.getConnectorConnectionLimit();
+    if (connectorConnectionLimit > 0) {
+      addBean(new ConnectionLimit(connectorConnectionLimit, connectors.toArray(new Connector[0])));
+    }
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -440,6 +440,26 @@ public class RestConfig extends AbstractConfig {
           + "Default is false.";
   private static final boolean DOS_FILTER_MANAGED_ATTR_DEFAULT = false;
 
+  private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";
+  private static final String SERVER_CONNECTION_LIMIT_DOC =
+      "Limits the number of active connections on that server to the configured number. Once that "
+          + "limit is reached further connections will not be accepted until the number of active "
+          + "connections goes below that limit again. Active connections here means all already "
+          + "opened connections plus all connections that are in the process of being accepted. "
+          + "If the limit is set to a non-positive number, no limit is applied. Default is 0.";
+  private static final int SERVER_CONNECTION_LIMIT_DEFAULT = 0;
+
+  // For rest-utils applications connectors correspond to configured listeners. See
+  // ApplicationServer#parseListeners for more details.
+  private static final String CONNECTOR_CONNECTION_LIMIT = "connector.connection.limit";
+  private static final String CONNECTOR_CONNECTION_LIMIT_DOC =
+      "Limits the number of active connections per connector to the configured number. Once that "
+          + "limit is reached further connections will not be accepted until the number of active "
+          + "connections goes below that limit again. Active connections here means all already "
+          + "opened connections plus all connections that are in the process of being accepted. "
+          + "If the limit is set to a non-positive number, no limit is applied. Default is 0.";
+  private static final int CONNECTOR_CONNECTION_LIMIT_DEFAULT = 0;
+
   public static final String HTTP2_ENABLED_CONFIG = "http2.enabled";
   protected static final String HTTP2_ENABLED_DOC =
       "If true, enable HTTP/2 connections. Connections will default to HTTP/2 not HTTP/1.1 "
@@ -919,6 +939,18 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_MANAGED_ATTR_DOC
         ).define(
+            SERVER_CONNECTION_LIMIT,
+            Type.INT,
+            SERVER_CONNECTION_LIMIT_DEFAULT,
+            Importance.LOW,
+            SERVER_CONNECTION_LIMIT_DOC
+        ).define(
+            CONNECTOR_CONNECTION_LIMIT,
+            Type.INT,
+            CONNECTOR_CONNECTION_LIMIT_DEFAULT,
+            Importance.LOW,
+            CONNECTOR_CONNECTION_LIMIT_DOC
+        ).define(
             HTTP2_ENABLED_CONFIG,
             Type.BOOLEAN,
             HTTP2_ENABLED_DEFAULT,
@@ -1062,6 +1094,14 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getDosFilterManagedAttr() {
     return getBoolean(DOS_FILTER_MANAGED_ATTR_CONFIG);
+  }
+
+  public final int getServerConnectionLimit() {
+    return getInt(SERVER_CONNECTION_LIMIT);
+  }
+
+  public final int getConnectorConnectionLimit() {
+    return getInt(CONNECTOR_CONNECTION_LIMIT);
   }
 
   public final Map<String, String> getMap(String propertyName) {

--- a/core/src/test/java/io/confluent/rest/ConnectionLimitTest.java
+++ b/core/src/test/java/io/confluent/rest/ConnectionLimitTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
+import java.net.URI;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.core.UriBuilder;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.eclipse.jetty.server.Server;
+import org.junit.jupiter.api.Test;
+
+public class ConnectionLimitTest {
+
+  @Test
+  public void testServerConnectionLimitEnabled() throws Exception {
+    int serverConnectionLimit = 5;
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.of(
+                    "listeners", "http://localhost:0",
+                    "server.connection.limit", Integer.toString(serverConnectionLimit))));
+    Server server = application.createServer();
+    server.start();
+
+    Queue<CloseableHttpClient> activeClients = new LinkedList<>();
+    // Reach the connection limit by sending a specific number requests without closing the
+    // underlying clients.
+    for (int i = 0; i < serverConnectionLimit; i++) {
+      CloseableHttpResponse response = sendCloseableRequest(server.getURI(), activeClients);
+      assertEquals(Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+      // The next request should time out as the connection limit should prevent establishing a new
+      // connection.
+      executor.submit(() ->
+          sendCloseableRequest(server.getURI(), activeClients)).get(1, TimeUnit.SECONDS);
+      fail();
+    } catch (Exception e) {
+      assertTrue(e instanceof TimeoutException);
+    }
+
+    // Make space for a new connection by closing one of the active ones.
+    activeClients.remove().close();
+
+    // The next request should succeed now.
+    Future<CloseableHttpResponse> future =
+        executor.submit(() -> sendCloseableRequest(server.getURI(), activeClients));
+    CloseableHttpResponse response = future.get(1, TimeUnit.SECONDS);
+    assertEquals(Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
+
+    // Clean up.
+    executor.shutdown();
+    for (CloseableHttpClient client : activeClients) {
+      client.close();
+    }
+    server.stop();
+  }
+
+  @Test
+  public void testServerConnectionLimitDisabled() throws Exception {
+    int serverConnectionLimit = 0;
+    FooApplication application =
+        new FooApplication(
+            new FooConfig(
+                ImmutableMap.of(
+                    "listeners", "http://localhost:0",
+                    "server.connection.limit", Integer.toString(serverConnectionLimit))));
+    Server server = application.createServer();
+    server.start();
+
+    Queue<CloseableHttpClient> activeClients = new LinkedList<>();
+    // No connection limit, so a lot of requests can be sent even without closing the underlying
+    // clients.
+    for (int i = 0; i < 100; i++) {
+      CloseableHttpResponse response = sendCloseableRequest(server.getURI(), activeClients);
+      assertEquals(Status.OK.getStatusCode(), response.getStatusLine().getStatusCode());
+    }
+
+    // Clean up.
+    for (CloseableHttpClient client : activeClients) {
+      client.close();
+    }
+    server.stop();
+  }
+
+  private static CloseableHttpResponse sendCloseableRequest(
+      URI serverUri,
+      Queue<CloseableHttpClient> activeConnectionClients) throws IOException {
+    CloseableHttpClient client = HttpClients.custom()
+        .setConnectionManager(new PoolingHttpClientConnectionManager())
+        .setKeepAliveStrategy((httpResponse, httpContext) -> -1)
+        .build();
+    activeConnectionClients.offer(client);
+    HttpGet get = new HttpGet(UriBuilder.fromUri(serverUri).path("/foo").build());
+    return client.execute(get);
+  }
+
+  public static final class FooApplication extends Application<FooConfig> {
+
+    public FooApplication(FooConfig config) {
+      super(config);
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, FooConfig appConfig) {
+      config.register(FooResource.class);
+    }
+  }
+
+  public static final class FooConfig extends RestConfig {
+
+    public FooConfig(Map<String, String> configs) {
+      super(baseConfigDef(), configs);
+    }
+  }
+
+  @Path("/foo")
+  public static final class FooResource {
+
+    @GET
+    public String getFoo() {
+      return "bar";
+    }
+  }
+}


### PR DESCRIPTION
This change enables configurable on startup connection limiting per server and per connector based on Jetty's `ConnectionLimit` listener (see its [Javadoc](https://www.eclipse.org/jetty/javadoc/jetty-9/org/eclipse/jetty/server/ConnectionLimit.html) and [this Jetty issue about its usage](https://github.com/eclipse/jetty.project/issues/2501#issue-319785646)).

That mechanism allows limiting the number of active connections (already opened + currently being opened) connections as with long-running connections, like with Kafka REST's Produce v3 streams, rate limits don't guarantee that we won't have an accumulation of connections past what the server can withstand.

This has been tested locally via the aforementioned Kafka REST Produce v3 streams.
After setting `server.connection.limit=3` and opening 3 Produce v3 streams, a subsequent Get Topics call did not establish a connection until the first opened Produce v3 stream timed out.
In the command output below notice the `Time Spent` column, indicating that this call took slightly less than the 30 second timeout which killed the first Produce v3 stream and opened a space for a new connection:
```
ddimitrov@maconfluent kafka-rest % curl http://localhost:8082/v3/clusters/lkc-kjg39m/topics/ | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   121    0   121    0     0      4      0 --:--:--  0:00:26 --:--:--    27
{
  "kind": "KafkaTopicList",
  "metadata": {
    "self": "http://localhost:8082/v3/clusters/lkc-kjg39m/topics",
    "next": null
  },
  "data": []
}
```