### PR TITLE
Revert "[MMA-12212] Bump jetty version to 9.4.48.v20220622 (#330)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.44.v20210927</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
This upgrade needs to go piece by piece (for individual), reverting to previous version for now.

This reverts commit 8eb6333cc4dd1844807a66b06bb93a5f15715450.