### PR TITLE
[MMA-12212] Bump jetty version to 9.4.48.v20220622

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.34</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
#### Before Update
```
[INFO] io.confluent.controlcenter:control-center:jar:5.4.9-SNAPSHOT
[INFO] \- io.confluent:rest-utils:jar:5.4.9-SNAPSHOT:compile
[INFO]    \- org.eclipse.jetty:jetty-server:jar:9.4.44.v20210927:compile
[INFO]       \- org.eclipse.jetty:jetty-http:jar:9.4.44.v20210927:compile
```
#### After Update
```
[INFO] io.confluent.controlcenter:control-center:jar:5.4.9-SNAPSHOT
[INFO] \- io.confluent:rest-utils:jar:5.4.9-SNAPSHOT:compile
[INFO]    \- org.eclipse.jetty:jetty-server:jar:9.4.48.v20220622:compile
[INFO]       \- org.eclipse.jetty:jetty-http:jar:9.4.48.v20220622:compile
```
#### Jira
https://confluentinc.atlassian.net/browse/MMA-12212