### PR TITLE
APIF-2959: Prepare rest-utils API for per-listener SSL configs.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -16,9 +16,40 @@
 
 package io.confluent.rest;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static io.confluent.rest.RestConfig.REST_SERVLET_INITIALIZERS_CLASSES_CONFIG;
+import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG;
+import static java.util.Collections.emptyMap;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.rest.auth.AuthUtil;
 import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
+import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
+import io.confluent.rest.exceptions.GenericExceptionMapper;
+import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
+import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
+import io.confluent.rest.exceptions.JsonParseExceptionMapper;
+import io.confluent.rest.extension.ResourceExtension;
+import io.confluent.rest.filters.CsrfTokenProtectionFilter;
+import io.confluent.rest.metrics.MetricsResourceMethodApplicationListener;
+import io.confluent.rest.validation.JacksonMessageBodyProvider;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import javax.servlet.DispatcherType;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.ws.rs.core.Configurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.JmxReporter;
 import org.apache.kafka.common.metrics.MetricConfig;
@@ -56,41 +87,6 @@ import org.glassfish.jersey.server.validation.ValidationFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import javax.servlet.DispatcherType;
-import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.ws.rs.core.Configurable;
-
-import io.confluent.rest.auth.AuthUtil;
-import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
-import io.confluent.rest.exceptions.GenericExceptionMapper;
-import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
-import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
-import io.confluent.rest.exceptions.JsonParseExceptionMapper;
-import io.confluent.rest.extension.ResourceExtension;
-import io.confluent.rest.filters.CsrfTokenProtectionFilter;
-import io.confluent.rest.metrics.MetricsResourceMethodApplicationListener;
-import io.confluent.rest.validation.JacksonMessageBodyProvider;
-
-import static io.confluent.rest.RestConfig.REST_SERVLET_INITIALIZERS_CLASSES_CONFIG;
-import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSES_CONFIG;
 
 /**
  * A REST application. Extend this class and implement setupResources() to register REST
@@ -499,10 +495,10 @@ public abstract class Application<T extends RestConfig> {
     // Support for named listeners is only implemented for the case of Applications
     // managed by ApplicationServer (direct instantiation of Application is to be
     // deprecated).
-    return ApplicationServer.parseListeners(
-      listenersConfig, Collections.emptyMap(), deprecatedPort, supportedSchemes, defaultScheme)
+    return RestConfig.parseListeners(
+            listenersConfig, emptyMap(), deprecatedPort, supportedSchemes, defaultScheme)
         .stream()
-        .map(ApplicationServer.NamedURI::getUri)
+        .map(NamedURI::getUri)
         .collect(Collectors.toList());
   }
 

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -20,24 +20,13 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.function.Function.identity;
 
 import java.lang.management.ManagementFactory;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.concurrent.BlockingQueue;
-import java.util.stream.Collectors;
-import javax.annotation.Nullable;
-import javax.ws.rs.core.UriBuilder;
-import javax.ws.rs.core.UriBuilderException;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;
@@ -83,9 +72,6 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   private static final Logger log = LoggerFactory.getLogger(ApplicationServer.class);
 
-  static final List<String> SUPPORTED_URI_SCHEMES =
-      Collections.unmodifiableList(Arrays.asList("http", "https"));
-
   // Package-visible for tests
   static boolean isJava11Compatible() {
     final String versionString = System.getProperty("java.specification.version");
@@ -116,92 +102,13 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     super.addEventListener(mbContainer);
     super.addBean(mbContainer);
 
-    listeners = parseListeners(
-        config.getList(RestConfig.LISTENERS_CONFIG),
-        config.getListenerProtocolMap(),
-        config.getInt(RestConfig.PORT_CONFIG),
-        SUPPORTED_URI_SCHEMES, "http");
+    listeners = config.getListeners();
 
-    this.sslContextFactory = createSslContextFactory(config);
+    this.sslContextFactory = SslFactory.createSslContextFactory(config.getBaseSslConfig());
     configureConnectors(sslContextFactory);
     configureConnectionLimits();
   }
 
-  static NamedURI constructNamedURI(
-          String listener,
-          Map<String,String> listenerProtocolMap,
-          List<String> supportedSchemes) {
-    URI uri;
-    try {
-      uri = new URI(listener);
-    } catch (URISyntaxException e) {
-      throw new ConfigException(
-          "Listener '" + listener + "' is not a valid URI.");
-    }
-    if (uri.getPort() == -1) {
-      throw new ConfigException(
-          "Listener '" + listener + "' must specify a port.");
-    }
-    if (supportedSchemes.contains(uri.getScheme())) {
-      return new NamedURI(uri, null); // unnamed.
-    }
-    String uriName = uri.getScheme().toLowerCase();
-    String protocol = listenerProtocolMap.get(uriName);
-    if (protocol == null) {
-      throw new ConfigException(
-          "Listener '" + uri + "' has an unsupported scheme '" + uri.getScheme() + "'");
-    }
-    try {
-      return new NamedURI(
-          UriBuilder.fromUri(listener).scheme(protocol).build(),
-          uriName);
-    } catch (UriBuilderException e) {
-      throw new ConfigException(
-          "Listener '" + listener + "' with protocol '" + protocol + "' is not a valid URI.");
-    }
-  }
-
-  /**
-   * TODO: delete deprecatedPort parameter when `PORT_CONFIG` is deprecated.
-   * It's only used to support the deprecated configuration.
-   */
-  static List<NamedURI> parseListeners(
-          List<String> listeners,
-          Map<String,String> listenerProtocolMap,
-          int deprecatedPort,
-          List<String> supportedSchemes,
-          String defaultScheme) {
-
-    // handle deprecated case, using PORT_CONFIG.
-    // TODO: remove this when `PORT_CONFIG` is deprecated, because LISTENER_CONFIG
-    // will have a default value which includes the default port.
-    if (listeners.isEmpty() || listeners.get(0).isEmpty()) {
-      log.warn(
-          "DEPRECATION warning: `listeners` configuration is not configured. "
-          + "Falling back to the deprecated `port` configuration.");
-      listeners = new ArrayList<>(1);
-      listeners.add(defaultScheme + "://0.0.0.0:" + deprecatedPort);
-    }
-
-    List<NamedURI> uris = listeners.stream()
-        .map(listener -> constructNamedURI(listener, listenerProtocolMap, supportedSchemes))
-        .collect(Collectors.toList());
-    List<NamedURI> namedUris =
-        uris.stream().filter(uri -> uri.getName() != null).collect(Collectors.toList());
-    List<NamedURI> unnamedUris =
-        uris.stream().filter(uri -> uri.getName() == null).collect(Collectors.toList());
-
-    if (namedUris.stream().map(a -> a.getName()).distinct().count() != namedUris.size()) {
-      throw new ConfigException(
-          "More than one listener was specified with same name. Listener names must be unique.");
-    }
-    if (namedUris.isEmpty() && unnamedUris.isEmpty()) {
-      throw new ConfigException(
-          "No listeners are configured. At least one listener must be configured.");
-    }
-
-    return uris;
-  }
 
   public void registerApplication(Application application) {
     application.setServer(this);
@@ -285,145 +192,14 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     super.doStart();
   }
 
