### PR TITLE
APIF-2959: Add support for per-listener SSL config.

### DIFF
--- a/core/src/main/java/io/confluent/rest/NamedURI.java
+++ b/core/src/main/java/io/confluent/rest/NamedURI.java
@@ -18,6 +18,7 @@ package io.confluent.rest;
 
 import javax.annotation.Nullable;
 import java.net.URI;
+import java.util.Locale;
 import java.util.Objects;
 
 public final class NamedURI {
@@ -27,7 +28,7 @@ public final class NamedURI {
 
   public NamedURI(URI uri, @Nullable String name) {
     this.uri = uri;
-    this.name = name;
+    this.name = name != null ? name.toLowerCase(Locale.ENGLISH) : null;
   }
 
   public URI getUri() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -30,9 +30,11 @@ import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.UriBuilder;
@@ -1141,10 +1143,20 @@ public class RestConfig extends AbstractConfig {
     return new SslConfig(this);
   }
 
+  private SslConfig getSslConfig(NamedURI listener) {
+    String prefix =
+        "listener.name." + Optional.ofNullable(listener.getName()).orElse("https") + ".";
+
+    Map<String, Object> overridden = originals();
+    overridden.putAll(filterByAndStripPrefix(originals(), prefix));
+
+    return new SslConfig(new RestConfig(baseConfigDef(), overridden));
+  }
+
   public final Map<NamedURI, SslConfig> getSslConfigs() {
     return getListeners().stream()
         .filter(listener -> listener.getUri().getScheme().equals("https"))
-        .collect(toImmutableMap(Function.identity(), unused -> getBaseSslConfig()));
+        .collect(toImmutableMap(Function.identity(), this::getSslConfig));
   }
 
   public final Map<String, String> getMap(String propertyName) {


### PR DESCRIPTION
`ApplicationServer` already has the ability to specify listener names in the `listeners` config. This PR adds the ability to specify per-listener-name overrides for the SSL configs only (i.e. configs starting with `ssl.`, no other config affected).

The way to do that is by setting the config `listener.name.<listener-name>.<ssl-config>` instead of `<ssl-config>`. If you set `<ssl-config>`, that will be treated as the default value for `listener.name.<listener-name>.<ssl-config>` for all listeners. Example:

```
// Config

listeners=A://1.1.1.1:1,B://2.2.2.2:2
listener.protocol.map=A:https,B:https
ssl.keystore.location=default.jks
listener.name.A.ssl.keystore.location=a.jks

// Means

// For listener https://1.1.1.1:1
ssl.keystore.location=a.jks

// For listener https://2.2.2.2:2
ssl.keystore.location=default.jks
```

Notice that `https` is a valid name, and it is special in that it can be specified multiple times. If SSL config is overriden for the name `https`, the override will apply to all the `https` named listeners. Example:

```
// Config

listeners=https://1.1.1.1:1,https://2.2.2.2:2,A://3.3.3.3:3
listener.protocol.map=A:https
ssl.keystore.location=default.jk
listener.name.A.ssl.keystore.location=a.jks
listener.name.https.ssl.keystore.location=https.jks

// Means

// For listener https://1.1.1.1:1
ssl.keystore.location=https.jks

// For listener https://2.2.2.2:2
ssl.keystore.location=https.jks

// For listener https://3.3.3.3:3
ssl.keystore.location=a.jks
```

One last piece of corner-case is around case-insensitive overrides. The original implementation of named listeners specifies that listener names should case-insensitive (i.e. setting `listeners=A://1.1.1.1:1` and `listener.protocol.map=a:https` should work). An unfortunate side-effect is that the same listener override could be set by accident multiple times. If that happens, one of them will be selected, but which one is unspecified. Example:

```
// Config

listeners=A://1.1.1.1:1
listener.protocol.map=A:https
ssl.keystore.location=default.jks
listener.name.A.ssl.keystore.location=a1.jks
listener.name.a.ssl.keystore.location=a2.jks

// For listener https://1.1.1.1:1

// It could mean this
ssl.keystore.location=a1.jks

// Or this
ssl.keystore.location=a2.jks

// It will be one of the above, but which one is unspecified. Just don't do that.
```

No changes required on downstream applications.