### PR TITLE
ErrorHandler to suppress the default Jetty behavior of printing full stacktraces for 500s

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -308,7 +308,7 @@ public abstract class Application<T extends RestConfig> {
       context.setBaseResource(staticResources);
     }
 
-    if (isErrorHandlingEnabled()) {
+    if (isErrorStackTraceSuppressionEnabled()) {
       context.setErrorHandler(new NoJettyDefaultStackTraceErrorHandler());
     }
 
@@ -432,7 +432,7 @@ public abstract class Application<T extends RestConfig> {
     return config.getBoolean(RestConfig.CSRF_PREVENTION_ENABLED);
   }
 
-  private boolean isErrorHandlingEnabled() {
+  private boolean isErrorStackTraceSuppressionEnabled() {
     return config.getBoolean(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE);
   }
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -19,6 +19,7 @@ package io.confluent.rest;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
+import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -307,6 +308,10 @@ public abstract class Application<T extends RestConfig> {
       context.setBaseResource(staticResources);
     }
 
+    if (isErrorHandlingEnabled()) {
+      context.setErrorHandler(new NoJettyDefaultStackTraceErrorHandler());
+    }
+
     configureSecurityHandler(context);
 
     if (isCorsEnabled()) {
@@ -425,6 +430,10 @@ public abstract class Application<T extends RestConfig> {
 
   private boolean isCsrfProtectionEnabled() {
     return config.getBoolean(RestConfig.CSRF_PREVENTION_ENABLED);
+  }
+
+  private boolean isErrorHandlingEnabled() {
+    return config.getBoolean(RestConfig.ERROR_HANDLING_ENABLED_CONFIG);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -433,7 +433,7 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private boolean isErrorHandlingEnabled() {
-    return config.getBoolean(RestConfig.ERROR_HANDLING_ENABLED_CONFIG);
+    return config.getBoolean(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -228,7 +228,7 @@ public class RestConfig extends AbstractConfig {
   @Deprecated
   public static final String SSL_CLIENT_AUTH_CONFIG = "ssl.client.auth";
   protected static final String SSL_CLIENT_AUTH_DOC =
-      "Whether or not to require the https client to authenticate via the server's trust store. " 
+      "Whether or not to require the https client to authenticate via the server's trust store. "
           + "Deprecated; please use " + SSL_CLIENT_AUTHENTICATION_CONFIG + " instead.";
   protected static final boolean SSL_CLIENT_AUTH_DEFAULT = false;
   public static final String SSL_ENABLED_PROTOCOLS_CONFIG = "ssl.enabled.protocols";
@@ -480,6 +480,15 @@ public class RestConfig extends AbstractConfig {
           + "https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt for more information. "
           + "Default is false.";
   protected static final boolean PROXY_PROTOCOL_ENABLED_DEFAULT = false;
+
+  public static final String ERROR_HANDLING_ENABLED_CONFIG = "error.handling.enabled";
+
+  protected static final String ERROR_HANDLING_ENABLED_DOC =
+      "If true, enable overall error handling for any uncaught errors in handlers pipeline. "
+          + "Exceptions usually display stack trace to the client and the error handler will "
+          + "disable the stack trace to the client.";
+
+  protected static final boolean ERROR_HANDLING_ENABLED_DEFAULT = true;
 
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
@@ -974,6 +983,12 @@ public class RestConfig extends AbstractConfig {
             NOSNIFF_PROTECTION_ENABLED_DEFAULT,
             Importance.LOW,
             NOSNIFF_PROTECTION_ENABLED_DOC
+        ).define(
+            ERROR_HANDLING_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            ERROR_HANDLING_ENABLED_DEFAULT,
+            Importance.LOW,
+            ERROR_HANDLING_ENABLED_DOC
         );
   }
 

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -481,14 +481,13 @@ public class RestConfig extends AbstractConfig {
           + "Default is false.";
   protected static final boolean PROXY_PROTOCOL_ENABLED_DEFAULT = false;
 
-  public static final String ERROR_HANDLING_ENABLED_CONFIG = "error.handling.enabled";
+  public static final String SUPPRESS_STACK_TRACE_IN_RESPONSE = "suppress.stack.trace.response";
 
-  protected static final String ERROR_HANDLING_ENABLED_DOC =
+  protected static final String SUPPRESS_STACK_TRACE_IN_RESPONSE_DOC =
       "If true, enable overall error handling for any uncaught errors in handlers pipeline. "
-          + "Exceptions usually display stack trace to the client and the error handler will "
-          + "disable the stack trace to the client.";
+          + "This ensures that no stack traces are included in responses to clients.";
 
-  protected static final boolean ERROR_HANDLING_ENABLED_DEFAULT = true;
+  protected static final boolean SUPPRESS_STACK_TRACE_IN_RESPONSE_DEFAULT = true;
 
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
@@ -984,11 +983,11 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             NOSNIFF_PROTECTION_ENABLED_DOC
         ).define(
-            ERROR_HANDLING_ENABLED_CONFIG,
+            SUPPRESS_STACK_TRACE_IN_RESPONSE,
             Type.BOOLEAN,
-            ERROR_HANDLING_ENABLED_DEFAULT,
+            SUPPRESS_STACK_TRACE_IN_RESPONSE_DEFAULT,
             Importance.LOW,
-            ERROR_HANDLING_ENABLED_DOC
+            SUPPRESS_STACK_TRACE_IN_RESPONSE_DOC
         );
   }
 

--- a/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
+++ b/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
@@ -27,7 +27,7 @@ public class NoJettyDefaultStackTraceErrorHandler extends ErrorHandler {
         retrieveErrorMessage(code, message));
   }
 
-  private String retrieveErrorMessage(int code, String message) {
+  protected String retrieveErrorMessage(int code, String message) {
     switch (code) {
       case HttpStatus.INTERNAL_SERVER_ERROR_500:
         return HttpStatus.getMessage(code);

--- a/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
+++ b/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ */
+
+package io.confluent.rest.errorhandlers;
+
+import java.io.IOException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.ErrorHandler;
+
+public class NoJettyDefaultStackTraceErrorHandler extends ErrorHandler {
+  private static final String JAVAX_ERROR_EXCEPTION_ATTRIBUTE = "javax.servlet.error.exception";
+
+  public NoJettyDefaultStackTraceErrorHandler() {
+    super();
+    setShowServlet(false);
+  }
+
+  @Override
+  protected void generateAcceptableResponse(Request baseRequest, HttpServletRequest request,
+      HttpServletResponse response, int code, String message) throws IOException {
+    request.setAttribute(JAVAX_ERROR_EXCEPTION_ATTRIBUTE, null);
+    super.generateAcceptableResponse(baseRequest, request, response, code,
+        retrieveErrorMessage(code, message));
+  }
+
+  private String retrieveErrorMessage(int code, String message) {
+    switch (code) {
+      case HttpStatus.INTERNAL_SERVER_ERROR_500:
+        return HttpStatus.getMessage(code);
+      default:
+        return message;
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
@@ -46,6 +46,7 @@ public class CsrfHandlingTest {
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty(RestConfig.CSRF_PREVENTION_ENABLED, "true");
+    props.setProperty(RestConfig.ERROR_HANDLING_ENABLED_CONFIG, "false"); // tests currently look at stack trace for validation
 
     config = new TestRestConfig(props);
     app = new CsrfApplication(config);

--- a/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
+++ b/core/src/test/java/io/confluent/rest/CsrfHandlingTest.java
@@ -46,7 +46,7 @@ public class CsrfHandlingTest {
   public void setUp() throws Exception {
     Properties props = new Properties();
     props.setProperty(RestConfig.CSRF_PREVENTION_ENABLED, "true");
-    props.setProperty(RestConfig.ERROR_HANDLING_ENABLED_CONFIG, "false"); // tests currently look at stack trace for validation
+    props.setProperty(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE, "false"); // tests currently look at stack trace for validation
 
     config = new TestRestConfig(props);
     app = new CsrfApplication(config);

--- a/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
@@ -1,0 +1,117 @@
+package io.confluent.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
+import java.io.IOException;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class ErrorHandlerIntegrationTest {
+
+  private static final String DUMMY_EXCEPTION = "dummy exception";
+  private Server server;
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    server.stop();
+    server.join();
+  }
+
+  @Test
+  public void unhandledServerExceptionDisplaysStackTrace() throws Exception {
+    TestApplication application = new TestApplication(new RestConfig(RestConfig.baseConfigDef()),
+        false);
+    server = application.createServer();
+    server.start();
+
+    Response response = ClientBuilder.newClient()
+        .target(server.getURI())
+        .path("/test/path")
+        .request(MediaType.TEXT_HTML)
+        .get();
+
+    String responseValue = response.readEntity(String.class);
+
+    assertEquals(500, response.getStatus());
+    assertTrue(responseValue.toLowerCase().contains(DUMMY_EXCEPTION));
+    assertTrue(responseValue.toLowerCase().contains("caused by"));
+  }
+
+  @Test
+  public void handledServerExceptionDoesNotDisplayStackTrace() throws Exception {
+    TestApplication application = new TestApplication(new RestConfig(RestConfig.baseConfigDef()),
+        true);
+    server = application.createServer();
+    server.start();
+
+    Response response = ClientBuilder.newClient()
+        .target(server.getURI())
+        .path("/test/path")
+        .request(MediaType.TEXT_HTML)
+        .get();
+
+    String responseValue = response.readEntity(String.class).toLowerCase();
+
+    assertEquals(500, response.getStatus());
+    assertFalse(responseValue.contains(DUMMY_EXCEPTION));
+    assertFalse(responseValue.contains("caused by"));
+    assertTrue(responseValue.contains("server error"));
+  }
+
+  private static class TestApplication extends Application<RestConfig> {
+
+    private final boolean handleError;
+
+    TestApplication(RestConfig restConfig, boolean handleError) {
+      super(restConfig);
+      this.handleError = handleError;
+    }
+
+    @Override
+    protected void configurePreResourceHandling(ServletContextHandler contextHandler) {
+      contextHandler.setHandler(new DummyServerHandler());
+      if (handleError) {
+        contextHandler.setErrorHandler(new NoJettyDefaultStackTraceErrorHandler());
+      }
+    }
+
+    @Override
+    public void setupResources(Configurable<?> config, RestConfig appConfig) {
+      config.register(TestResource.class);
+    }
+  }
+
+  private static class DummyServerHandler extends ServletHandler {
+
+    public void doHandle(String target, Request baseRequest, HttpServletRequest request,
+        HttpServletResponse response) throws IOException, ServletException {
+      throw new RuntimeException(DUMMY_EXCEPTION);
+    }
+  }
+
+  @Path("/test")
+  public static class TestResource {
+
+    @GET
+    @Path("/path")
+    public String path() {
+      return "ok";
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
@@ -41,7 +41,7 @@ public class ErrorHandlerIntegrationTest {
       throws Exception {
 
     Properties props = new Properties();
-    props.setProperty(RestConfig.ERROR_HANDLING_ENABLED_CONFIG, "false");
+    props.setProperty(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE, "false");
     TestRestConfig config = new TestRestConfig(props);
 
     TestApplication application = new TestApplication(config);


### PR DESCRIPTION
An issue was noticed where any unhandled exceptions thrown by Jetty Handlers display the stack trace of the exception to the user. For internal server errors we should avoid showing stack traces to the user as it poses a security risk. The StackTraceErrorHandler removes stack traces and servlet information before passing response to user and is optional by consumers of the rest-utils library.