### PR TITLE
APIF-2739: Upgrade Jetty to 9.4.48.v20220622.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty.version>9.4.48.v20220622</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <guava.version>30.1.1-jre</guava.version>


### PR DESCRIPTION
Address CVE-2022-2047.

This PR needs to be merged together with https://github.com/confluentinc/ce-kafka/pull/7068, to avoid issues with conflicting jars.