### PR TITLE
Adapt test to the new ConcurrentTransactionsException heritage

### DIFF
--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -134,19 +134,8 @@ public class KafkaExceptionMapperTest {
     //test couple of kafka exception
     verifyMapperResponse(new CommitFailedException(), Status.INTERNAL_SERVER_ERROR,
         KAFKA_ERROR_ERROR_CODE);
-
-    Exception cte = new ConcurrentTransactionsException("some message");
-    // In KAFKA-14417, ConcurrentTransactionsException was changed from an ApiException to be
-    //  a RetriableException (which is itself an ApiException)
-    // To adapt to this, using if/else logic based on instanceof check so the test can handle the
-    //  ConcurrentTransactionsException being of either heritage
-    if (cte instanceof RetriableException) {
-      // After the change KAFKA-14417 ripples thru the builds, this should be the eventual check,
-      //  with the else block looking for KAFKA_ERROR_ERROR_CODE being removed.
-      verifyMapperResponse(cte, Status.INTERNAL_SERVER_ERROR, KAFKA_RETRIABLE_ERROR_ERROR_CODE);
-    } else {
-      verifyMapperResponse(cte, Status.INTERNAL_SERVER_ERROR, KAFKA_ERROR_ERROR_CODE);
-    }
+    verifyMapperResponse(new ConcurrentTransactionsException("some message"),
+        Status.INTERNAL_SERVER_ERROR, KAFKA_RETRIABLE_ERROR_ERROR_CODE);
 
     //test few general exceptions
     verifyMapperResponse(new NullPointerException("some message"), Status.INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
 - now that the change from KAFKA-14417 ConcurrentTransactionsException 
   has propagated thru the system