### PR TITLE
DGS-4220: fix request tag based metrics

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -71,6 +71,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       "unknown", "1xx", "2xx", "3xx", "4xx", "5xx"};
   private static final int PERCENTILE_NUM_BUCKETS = 200;
   private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(10);
+  private static final long SENSOR_EXPIRY_SECONDS = TimeUnit.HOURS.toSeconds(1);
 
   private final Metrics metrics;
   private final String metricGrpPrefix;
@@ -192,7 +193,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       allTags.putAll(requestTags);
 
       this.requestSizeSensor = metrics.sensor(
-          getName(method, annotation, "request-size", requestTags));
+          getName(method, annotation, "request-size", requestTags),
+          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       MetricName metricName = new MetricName(
           getName(method, annotation, "request-count"), metricGrpName,
           "The request count using a windowed counter", allTags);
@@ -215,7 +217,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       this.requestSizeSensor.add(metricName, new Max());
 
       this.responseSizeSensor = metrics.sensor(
-          getName(method, annotation, "response-size", requestTags));
+          getName(method, annotation, "response-size", requestTags),
+          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
           getName(method, annotation, "response-rate"), metricGrpName,
           "The average number of HTTP responses per second.", allTags);
@@ -234,7 +237,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       this.responseSizeSensor.add(metricName, new Max());
 
       this.requestLatencySensor = metrics.sensor(
-          getName(method, annotation, "request-latency", requestTags));
+          getName(method, annotation, "request-latency", requestTags),
+          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
           getName(method, annotation, "request-latency-avg"), metricGrpName,
           "The average request latency in ms", allTags);
@@ -258,7 +262,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       for (int i = 0; i < errorSensorByStatus.length; i++) {
         errorSensorByStatus[i] = metrics.sensor(
-            getName(method, annotation, "errors" + i, requestTags));
+            getName(method, annotation, "errors" + i, requestTags),
+            null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
         SortedMap<String, String> tags = new TreeMap<>(allTags);
         tags.put(HTTP_STATUS_CODE_TAG, HTTP_STATUS_CODE_TEXT[i]);
         metricName = new MetricName(getName(method, annotation, "request-error-rate"),
@@ -276,7 +281,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
         errorSensorByStatus[i].add(metricName, new WindowedCount());
       }
 
-      this.errorSensor = metrics.sensor(getName(method, annotation, "errors", requestTags));
+      this.errorSensor = metrics.sensor(getName(method, annotation, "errors", requestTags),
+          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
           getName(method, annotation, "request-error-rate"),
           metricGrpName,
@@ -284,7 +290,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           allTags);
       this.errorSensor.add(metricName, new Rate());
 
-      this.errorSensor = metrics.sensor(getName(method, annotation, "errors-count", requestTags));
+      this.errorSensor = metrics.sensor(getName(method, annotation, "errors-count", requestTags),
+          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
           getName(method, annotation, "request-error-count"),
           metricGrpName,

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -289,9 +289,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           "The average number of requests per second that resulted in HTTP error responses",
           allTags);
       this.errorSensor.add(metricName, new Rate());
-
-      this.errorSensor = metrics.sensor(getName(method, annotation, "errors-count", requestTags),
-          null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
           getName(method, annotation, "request-error-count"),
           metricGrpName,


### PR DESCRIPTION
This PR tries to fix the bug that a sensor created for a method + performance annotation pair is shared across the entire application, as opposed to each request tag set having its own copy of sensor. It is causing a problem when request tags are used. A sensor is either created or fetched depending on whether the name exists. For example, 
1. `methodX.request-size` sensor is created on application startup, let's call it sensorA
2. a request w/ tag1 comes in, sensorA is returned because the same sensor name is provided
3. a request w/ tag2 comes in, sensorA is again returned

However, each tag really should have its own sensor.

The fix sorts request tags to make sure the same sensor is used for the same set of request tags. Tags in `MetricName` is also sorted for `JmxReporter` to create consistent MBean names. I understand this is an implicit side effect, a more proper place to ensure the consistency is within `JmxReporter`.

This PR also fixes a bug that the error sensor is overwritten, so error rates are not recorded.