-  @SuppressWarnings("deprecation")
-  private void configureClientAuth(SslContextFactory sslContextFactory, RestConfig config) {
-    String clientAuthentication = config.getString(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG);
-
-    if (config.originals().containsKey(RestConfig.SSL_CLIENT_AUTH_CONFIG)) {
-      if (config.originals().containsKey(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG)) {
-        log.warn(
-                "The {} configuration is deprecated. Since a value has been supplied for the {} "
-                        + "configuration, that will be used instead",
-                RestConfig.SSL_CLIENT_AUTH_CONFIG,
-                RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG
-        );
-      } else {
-        log.warn(
-                "The configuration {} is deprecated and should be replaced with {}",
-                RestConfig.SSL_CLIENT_AUTH_CONFIG,
-                RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG
-        );
-        clientAuthentication = config.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG)
-                ? RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED
-                : RestConfig.SSL_CLIENT_AUTHENTICATION_NONE;
-      }
-    }
-
-    switch (clientAuthentication) {
-      case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED:
-        sslContextFactory.setNeedClientAuth(true);
-        break;
-      case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUESTED:
-        sslContextFactory.setWantClientAuth(true);
-        break;
-      case RestConfig.SSL_CLIENT_AUTHENTICATION_NONE:
-        break;
-      default:
-        throw new ConfigException(
-                "Unexpected value for {} configuration: {}",
-                RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
-                clientAuthentication
-        );
-    }
-  }
-
-  private Path getWatchLocation(RestConfig config) {
-    Path keystorePath = Paths.get(config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG));
-    String watchLocation = config.getString(RestConfig.SSL_KEYSTORE_WATCH_LOCATION_CONFIG);
-    if (!watchLocation.isEmpty()) {
-      keystorePath = Paths.get(watchLocation);
-    }
-    return keystorePath;
-  }
-
-  private SslContextFactory createSslContextFactory(RestConfig config) {
-    SslContextFactory sslContextFactory = new SslContextFactory.Server();
-    if (!config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG).isEmpty()) {
-      sslContextFactory.setKeyStorePath(
-              config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG)
-      );
-      sslContextFactory.setKeyStorePassword(
-              config.getPassword(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG).value()
-      );
-      sslContextFactory.setKeyManagerPassword(
-              config.getPassword(RestConfig.SSL_KEY_PASSWORD_CONFIG).value()
-      );
-      sslContextFactory.setKeyStoreType(
-              config.getString(RestConfig.SSL_KEYSTORE_TYPE_CONFIG)
-      );
-
-      if (!config.getString(RestConfig.SSL_KEYMANAGER_ALGORITHM_CONFIG).isEmpty()) {
-        sslContextFactory.setKeyManagerFactoryAlgorithm(
-                config.getString(RestConfig.SSL_KEYMANAGER_ALGORITHM_CONFIG));
-      }
-
-      if (config.getBoolean(RestConfig.SSL_KEYSTORE_RELOAD_CONFIG)) {
-        Path watchLocation = getWatchLocation(config);
-        try {
-          FileWatcher.onFileChange(watchLocation, () -> {
-                // Need to reset the key store path for symbolic link case
-                sslContextFactory.setKeyStorePath(
-                    config.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG)
-                );
-                sslContextFactory.reload(scf -> log.info("Reloaded SSL cert"));
-              }
-          );
-          log.info("Enabled SSL cert auto reload for: " + watchLocation);
-        } catch (java.io.IOException e) {
-          log.error("Can not enabled SSL cert auto reload", e);
-        }
-      }
-    }
-
-    configureClientAuth(sslContextFactory, config);
-
-    List<String> enabledProtocols = config.getList(RestConfig.SSL_ENABLED_PROTOCOLS_CONFIG);
-    if (!enabledProtocols.isEmpty()) {
-      sslContextFactory.setIncludeProtocols(enabledProtocols.toArray(new String[0]));
-    }
-
-    List<String> cipherSuites = config.getList(RestConfig.SSL_CIPHER_SUITES_CONFIG);
-    if (!cipherSuites.isEmpty()) {
-      sslContextFactory.setIncludeCipherSuites(cipherSuites.toArray(new String[0]));
-    }
-
-    sslContextFactory.setEndpointIdentificationAlgorithm(
-            config.getString(RestConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG));
-
-    if (!config.getString(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG).isEmpty()) {
-      sslContextFactory.setTrustStorePath(
-              config.getString(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG)
-      );
-      sslContextFactory.setTrustStorePassword(
-              config.getPassword(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG).value()
-      );
-      sslContextFactory.setTrustStoreType(
-              config.getString(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG)
-      );
-
-      if (!config.getString(RestConfig.SSL_TRUSTMANAGER_ALGORITHM_CONFIG).isEmpty()) {
-        sslContextFactory.setTrustManagerFactoryAlgorithm(
-                config.getString(RestConfig.SSL_TRUSTMANAGER_ALGORITHM_CONFIG)
-        );
-      }
-    }
-
-    sslContextFactory.setProtocol(config.getString(RestConfig.SSL_PROTOCOL_CONFIG));
-    if (!config.getString(RestConfig.SSL_PROVIDER_CONFIG).isEmpty()) {
-      sslContextFactory.setProtocol(config.getString(RestConfig.SSL_PROVIDER_CONFIG));
-    }
-
-    sslContextFactory.setRenegotiationAllowed(false);
-
-    return sslContextFactory;
-  }
-
   SslContextFactory getSslContextFactory() {
     return this.sslContextFactory;
   }
 
   public Map<NamedURI, SslContextFactory> getSslContextFactories() {
-    return listeners.stream().collect(toImmutableMap(identity(), listener -> sslContextFactory));
+    return listeners.stream()
+        .filter(listener -> listener.getUri().getScheme().equals("https"))
+        .collect(toImmutableMap(identity(), listener -> sslContextFactory));
   }
 
   private void configureConnectors(SslContextFactory sslContextFactory) {
@@ -526,7 +302,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
       }
     } else {
       log.info("Adding listener: " + listener);
-      if (listener.uri.getScheme().equals("http")) {
+      if (listener.getUri().getScheme().equals("http")) {
         if (proxyProtocolEnabled) {
           connectionFactories.add(new ProxyConnectionFactory(httpConnectionFactory.getProtocol()));
         }
@@ -640,47 +416,5 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     return new QueuedThreadPool(config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG),
             config.getInt(RestConfig.THREAD_POOL_MIN_CONFIG),
             requestQueue);
-  }
-
-  public static final class NamedURI {
-    private final URI uri;
-    @Nullable
-    private final String name;
-
-    public NamedURI(URI uri, @Nullable String name) {
-      this.uri = uri;
-      this.name = name;
-    }
-
-    public URI getUri() {
-      return uri;
-    }
-
-    @Nullable
-    public String getName() {
-      return name;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      NamedURI namedURI = (NamedURI) o;
-      return uri.equals(namedURI.uri) && Objects.equals(name, namedURI.name);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(uri, name);
-    }
-
-    @Override
-    public String toString() {
-      return "NamedURI{uri=" + uri + ", name='" + name + "'}";
-    }
   }
 }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -16,9 +16,6 @@
 
 package io.confluent.rest;
 
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.util.function.Function.identity;
-
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -194,12 +191,6 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   SslContextFactory getSslContextFactory() {
     return this.sslContextFactory;
-  }
-
-  public Map<NamedURI, SslContextFactory> getSslContextFactories() {
-    return listeners.stream()
-        .filter(listener -> listener.getUri().getScheme().equals("https"))
-        .collect(toImmutableMap(identity(), listener -> sslContextFactory));
   }
 
   private void configureConnectors(SslContextFactory sslContextFactory) {

--- a/core/src/main/java/io/confluent/rest/NamedURI.java
+++ b/core/src/main/java/io/confluent/rest/NamedURI.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import javax.annotation.Nullable;
+import java.net.URI;
+import java.util.Objects;
+
+public final class NamedURI {
+  private final URI uri;
+  @Nullable
+  private final String name;
+
+  public NamedURI(URI uri, @Nullable String name) {
+    this.uri = uri;
+    this.name = name;
+  }
+
+  public URI getUri() {
+    return uri;
+  }
+
+  @Nullable
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    NamedURI namedURI = (NamedURI) o;
+    return uri.equals(namedURI.uri) && Objects.equals(name, namedURI.name);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(uri, name);
+  }
+
+  @Override
+  public String toString() {
+    return "NamedURI{uri=" + uri + ", name='" + name + "'}";
+  }
+}

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -16,26 +16,33 @@
 
 package io.confluent.rest;
 
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+import static org.apache.kafka.clients.CommonClientConfigs.METRICS_CONTEXT_PREFIX;
+
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.metrics.RestMetricsContext;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import javax.ws.rs.core.UriBuilder;
+import javax.ws.rs.core.UriBuilderException;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.utils.Time;
-
-import static java.util.Collections.emptyList;
-import static org.apache.kafka.clients.CommonClientConfigs.METRICS_CONTEXT_PREFIX;
 
 public class RestConfig extends AbstractConfig {
 
@@ -269,7 +276,7 @@ public class RestConfig extends AbstractConfig {
   public static final String AUTHENTICATION_ROLES_CONFIG = "authentication.roles";
   public static final String AUTHENTICATION_ROLES_DOC = "Valid roles to authenticate against.";
   public static final List<String> AUTHENTICATION_ROLES_DEFAULT =
-      Collections.unmodifiableList(Arrays.asList("*"));
+      unmodifiableList(Arrays.asList("*"));
 
   public static final String AUTHENTICATION_SKIP_PATHS = "authentication.skip.paths";
   public static final String AUTHENTICATION_SKIP_PATHS_DOC = "Comma separated list of paths that "
@@ -488,6 +495,9 @@ public class RestConfig extends AbstractConfig {
           + "This ensures that no stack traces are included in responses to clients.";
 
   protected static final boolean SUPPRESS_STACK_TRACE_IN_RESPONSE_DEFAULT = true;
+
+  static final List<String> SUPPORTED_URI_SCHEMES =
+      unmodifiableList(Arrays.asList("http", "https"));
 
   public static ConfigDef baseConfigDef() {
     return baseConfigDef(
@@ -1118,6 +1128,25 @@ public class RestConfig extends AbstractConfig {
     return getInt(CONNECTOR_CONNECTION_LIMIT);
   }
 
+  public final List<NamedURI> getListeners() {
+    return parseListeners(
+        getList(RestConfig.LISTENERS_CONFIG),
+        getListenerProtocolMap(),
+        getInt(RestConfig.PORT_CONFIG),
+        SUPPORTED_URI_SCHEMES,
+        "http");
+  }
+
+  public final SslConfig getBaseSslConfig() {
+    return new SslConfig(this);
+  }
+
+  public final Map<NamedURI, SslConfig> getSslConfigs() {
+    return getListeners().stream()
+        .filter(listener -> listener.getUri().getScheme().equals("https"))
+        .collect(toImmutableMap(Function.identity(), unused -> getBaseSslConfig()));
+  }
+
   public final Map<String, String> getMap(String propertyName) {
     List<String> list = getList(propertyName);
     Map<String, String> map = new HashMap<>();
@@ -1139,6 +1168,72 @@ public class RestConfig extends AbstractConfig {
     return map;
   }
 
+  static List<NamedURI> parseListeners(
+      List<String> listeners,
+      Map<String,String> listenerProtocolMap,
+      int deprecatedPort,
+      List<String> supportedSchemes,
+      String defaultScheme) {
+
+    // handle deprecated case, using PORT_CONFIG.
+    // TODO: remove this when `PORT_CONFIG` is deprecated, because LISTENER_CONFIG
+    // will have a default value which includes the default port.
+    if (listeners.isEmpty() || listeners.get(0).isEmpty()) {
+      listeners = singletonList(defaultScheme + "://0.0.0.0:" + deprecatedPort);
+    }
+
+    List<NamedURI> uris = listeners.stream()
+        .map(listener -> constructNamedURI(listener, listenerProtocolMap, supportedSchemes))
+        .collect(Collectors.toList());
+    List<NamedURI> namedUris =
+        uris.stream().filter(uri -> uri.getName() != null).collect(Collectors.toList());
+    List<NamedURI> unnamedUris =
+        uris.stream().filter(uri -> uri.getName() == null).collect(Collectors.toList());
+
+    if (namedUris.stream().map(a -> a.getName()).distinct().count() != namedUris.size()) {
+      throw new ConfigException(
+          "More than one listener was specified with same name. Listener names must be unique.");
+    }
+    if (namedUris.isEmpty() && unnamedUris.isEmpty()) {
+      throw new ConfigException(
+          "No listeners are configured. At least one listener must be configured.");
+    }
+
+    return uris;
+  }
+
+  private static NamedURI constructNamedURI(
+      String listener, Map<String,String> listenerProtocolMap, List<String> supportedSchemes) {
+    URI uri;
+    try {
+      uri = new URI(listener);
+    } catch (URISyntaxException e) {
+      throw new ConfigException(
+          "Listener '" + listener + "' is not a valid URI.");
+    }
+    if (uri.getPort() == -1) {
+      throw new ConfigException(
+          "Listener '" + listener + "' must specify a port.");
+    }
+    if (supportedSchemes.contains(uri.getScheme())) {
+      return new NamedURI(uri, null); // unnamed.
+    }
+    String uriName = uri.getScheme().toLowerCase();
+    String protocol = listenerProtocolMap.get(uriName);
+    if (protocol == null) {
+      throw new ConfigException(
+          "Listener '" + uri + "' has an unsupported scheme '" + uri.getScheme() + "'");
+    }
+    try {
+      return new NamedURI(
+          UriBuilder.fromUri(listener).scheme(protocol).build(),
+          uriName);
+    } catch (UriBuilderException e) {
+      throw new ConfigException(
+          "Listener '" + listener + "' with protocol '" + protocol + "' is not a valid URI.");
+    }
+  }
+
   public final Map<String, String> getListenerProtocolMap() {
     Map<String, String> result = getMap(LISTENER_PROTOCOL_MAP_CONFIG)
         .entrySet()
@@ -1147,12 +1242,12 @@ public class RestConfig extends AbstractConfig {
             e -> e.getKey().toLowerCase(),
             e -> e.getValue().toLowerCase()));
     for (Map.Entry<String, String> entry : result.entrySet()) {
-      if (!ApplicationServer.SUPPORTED_URI_SCHEMES.contains(entry.getValue())) {
+      if (!SUPPORTED_URI_SCHEMES.contains(entry.getValue())) {
         throw new ConfigException(
             "Listener '" + entry.getKey()
             + "' specifies an unsupported protocol: " + entry.getValue());
       }
-      if (ApplicationServer.SUPPORTED_URI_SCHEMES.contains(entry.getKey())) {
+      if (SUPPORTED_URI_SCHEMES.contains(entry.getKey())) {
         // forbid http:https and https:http
         if (!entry.getKey().equals(entry.getValue())) {
           throw new ConfigException(

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -1187,16 +1187,10 @@ public class RestConfig extends AbstractConfig {
         .collect(Collectors.toList());
     List<NamedURI> namedUris =
         uris.stream().filter(uri -> uri.getName() != null).collect(Collectors.toList());
-    List<NamedURI> unnamedUris =
-        uris.stream().filter(uri -> uri.getName() == null).collect(Collectors.toList());
 
-    if (namedUris.stream().map(a -> a.getName()).distinct().count() != namedUris.size()) {
+    if (namedUris.stream().map(NamedURI::getName).distinct().count() != namedUris.size()) {
       throw new ConfigException(
           "More than one listener was specified with same name. Listener names must be unique.");
-    }
-    if (namedUris.isEmpty() && unnamedUris.isEmpty()) {
-      throw new ConfigException(
-          "No listeners are configured. At least one listener must be configured.");
     }
 
     return uris;
@@ -1209,7 +1203,7 @@ public class RestConfig extends AbstractConfig {
       uri = new URI(listener);
     } catch (URISyntaxException e) {
       throw new ConfigException(
-          "Listener '" + listener + "' is not a valid URI.");
+          "Listener '" + listener + "' is not a valid URI: " + e.getMessage());
     }
     if (uri.getPort() == -1) {
       throw new ConfigException(

--- a/core/src/main/java/io/confluent/rest/SslClientAuth.java
+++ b/core/src/main/java/io/confluent/rest/SslClientAuth.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+public enum SslClientAuth {
+  NONE, WANT, NEED
+}

--- a/core/src/main/java/io/confluent/rest/SslConfig.java
+++ b/core/src/main/java/io/confluent/rest/SslConfig.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public final class SslConfig {
+
+  private static final SslConfig DEFAULT_CONFIG =
+      new SslConfig(new RestConfig(RestConfig.baseConfigDef()));
+
+  private final RestConfig restConfig;
+
+  SslConfig(RestConfig restConfig) {
+    this.restConfig = requireNonNull(restConfig);
+  }
+
+  public static SslConfig defaultConfig() {
+    return DEFAULT_CONFIG;
+  }
+
+  public SslClientAuth getClientAuth() {
+    switch (restConfig.getString(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG)) {
+      case RestConfig.SSL_CLIENT_AUTHENTICATION_NONE:
+        return SslClientAuth.NONE;
+      case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUESTED:
+        return SslClientAuth.WANT;
+      case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED:
+        return SslClientAuth.NEED;
+      default:
+    }
+
+    if (restConfig.getBoolean(RestConfig.SSL_CLIENT_AUTH_CONFIG)) {
+      return SslClientAuth.NEED;
+    } else {
+      return SslClientAuth.NONE;
+    }
+  }
+
+  public String getEndpointIdentificationAlgorithm() {
+    return restConfig.getString(RestConfig.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG);
+  }
+
+  public List<String> getIncludeCipherSuites() {
+    return restConfig.getList(RestConfig.SSL_CIPHER_SUITES_CONFIG);
+  }
+
+  public List<String> getIncludeProtocols() {
+    return restConfig.getList(RestConfig.SSL_ENABLED_PROTOCOLS_CONFIG);
+  }
+
+  public String getKeyManagerFactoryAlgorithm() {
+    return restConfig.getString(RestConfig.SSL_KEYMANAGER_ALGORITHM_CONFIG);
+  }
+
+  public String getKeyManagerPassword() {
+    return restConfig.getPassword(RestConfig.SSL_KEY_PASSWORD_CONFIG).value();
+  }
+
+  public String getKeyStorePassword() {
+    return restConfig.getPassword(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG).value();
+  }
+
+  public String getKeyStorePath() {
+    return restConfig.getString(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG);
+  }
+
+  public String getKeyStoreType() {
+    return restConfig.getString(RestConfig.SSL_KEYSTORE_TYPE_CONFIG);
+  }
+
+  public String getProtocol() {
+    return restConfig.getString(RestConfig.SSL_PROTOCOL_CONFIG);
+  }
+
+  public String getProvider() {
+    return restConfig.getString(RestConfig.SSL_PROVIDER_CONFIG);
+  }
+
+  public boolean getReloadOnKeyStoreChange() {
+    return restConfig.getBoolean(RestConfig.SSL_KEYSTORE_RELOAD_CONFIG);
+  }
+
+  public String getReloadOnKeyStoreChangePath() {
+    if (!restConfig.getString(RestConfig.SSL_KEYSTORE_WATCH_LOCATION_CONFIG).isEmpty()) {
+      return restConfig.getString(RestConfig.SSL_KEYSTORE_WATCH_LOCATION_CONFIG);
+    } else {
+      return getKeyStorePath();
+    }
+  }
+
+  public String getTrustManagerFactoryAlgorithm() {
+    return restConfig.getString(RestConfig.SSL_TRUSTMANAGER_ALGORITHM_CONFIG);
+  }
+
+  public String getTrustStorePassword() {
+    return restConfig.getPassword(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG).value();
+  }
+
+  public String getTrustStorePath() {
+    return restConfig.getString(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG);
+  }
+
+  public String getTrustStoreType() {
+    return restConfig.getString(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG);
+  }
+}

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public final class SslFactory {
+
+  private static final Logger log = LoggerFactory.getLogger(SslFactory.class);
+
+  private SslFactory() {}
+
+  public static SslContextFactory createSslContextFactory(SslConfig sslConfig) {
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+
+    if (!sslConfig.getKeyStorePath().isEmpty()) {
+      sslContextFactory.setKeyStorePath(sslConfig.getKeyStorePath());
+      sslContextFactory.setKeyStorePassword(sslConfig.getKeyStorePassword());
+      sslContextFactory.setKeyManagerPassword(sslConfig.getKeyManagerPassword());
+      sslContextFactory.setKeyStoreType(sslConfig.getKeyStoreType());
+
+      if (!sslConfig.getKeyManagerFactoryAlgorithm().isEmpty()) {
+        sslContextFactory.setKeyManagerFactoryAlgorithm(sslConfig.getKeyManagerFactoryAlgorithm());
+      }
+
+      if (sslConfig.getReloadOnKeyStoreChange()) {
+        Path watchLocation = Paths.get(sslConfig.getReloadOnKeyStoreChangePath());
+        try {
+          FileWatcher.onFileChange(watchLocation, () -> {
+                // Need to reset the key store path for symbolic link case
+                sslContextFactory.setKeyStorePath(sslConfig.getKeyStorePath());
+                sslContextFactory.reload(scf -> log.info("Reloaded SSL cert"));
+              }
+          );
+          log.info("Enabled SSL cert auto reload for: " + watchLocation);
+        } catch (java.io.IOException e) {
+          log.error("Can not enabled SSL cert auto reload", e);
+        }
+      }
+    }
+
+    configureClientAuth(sslContextFactory, sslConfig);
+
+    if (!sslConfig.getIncludeProtocols().isEmpty()) {
+      sslContextFactory.setIncludeProtocols(
+          sslConfig.getIncludeProtocols().toArray(new String[0]));
+    }
+
+    if (!sslConfig.getIncludeCipherSuites().isEmpty()) {
+      sslContextFactory.setIncludeCipherSuites(
+          sslConfig.getIncludeCipherSuites().toArray(new String[0]));
+    }
+
+    sslContextFactory.setEndpointIdentificationAlgorithm(
+        sslConfig.getEndpointIdentificationAlgorithm());
+
+    if (!sslConfig.getTrustStorePath().isEmpty()) {
+      sslContextFactory.setTrustStorePath(sslConfig.getTrustStorePath());
+      sslContextFactory.setTrustStorePassword(sslConfig.getTrustStorePassword());
+      sslContextFactory.setTrustStoreType(sslConfig.getTrustStoreType());
+
+      if (!sslConfig.getTrustManagerFactoryAlgorithm().isEmpty()) {
+        sslContextFactory.setTrustManagerFactoryAlgorithm(
+            sslConfig.getTrustManagerFactoryAlgorithm());
+      }
+    }
+
+    sslContextFactory.setProtocol(sslConfig.getProtocol());
+    if (!sslConfig.getProvider().isEmpty()) {
+      sslContextFactory.setProvider(sslConfig.getProvider());
+    }
+
+    sslContextFactory.setRenegotiationAllowed(false);
+
+    return sslContextFactory;
+  }
+
+  private static void configureClientAuth(
+      SslContextFactory.Server sslContextFactory, SslConfig config) {
+    switch (config.getClientAuth()) {
+      case NEED:
+        sslContextFactory.setNeedClientAuth(true);
+        break;
+      case WANT:
+        sslContextFactory.setWantClientAuth(true);
+        break;
+      default:
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationServerTest.java
@@ -169,10 +169,7 @@ public class ApplicationServerTest {
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
     // Should not throw, since http is not considered a listener name.
-    List<ApplicationServer.NamedURI> listeners = ApplicationServer.parseListeners(
-      config.getList(RestConfig.LISTENERS_CONFIG),
-      config.getListenerProtocolMap(),
-      0, ApplicationServer.SUPPORTED_URI_SCHEMES, "");
+    List<NamedURI> listeners = config.getListeners();
 
     assertEquals(2, listeners.size());
 
@@ -190,12 +187,7 @@ public class ApplicationServerTest {
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
-    assertThrows(ConfigException.class,
-        () ->
-    ApplicationServer.parseListeners(
-      config.getList(RestConfig.LISTENERS_CONFIG),
-      config.getListenerProtocolMap(),
-      0, ApplicationServer.SUPPORTED_URI_SCHEMES, ""));
+    assertThrows(ConfigException.class, config::getListeners);
   }
 
   @Test
@@ -205,10 +197,7 @@ public class ApplicationServerTest {
     props.put(RestConfig.LISTENER_PROTOCOL_MAP_CONFIG, "INTERNAL:http,EXTERNAL:https");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
-    List<ApplicationServer.NamedURI> namedListeners = ApplicationServer.parseListeners(
-      config.getList(RestConfig.LISTENERS_CONFIG),
-      config.getListenerProtocolMap(),
-      0, ApplicationServer.SUPPORTED_URI_SCHEMES, "");
+    List<NamedURI> namedListeners = config.getListeners();
 
     assertEquals(2, namedListeners.size());
 
@@ -225,10 +214,7 @@ public class ApplicationServerTest {
     props.put(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:4000,https://0.0.0.0:443");
     RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
 
-    List<ApplicationServer.NamedURI> namedListeners = ApplicationServer.parseListeners(
-      config.getList(RestConfig.LISTENERS_CONFIG),
-      config.getListenerProtocolMap(),
-      0, ApplicationServer.SUPPORTED_URI_SCHEMES, "");
+    List<NamedURI> namedListeners = config.getListeners();
 
     assertEquals(2, namedListeners.size());
 

--- a/core/src/test/java/io/confluent/rest/ApplicationTest.java
+++ b/core/src/test/java/io/confluent/rest/ApplicationTest.java
@@ -30,6 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import io.confluent.rest.extension.ResourceExtension;
+import io.confluent.rest.metrics.RestMetricsContext;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.net.URI;
@@ -50,8 +51,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
-
-import io.confluent.rest.metrics.RestMetricsContext;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -99,7 +98,7 @@ public class ApplicationTest {
     List<String> listenersConfig = new ArrayList<>();
     List<URI> listeners = Application.parseListeners(listenersConfig,
         RestConfig.PORT_CONFIG_DEFAULT,
-        ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+        RestConfig.SUPPORTED_URI_SCHEMES, "http");
     assertEquals(1, listeners.size(), "Should have only one listener.");
     assertExpectedUri(listeners.get(0), "http", "0.0.0.0", RestConfig.PORT_CONFIG_DEFAULT);
   }
@@ -110,7 +109,7 @@ public class ApplicationTest {
     listenersConfig.add("http://localhost:123");
     listenersConfig.add("https://localhost:124");
     List<URI> listeners = Application.parseListeners(listenersConfig, -1,
-        ApplicationServer.SUPPORTED_URI_SCHEMES, "http");
+        RestConfig.SUPPORTED_URI_SCHEMES, "http");
     assertEquals(2, listeners.size(), "Should have two listeners.");
     assertExpectedUri(listeners.get(0), "http", "localhost", 123);
     assertExpectedUri(listeners.get(1), "https", "localhost", 124);
@@ -122,7 +121,7 @@ public class ApplicationTest {
     listenersConfig.add("!");
     assertThrows(ConfigException.class,
         () ->
-            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+            Application.parseListeners(listenersConfig, -1, RestConfig.SUPPORTED_URI_SCHEMES,
                 "http"));
   }
 
@@ -133,7 +132,7 @@ public class ApplicationTest {
     listenersConfig.add("foo://localhost:8081");
     assertThrows(ConfigException.class,
         () ->
-            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+            Application.parseListeners(listenersConfig, -1, RestConfig.SUPPORTED_URI_SCHEMES,
                 "http"));
   }
 
@@ -143,7 +142,7 @@ public class ApplicationTest {
     listenersConfig.add("bar://localhost:8081");
     assertThrows(ConfigException.class,
         () ->
-            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+            Application.parseListeners(listenersConfig, -1, RestConfig.SUPPORTED_URI_SCHEMES,
                 "http"));
   }
 
@@ -153,7 +152,7 @@ public class ApplicationTest {
     listenersConfig.add("http://localhost");
     assertThrows(ConfigException.class,
         () ->
-            Application.parseListeners(listenersConfig, -1, ApplicationServer.SUPPORTED_URI_SCHEMES,
+            Application.parseListeners(listenersConfig, -1, RestConfig.SUPPORTED_URI_SCHEMES,
                 "http"));
   }
 


### PR DESCRIPTION
This PR prepares the rest-utils API for per-listener SSL configs. Changes:

 * [new] `SslConfig`: This class encapsulates the many SSL params in rest-utils.
 * [new] `SslFactory`: `ApplicationServer.createSslContextFactory` method extracted out.
 * Moved all the listener parsing logic from `ApplicationServer` to `RestConfig`.
 * [new] `RestConfig.getBaseSslConfig()`: Returns the unprefixed (base) SSL configs.
 * [new] `RestConfig.getSslConfigs()`: Returns the per-listener SSL configs.

Note that this PR does not implements per-listener SSL config. It only introduces the APIs, so that downstream applications can adapt before the changes. As such, all the SSL configs returned are the same for all listeners.