### PR TITLE
Add BoringSSL TLS provider with Conscrypt

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -82,6 +82,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-alpn-conscrypt-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.conscrypt</groupId>
+            <artifactId>conscrypt-openjdk-uber</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
         </dependency>
         <dependency>

--- a/core/src/main/java/io/confluent/rest/SslConfig.java
+++ b/core/src/main/java/io/confluent/rest/SslConfig.java
@@ -22,6 +22,8 @@ import static java.util.Objects.requireNonNull;
 
 public final class SslConfig {
 
+  public static final String TLS_CONSCRYPT = "Conscrypt";
+
   private static final SslConfig DEFAULT_CONFIG =
       new SslConfig(new RestConfig(RestConfig.baseConfigDef()));
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.5.0-0</io.confluent.rest-utils.version>
+        <conscrypt.version>2.5.2</conscrypt.version>
     </properties>
 
     <repositories>
@@ -164,6 +165,16 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-alpn-java-server</artifactId>
                 <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-alpn-conscrypt-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.conscrypt</groupId>
+                <artifactId>conscrypt-openjdk-uber</artifactId>
+                <version>${conscrypt.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
Adding jetty to uses [Conscrypt](https://github.com/google/conscrypt) TLS Engine as well which is based on BoringSSL and provides better TLS performance. Also with Conscrypt [HTTP/2 with Jetty can be supported over JDK 8](https://github.com/jetty-project/jetty.project/blob/e89b985fd59928d3f0432bddf38991977366d85c/documentation/jetty-documentation/src/main/asciidoc/old_docs/alpn/alpn.adoc#L35) as well.

Configuration needed:
```
ssl.protocol=TLSv1.3
ssl.provider=Conscrypt
```

The changes were tested with `Java 8` and `Java 17` in `HTTP/2` `enabled/disabled` mode and `with/without` `Conscrypt` TLS provider. 

## Java 1.8.0.351:
  ### Http/2 - disabled with Default TLS/SSL Engine
```
    [2023-03-06 13:05:01,649] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@4364712f(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:05:01,649] DEBUG Chose explicit alias=kafka-rest keyType=RSA on sun.security.ssl.SSLEngineImpl@5fe33b07 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

  ### Http/2 - disabled with Conscrypt TLS/SSL Engine
```
    [2023-03-06 13:06:02,170] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:06:02,172] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@fe34b86(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:06:02,173] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:06:02,173] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@fe34b86(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:06:02,173] DEBUG Chose explicit alias=kafka-rest keyType=RSA on org.conscrypt.ConscryptEngine@4bff000 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
    [2023-03-06 13:06:02,176] DEBUG Chose explicit alias=null keyType=EC on org.conscrypt.ConscryptEngine@4bff000 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

  ### Http/2 - Enabled and Default TLS/SSL Engine
  #### HTTP/2 is not compatible in this scenario hence no HTTP/2 initialization triggers
```
    [2023-03-06 13:55:19,283] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:55:19,328] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@4364712f(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:55:19,329] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:55:19,329] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@4364712f(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:55:19,329] DEBUG Chose explicit alias=kafka-rest keyType=RSA on sun.security.ssl.SSLEngineImpl@5fe33b07 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

  ### Http/2 - Enabled and Conscrypt TLS/SSL Engine
```
    [2023-03-06 13:53:13,407] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:53:13,411] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@78b612c6(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:53:13,411] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:53:13,411] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@78b612c6(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:53:13,411] DEBUG Chose explicit alias=kafka-rest keyType=RSA on org.conscrypt.ConscryptEngine@2826aaeb (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
    [2023-03-06 13:53:13,415] DEBUG Chose explicit alias=null keyType=EC on org.conscrypt.ConscryptEngine@2826aaeb (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

## Java 17:
  ### Http/2 - disabled and Default TLS/SSL Engine
```
    [2023-03-06 13:14:18,462] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:14:18,480] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@2eada095(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:14:18,481] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:14:18,481] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@2eada095(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:14:18,481] DEBUG Chose explicit alias=kafka-rest keyType=RSA on SSLEngine[hostname=127.0.0.1, port=50810, Session(1678108458411|SSL_NULL_WITH_NULL_NULL)] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

  ### Http/2 - disabled and Conscrypt TLS/SSL Engine
```
    [2023-03-06 13:15:06,709] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:15:06,711] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@364b1061(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:15:06,711] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:15:06,711] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@364b1061(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:15:06,711] DEBUG Chose explicit alias=kafka-rest keyType=RSA on org.conscrypt.ConscryptEngine@720da883 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
    [2023-03-06 13:15:06,714] DEBUG Chose explicit alias=null keyType=EC on org.conscrypt.ConscryptEngine@720da883 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
```

  ### Http/2 - Enabled and Default TLS/SSL Engine
```
    [2023-03-06 13:16:56,561] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:16:56,581] DEBUG apply ALPNServerConnection@926816a::DecryptedEndPoint@5ea63108{l=/127.0.0.1:8082,r=/127.0.0.1:50862,OPEN,fill=-,flush=-,to=56/30000} [h2, http/1.1] (org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor:74)
    [2023-03-06 13:16:56,584] DEBUG proto=h2 tls=TLSv1.3 cipher=TLS_AES_256_GCM_SHA384 9.2.2-acceptable=true (org.eclipse.jetty.http2.server.HTTP2ServerConnectionFactory:73)
    [2023-03-06 13:16:56,584] DEBUG Protocol selected h2 from client[h2, http/1.1] and server[h2, http/1.1] on DecryptedEndPoint@5ea63108{l=/127.0.0.1:8082,r=/127.0.0.1:50862,OPEN,fill=-,flush=-,to=59/30000} (org.eclipse.jetty.alpn.server.ALPNServerConnection:90)
    [2023-03-06 13:16:56,590] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@59636c47(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:16:56,590] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:16:56,590] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@59636c47(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:16:56,590] DEBUG Chose explicit alias=kafka-rest keyType=RSA on SSLEngine[hostname=127.0.0.1, port=50862, Session(1678108616517|SSL_NULL_WITH_NULL_NULL)] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
    [2023-03-06 13:16:56,661] DEBUG fill NEED_WRAP (org.eclipse.jetty.io.ssl.SslConnection:646)
```

  ### Http/2 - Enabled and Conscrypt TLS/SSL Engine
```
    [2023-03-06 13:17:48,417] DEBUG SNI host name localhost (org.eclipse.jetty.util.ssl.SslContextFactory:2161)
    [2023-03-06 13:17:48,419] DEBUG Selecting alias: keyType=RSA, sni=localhost, sniRequired=false, certs=[X509@59636c47(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[])] (org.eclipse.jetty.util.ssl.SslContextFactory:2397)
    [2023-03-06 13:17:48,420] DEBUG Selected alias=kafka-rest (org.eclipse.jetty.util.ssl.SslContextFactory:2436)
    [2023-03-06 13:17:48,420] DEBUG Matched SNI localhost with alias kafka-rest, certificate X509@59636c47(kafka-rest,h=[localhost, kafka-rest],a=[/127.0.0.1],w=[]) from aliases [kafka-rest] (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:172)
    [2023-03-06 13:17:48,420] DEBUG Chose explicit alias=kafka-rest keyType=RSA on org.conscrypt.ConscryptEngine@8197ed2 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)
    [2023-03-06 13:17:48,423] DEBUG Chose explicit alias=null keyType=EC on org.conscrypt.ConscryptEngine@8197ed2 (org.eclipse.jetty.util.ssl.SniX509ExtendedKeyManager:208)