### PR TITLE
Add ApplicationServer.getSslContextFactories method.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -225,6 +225,7 @@ public abstract class Application<T extends RestConfig> {
   /**
    * expose SslContextFactory
    */
+  @Deprecated
   protected SslContextFactory getSslContextFactory() {
     return server.getSslContextFactory();
   }


### PR DESCRIPTION
And use it to configure the per-listener SSL factories, even if they are all the same.

This is needed so that https://github.com/confluentinc/blueway/pull/2445 works without changing behaviour on C3 backend.