### PR TITLE
Use LINEAR instead of CONSTANT bucket sizing for latency percentiles.

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -256,7 +256,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       Percentiles percs = new Percentiles(Float.SIZE / 8 * PERCENTILE_NUM_BUCKETS,
           0.0,
           PERCENTILE_MAX_LATENCY_IN_MS,
-          Percentiles.BucketSizing.CONSTANT,
+          Percentiles.BucketSizing.LINEAR,
           new Percentile(new MetricName(
               getName(method, annotation, "request-latency-95"), metricGrpName,
               "The 95th percentile request latency in ms", allTags), 95),


### PR DESCRIPTION
  This will give greater precision when latency is closer to zero
  (and less precision when it's further). With 200 buckets to cover
  10 seconds, CONSTANT sizing gave no precision below 50 ms.

Ref: https://github.com/confluentinc/ce-kafka/blob/5f154af1ffc138ac5ab7b4de1829e3c247f32015/clients/src/main/java/org/apache/kafka/common/metrics/stats/Histogram.java#L164-L168