### PR TITLE
KREST-8391 swap order of dos rate limiters

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -675,6 +675,7 @@ public abstract class Application<T extends RestConfig> {
     if (!config.isDosFilterEnabled()) {
       return;
     }
+    // Ensure that the per connection limiter is first - KREST-8391
     configureNonGlobalDosFilter(context);
     configureGlobalDosFilter(context);
   }

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -675,8 +675,8 @@ public abstract class Application<T extends RestConfig> {
     if (!config.isDosFilterEnabled()) {
       return;
     }
-    configureGlobalDosFilter(context);
     configureNonGlobalDosFilter(context);
+    configureGlobalDosFilter(context);
   }
 
   private void configureNonGlobalDosFilter(ServletContextHandler context) {


### PR DESCRIPTION
We use two jetty DOS rate limiters - a global (all ips) one and a per connection one.

These were registered backwards - the global one first and then the per connection one.

This meant that if someone was spamming our endpoints, the global limiter's requests were all used up before the per connection one could take effect.

Jetty maintains the order of the filters registered, so if we register the per connection one first, that will get rid of the too many connections from a single ip issue.

I've tested this locally using curl with the --resolve option.  Requests from 127.0.0.1 in a tight loop get rate limited, and requests from my ip address that go through at a much slower rate do not.

There is a slight concern that the list of ip addresses held by the dos filter might get too long, but I don't have a way to test this locally, and I don't think it's any different to the situation we have at present where we might have lots of different ip addresses connecting over a period of time,