### PR TITLE
KREST-8331 - Remove class names from exceptions

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/JsonMappingExceptionMapper.java
@@ -17,6 +17,8 @@
 package io.confluent.rest.exceptions;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
+import com.google.common.annotations.VisibleForTesting;
+
 import io.confluent.rest.entities.ErrorMessage;
 
 import javax.annotation.Priority;
@@ -29,26 +31,60 @@ import javax.ws.rs.ext.Provider;
 public class JsonMappingExceptionMapper implements ExceptionMapper<JsonMappingException> {
 
   public static final int BAD_REQUEST_CODE = 400;
-  // For the exception message, it contains information like `(for Object starting at
+  // For the exception message, it contains information like `(for Object starting
+  // at
   // [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor
   // $UnCloseableInputStream);
-  // line: 1, column: 129])`, but we don't want to expose all these information to user,
+  // line: 1, column: 129])`, but we don't want to expose all these information to
+  // user,
   // so we need to use this splitter to hide source part of the information.
   public static final String MESSAGE_SOURCE_SPLITTER = "\\(for Object starting at";
 
   @Override
   public Response toResponse(JsonMappingException exception) {
-    String originalMessage = exception.getOriginalMessage();
-    String messageWithoutSource = originalMessage == null ? null :
-            originalMessage.split(MESSAGE_SOURCE_SPLITTER)[0].trim();
-
-    ErrorMessage message = new ErrorMessage(
-        BAD_REQUEST_CODE,
-            messageWithoutSource
-    );
+    ErrorMessage message = new ErrorMessage(BAD_REQUEST_CODE,
+        sanitizeExceptionMessage(exception.getOriginalMessage()));
 
     return Response.status(BAD_REQUEST_CODE)
         .entity(message)
         .build();
+  }
+
+  @VisibleForTesting
+  public String sanitizeExceptionMessage(String originalMessage) {
+    if (originalMessage == null) {
+      return null;
+    }
+
+    // First strip off any trailing details of the code generating the exception.
+    // Example: `(for Object starting at [Source: (o.a.k.C); line: 1, column: 9])`
+    String sanitizedMessage = originalMessage.split(MESSAGE_SOURCE_SPLITTER)[0].trim();
+
+    // If the message contains a fully qualified Java class name, strip the package
+    // name leaving the class name. For an inner class, retain just the inner class.
+
+    // The exception messages use ` to enclose the Java class name.
+    String[] fragments = sanitizedMessage.split("\\`", -1);
+    if (fragments.length > 2) {
+      // The class name is the second fragment
+      String className = fragments[1];
+
+      // Find the final . to indicate the end of the package name
+      int lastDot = className.lastIndexOf('.');
+      if ((lastDot != -1) && (lastDot != className.length() - 1)) {
+        className = className.substring(lastDot + 1);
+      }
+
+      // Find the final $ to indicate the start of an inner class name
+      int dollar = className.lastIndexOf('$');
+      if ((dollar != -1) && (dollar != className.length() - 1)) {
+        className = className.substring(dollar + 1);
+      }
+
+      fragments[1] = className;
+      sanitizedMessage = String.join("`", fragments);
+    }
+
+    return sanitizedMessage;
   }
 }


### PR DESCRIPTION
Exceptions which are generated by Jackson databind include a lot of information about the code such as full class names. This change abbreviates the class name information to reveal less of the implementation of the REST Proxy.