### PR TITLE
Make SNI host check explicit

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -228,7 +228,10 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     for (NamedURI listener : listeners) {
       if (listener.getUri().getScheme().equals("https")) {
         if (httpConfiguration.getCustomizer(SecureRequestCustomizer.class) == null) {
-          httpConfiguration.addCustomizer(new SecureRequestCustomizer());
+          SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
+          // Explicitly making sure that SNI is checked against Host in HTTP request
+          secureRequestCustomizer.setSniHostCheck(true);
+          httpConfiguration.addCustomizer(secureRequestCustomizer);
         }
       }
       addConnectorForListener(httpConfiguration, httpConnectionFactory, listener,


### PR DESCRIPTION
The default value of SniHostCheck in SecureRequestCustomizer class is true. That means this option is always enabled in our Kafka REST.

This PR is just making sure that we explicitly set this to true (for example, some time later there is a breaking change in jetty library if we ever update it).