### PR TITLE
MINOR: Add request cumulative counter in MetricsResourceMethodApplicationListener

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -43,6 +43,7 @@ import io.confluent.rest.annotations.PerformanceMetric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.metrics.stats.Percentile;
 import org.apache.kafka.common.metrics.stats.Percentiles;
@@ -203,6 +204,10 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           getName(method, annotation, "request-rate"), metricGrpName,
           "The average number of HTTP requests per second.", allTags);
       this.requestSizeSensor.add(metricName, new Rate(new WindowedCount()));
+      metricName = new MetricName(
+          getName(method, annotation, "request-cumulative-count"), metricGrpName,
+          "The request count using a cumulative counter", allTags);
+      this.requestSizeSensor.add(metricName, new CumulativeCount());
       metricName = new MetricName(
           getName(method, annotation, "request-byte-rate"), metricGrpName,
           "Bytes/second of incoming requests", allTags);

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -108,10 +108,12 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       switch (metric.metricName().name()) {
         case "request-count": // global metrics
+        case "request-cumulative-count": // global metrics
           assertMetric(metric, totalRequests);
           totalRequestsCheckpoint++;
           break;
         case "hello.request-count": // method metrics
+        case "hello.request-cumulative-count": // method metrics
           if (metric.metricName().tags().containsValue("value1")) {
             assertMetric(metric, (totalRequests + 1) / 3);
             helloTag1RequestsCheckpoint++;
@@ -125,10 +127,10 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
           break;
       }
     }
-    assertEquals(1, totalRequestsCheckpoint);
-    assertEquals(1, helloTag1RequestsCheckpoint);
-    assertEquals(1, helloTag2RequestsCheckpoint);
-    assertEquals(1, helloRequestsCheckpoint);
+    assertEquals(2, totalRequestsCheckpoint);
+    assertEquals(2, helloTag1RequestsCheckpoint);
+    assertEquals(2, helloTag2RequestsCheckpoint);
+    assertEquals(2, helloRequestsCheckpoint);
   }
 
   @Test
@@ -315,7 +317,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   private void assertMetric(KafkaMetric metric, int expectedValue) {
-    assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
     Object metricValue = metric.metricValue();
     assertTrue(metricValue instanceof Double, "Metrics should be measurable");
     double countValue = (double) metricValue;


### PR DESCRIPTION
We need a cumulative counter to report request count, rather than the existing windowed/sampled count. The potential issue with windowed count is discussed [here](https://github.com/confluentinc/rest-utils/issues/344), which will not be addressed in this PR.