### PR TITLE
[DO NOT MERGE] MMA-12410 Do not send server version in response headers

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -30,6 +30,10 @@ import org.eclipse.jetty.security.authentication.LoginAuthenticator;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLog;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.handler.HandlerCollection;
 import org.eclipse.jetty.server.handler.RequestLogHandler;
 import org.eclipse.jetty.servlet.DefaultServlet;
@@ -209,6 +213,11 @@ public abstract class Application<T extends RestConfig> {
     // CHECKSTYLE_RULES.ON: MethodLength|CyclomaticComplexity|JavaNCSS|NPathComplexity
     if (server == null) {
       server = new ApplicationServer(config);
+      HttpConfiguration httpConfig = new HttpConfiguration();
+      httpConfig.setSendServerVersion(false);
+      HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfig);
+      ServerConnector httpConnector = new ServerConnector(server, httpFactory);
+      server.setConnectors(new Connector[] { httpConnector });
       server.registerApplication(this);
     }
     return server;


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/MMA-12410

This PR tries to remove server version from response headers as suggested at https://stackoverflow.com/questions/15652902/remove-the-http-server-header-in-jetty-9

**Do not merge:**
PR in development. With these changes, control-center is unable to start with no apparent error logs to debug

Notice **Server: Jetty(9.4.44.v20210927)** header in response

```
curl -v http://localhost:9021/api/connect/connect-default/ReplicatorMetrics
*   Trying 127.0.0.1...
* TCP_NODELAY set
* Connected to localhost (127.0.0.1) port 9021 (#0)
> GET /api/connect/connect-default/ReplicatorMetrics HTTP/1.1
> Host: localhost:9021
> User-Agent: curl/7.58.0
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Sat, 27 Aug 2022 01:31:47 GMT
< X-Content-Type-Options: nosniff
< X-Confluent-Control-Center-Version: 5.5.12-SNAPSHOT
< Strict-Transport-Security: max-age=31536000
< X-Frame-Options: SAMEORIGIN
< Date: Sat, 27 Aug 2022 01:31:47 GMT
< Content-Type: application/json
< Server: Jetty(9.4.44.v20210927)
< Vary: Accept-Encoding, User-Agent
< Content-Length: 17
<
* Connection #0 to host localhost left intact
{"connectors":[]}%
```