### PR TITLE
Defer loading Conscrypt library

### DIFF
--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -16,12 +16,9 @@
 
 package io.confluent.rest;
 
-import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.Provider;
 import java.security.Security;
-import java.util.Map;
 import org.conscrypt.OpenSSLProvider;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.ssl.SslContextFactory.Server;
@@ -31,9 +28,6 @@ import org.slf4j.LoggerFactory;
 public final class SslFactory {
 
   private static final Logger log = LoggerFactory.getLogger(SslFactory.class);
-
-  private static final Map<String, Provider> securityProviderMap = ImmutableMap.of(
-      SslConfig.TLS_CONSCRYPT, new OpenSSLProvider());
 
   private SslFactory() {}
 
@@ -117,8 +111,8 @@ public final class SslFactory {
 
   private static void configureSecurityProvider(Server sslContextFactory, SslConfig sslConfig) {
     sslContextFactory.setProvider(sslConfig.getProvider());
-    if (securityProviderMap.containsKey(sslConfig.getProvider())) {
-      Security.addProvider(securityProviderMap.get(sslConfig.getProvider()));
+    if (SslConfig.TLS_CONSCRYPT.equalsIgnoreCase(sslConfig.getProvider())) {
+      Security.addProvider(new OpenSSLProvider());
     }
   }
 }


### PR DESCRIPTION
- Conscrypt is not yet supported on AARCH64 architecture hence eager loading of library causes issue. Defer load until ssl provider explicitly specifies. 

- Supported platforms are mentioned here: https://github.com/google/conscrypt/#native-classifiers

## Tests

- Change has been tested on server with `arm64` arch.