### PR TITLE
CIAM-2673: initialize start time in metrics before onEvent() is called

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -412,7 +412,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     public MetricsRequestEventListener(final Map<Method, RequestScopedMetrics> metrics, Time time) {
       this.metrics = metrics;
       this.time = time;
-      // CIAM-2673: if an exception occurs, MATCHING_START is never reached, resulting in false latency metrics
+      // CIAM-2673: if an exception occur in a filter that runs before this method listener,
+      // MATCHING_START is never reached, resulting in false latency metrics
       this.started = time.milliseconds();
     }
 

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -412,6 +412,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     public MetricsRequestEventListener(final Map<Method, RequestScopedMetrics> metrics, Time time) {
       this.metrics = metrics;
       this.time = time;
+      // CIAM-2673: if an exception occurs, MATCHING_START is never reached, resulting in false latency metrics
+      this.started = time.milliseconds();
     }
 
     @Override


### PR DESCRIPTION
We're noticing severe latency spikes that correspond with API errors. Upon investigation, it seems that the `started` variable in `MetricsRequestEventListener` does not get initialized in `onEvent()` when an error occurs, resulting in a total latency calculation of `Time.milliseconds() - 0`. This CR initializes `started` in the constructor to avoid false latency reports.