### PR TITLE
APIF-2959: Fix SslConfig.getClientAuth.

### DIFF
--- a/core/src/main/java/io/confluent/rest/SslConfig.java
+++ b/core/src/main/java/io/confluent/rest/SslConfig.java
@@ -36,7 +36,10 @@ public final class SslConfig {
   }
 
   public SslClientAuth getClientAuth() {
-    switch (restConfig.getString(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG)) {
+    String clientAuthentication =
+        (String) restConfig.originals()
+            .getOrDefault(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG, "");
+    switch (clientAuthentication) {
       case RestConfig.SSL_CLIENT_AUTHENTICATION_NONE:
         return SslClientAuth.NONE;
       case RestConfig.SSL_CLIENT_AUTHENTICATION_REQUESTED:


### PR DESCRIPTION
https://github.com/confluentinc/rest-utils/pull/357 broke SslConfig.getClientAuth by ignoring the `ssl.client.auth` config. This happens because the `ssl.client.authentication` config has a default of `NONE`, meaning the switch on getClientAuth never reaches the default clause. This breaks downstream projects that rely on the `ssl.client.auth` flag.