### PR TITLE
Convert the response to json format and hidding the details of the co…

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -629,6 +629,7 @@ public abstract class Application<T extends RestConfig> {
     config.register(jsonProvider);
     if (registerExceptionMapper) {
       config.register(JsonParseExceptionMapper.class);
+      config.register(JsonMappingExceptionMapper.class);
     }
   }
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Confluent Inc.
+ * Copyright 2014 - 2022 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package io.confluent.rest;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.jaxrs.base.JsonParseExceptionMapper;
 
 import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
 import org.apache.kafka.common.config.ConfigException;
@@ -84,6 +83,7 @@ import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.GenericExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
+import io.confluent.rest.exceptions.JsonParseExceptionMapper;
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
 import io.confluent.rest.metrics.MetricsResourceMethodApplicationListener;
@@ -650,6 +650,7 @@ public abstract class Application<T extends RestConfig> {
   protected void registerExceptionMappers(Configurable<?> config, T restConfig) {
     config.register(ConstraintViolationExceptionMapper.class);
     config.register(JsonMappingExceptionMapper.class);
+    config.register(JsonParseExceptionMapper.class);
     config.register(new WebApplicationExceptionMapper(restConfig));
     config.register(new GenericExceptionMapper(restConfig));
   }

--- a/core/src/main/java/io/confluent/rest/exceptions/JsonParseExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/JsonParseExceptionMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.exceptions;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import io.confluent.rest.entities.ErrorMessage;
+
+import javax.annotation.Priority;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+@Priority(1)
+public class JsonParseExceptionMapper implements ExceptionMapper<JsonParseException> {
+
+  public static final int BAD_REQUEST_CODE = 400;
+
+  @Override
+  public Response toResponse(JsonParseException exception) {
+
+    ErrorMessage message = new ErrorMessage(
+        BAD_REQUEST_CODE,
+            exception.getOriginalMessage()
+    );
+
+    return Response.status(BAD_REQUEST_CODE)
+        .entity(message)
+        .build();
+  }
+}

--- a/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/JsonMappingExceptionMapperTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Confluent Inc.
+ * Copyright 2021 - 2022 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package io.confluent.rest;
 
+import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.rest.entities.ErrorMessage;
@@ -53,6 +54,18 @@ public class JsonMappingExceptionMapperTest {
     } catch (Exception e) {
       fail("A JsonMappingException is expected.");
     }
+  }
+
+  @Test
+  public void testJsonMappingExceptionRemoveDetailsFromMessage() {
+      JsonMappingException jsonMappingException = new JsonMappingException("Json mapping error (for Object starting at:", JsonLocation.NA);
+      jsonMappingException.prependPath(new JsonMappingException.Reference("path"), 0);
+
+      Response response = mapper.toResponse(jsonMappingException);
+      assertEquals(400, response.getStatus());
+      ErrorMessage out = (ErrorMessage)response.getEntity();
+      assertEquals(400, out.getErrorCode());
+      assertEquals("Json mapping error", out.getMessage());
   }
 
   class User {

--- a/core/src/test/java/io/confluent/rest/JsonParseExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/JsonParseExceptionMapperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+import io.confluent.rest.entities.ErrorMessage;
+import io.confluent.rest.exceptions.JsonParseExceptionMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonParseExceptionMapperTest {
+
+  private JsonParseExceptionMapper mapper;
+
+  @BeforeEach
+  public void setUp() {
+    mapper = new JsonParseExceptionMapper();
+  }
+
+  @Test
+  public void testJsonParseExceptionRemoveDetailsFromMessage() {
+      JsonParseException jsonParseException = new JsonParseException("Json parse error", JsonLocation.NA);
+
+      Response response = mapper.toResponse(jsonParseException);
+      assertEquals(400, response.getStatus());
+      ErrorMessage out = (ErrorMessage)response.getEntity();
+      assertEquals(400, out.getErrorCode());
+      assertEquals("Json parse error", out.getMessage());
+  }
+}


### PR DESCRIPTION
…de path

For the V2 version, when produce a message, if the request body is an invalid json, we will meet this two problems.
1 ) The response is not a json message.
2) It contains two much information: for example
```
Unexpected character (''' (code 39)): was expecting double-quote to start field name
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 7, column: 7] (through reference chain: io.confluent.kafkarest.entities.v2.ProduceRequest["records"]->java.util.ArrayList[1])
```

The reasons the above problems are:
1) https://github.com/confluentinc/rest-utils/blob/master/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java doesn't trigger when throws JsonMappingException, so the response doesn't convert to json.
2) Exception message is not been handled from JsonMappingException, all the details returned to users directly.

How to fix:
1) There are two types Jackson related exception: JsonParseException and the one we met JsonMappingException, we need to register both mappers here https://github.com/confluentinc/rest-utils/blob/master/core/src/main/java/io/confluent/rest/Application.java#L631, but we only registered JsonParseExceptionMapper
2) According to https://stackoverflow.com/a/58287443,
Starting with Jersey 2.26 (1, 2) it should be enough to annotate the custom exception mapper with a sufficiently high Priority
We are using version 2.34, so I added @Priority(1) to https://github.com/confluentinc/rest-utils/blob/master/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java#L31
3) Remove exception messages from https://github.com/confluentinc/rest-utils/blob/master/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java#L35

Manually test:
```
jliu@C02DM32YMD6T kafka-rest % curl -X POST \
     -H "Content-Type: application/vnd.kafka.json.v2+json" \
     -H "Accept: application/vnd.kafka.v2+json" \
     --data '{"records":[{"key":"abc","value":"alarm clock"},{"key":"htanaka","value":"batteries"},{"key":"awalther","value":"bookshelves"}, {
      "value": ["foo", "bar"],
      "partition": 1
    ]}' \
     "http://localhost:8082/topics/tst"
{"error_code":400,"message":"Unexpected close marker ']': expected '}'"}% 
```

Jenkins failed for 
```19:21:45  [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.432 s - in io.confluent.rest.CsrfHandlingTest
19:21:45  [INFO] 
19:21:45  [INFO] Results:
19:21:45  [INFO] 
19:21:45  [ERROR] Failures: 
19:21:45  [ERROR]   MetricsResourceMethodApplicationListenerIntegrationTest.testSuccessMetrics:112->assertMetric:325 Actual: 9.0 ==> expected: <10.0> but was: <9.0>
19:21:45  [INFO] 
19:21:45  [ERROR] Tests run: 152, Failures: 1, Errors: 0, Skipped: 2
```
Looking why it failed