### PR TITLE
Remove stacktrace in response when server throws BadMessageException

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -22,7 +22,6 @@ import static java.util.Collections.emptyMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.rest.auth.AuthUtil;
-import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.GenericExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
@@ -309,10 +308,6 @@ public abstract class Application<T extends RestConfig> {
       context.setBaseResource(staticResources);
     }
 
-    if (isErrorStackTraceSuppressionEnabled()) {
-      context.setErrorHandler(new NoJettyDefaultStackTraceErrorHandler());
-    }
-
     configureSecurityHandler(context);
 
     if (isCorsEnabled()) {
@@ -431,10 +426,6 @@ public abstract class Application<T extends RestConfig> {
 
   private boolean isCsrfProtectionEnabled() {
     return config.getBoolean(RestConfig.CSRF_PREVENTION_ENABLED);
-  }
-
-  private boolean isErrorStackTraceSuppressionEnabled() {
-    return config.getBoolean(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
+import io.confluent.rest.errorhandlers.NoJettyDefaultStackTraceErrorHandler;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -185,7 +186,13 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     }
   }
 
+  @Override
   protected final void doStart() throws Exception {
+    // set the default error handler
+    if (config.getSuppressStackTraceInResponse()) {
+      this.setErrorHandler(new NoJettyDefaultStackTraceErrorHandler());
+    }
+
     HandlerCollection handlers = new HandlerCollection();
     HandlerCollection wsHandlers = new HandlerCollection();
     for (Application<?> app : applications) {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -1153,6 +1153,10 @@ public class RestConfig extends AbstractConfig {
     return getInt(CONNECTOR_CONNECTION_LIMIT);
   }
 
+  public final boolean getSuppressStackTraceInResponse() {
+    return getBoolean(SUPPRESS_STACK_TRACE_IN_RESPONSE);
+  }
+
   public final List<NamedURI> getListeners() {
     return parseListeners(
         getList(RestConfig.LISTENERS_CONFIG),

--- a/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
+++ b/core/src/main/java/io/confluent/rest/errorhandlers/NoJettyDefaultStackTraceErrorHandler.java
@@ -5,6 +5,7 @@
 package io.confluent.rest.errorhandlers;
 
 import java.io.IOException;
+import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpStatus;
@@ -12,8 +13,6 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 
 public class NoJettyDefaultStackTraceErrorHandler extends ErrorHandler {
-  private static final String JAVAX_ERROR_EXCEPTION_ATTRIBUTE = "javax.servlet.error.exception";
-
   public NoJettyDefaultStackTraceErrorHandler() {
     super();
     setShowServlet(false);
@@ -22,7 +21,8 @@ public class NoJettyDefaultStackTraceErrorHandler extends ErrorHandler {
   @Override
   protected void generateAcceptableResponse(Request baseRequest, HttpServletRequest request,
       HttpServletResponse response, int code, String message) throws IOException {
-    request.setAttribute(JAVAX_ERROR_EXCEPTION_ATTRIBUTE, null);
+    // set Exception to null to avoid exposing stack trace to clients
+    request.setAttribute(RequestDispatcher.ERROR_EXCEPTION, null);
     super.generateAcceptableResponse(baseRequest, request, response, code,
         retrieveErrorMessage(code, message));
   }

--- a/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/ErrorHandlerIntegrationTest.java
@@ -4,15 +4,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
+import javax.net.ssl.SSLContext;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.test.TestSslUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.ConstraintMapping;
 import org.eclipse.jetty.security.ConstraintSecurityHandler;
@@ -22,39 +35,46 @@ import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.util.security.Constraint;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ErrorHandlerIntegrationTest {
 
   private static final String DUMMY_EXCEPTION = "dummy exception";
   private Server server;
+  private HttpClient httpClient;
+  private Properties props;
+  private File clientKeystore;
+
+  public static final String SSL_PASSWORD = "test1234";
+
+  @BeforeEach
+  public void setUp() {
+    props = new Properties();
+  }
 
   @AfterEach
   public void tearDown() throws Exception {
+    httpClient.stop();
     server.stop();
     server.join();
   }
 
   @Test
-  public void unhandledServerExceptionDisplaysStackTraceForInvalidAuthentication()
+  public void test_http_unhandledServerExceptionDisplaysStackTraceForInvalidAuthentication()
       throws Exception {
-
-    Properties props = new Properties();
     props.setProperty(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE, "false");
-    TestRestConfig config = new TestRestConfig(props);
+    startHttpServer("http");
 
-    TestApplication application = new TestApplication(config);
-    server = application.createServer();
-    server.start();
-
-    Response response = ClientBuilder.newClient()
-        .target(server.getURI())
+    startHttpClient("http");
+    ContentResponse response = httpClient.newRequest(server.getURI())
         .path("/test/path")
-        .request(MediaType.TEXT_HTML)
-        .get();
+        .accept(MediaType.TEXT_HTML)
+        .send();
 
-    String responseValue = response.readEntity(String.class);
+    String responseValue = response.getContentAsString();
 
     assertEquals(500, response.getStatus());
     assertTrue(responseValue.toLowerCase().contains(DUMMY_EXCEPTION));
@@ -62,24 +82,158 @@ public class ErrorHandlerIntegrationTest {
   }
 
   @Test
-  public void handledServerExceptionDoesNotDisplayStackTraceForInvalidAuthentication()
+  public void test_https_unhandledServerExceptionDisplaysStackTraceFor400SNICheck()
       throws Exception {
-    TestApplication application = new TestApplication(new TestRestConfig());
-    server = application.createServer();
-    server.start();
+    props.setProperty(RestConfig.SUPPRESS_STACK_TRACE_IN_RESPONSE, "false");
+    startHttpServer("https");
 
-    Response response = ClientBuilder.newClient()
-        .target(server.getURI())
+    startHttpClient("https");
+    ContentResponse response = httpClient.newRequest(server.getURI())
         .path("/test/path")
-        .request(MediaType.TEXT_HTML)
-        .get();
+        .accept(MediaType.TEXT_HTML)
+        // make Host different from SNI (localhost)
+        .header("Host", "abc.com")
+        .send();
 
-    String responseValue = response.readEntity(String.class).toLowerCase();
+    String responseValue = response.getContentAsString();
+    assertEquals(400, response.getStatus());
+    assertTrue(responseValue.toLowerCase().contains("host does not match sni"));
+    assertTrue(responseValue.toLowerCase().contains("caused by"));
+  }
+
+  @Test
+  public void test_http_handledServerExceptionDoesNotDisplayStackTraceForInvalidAuthentication()
+      throws Exception {
+    startHttpServer("http");
+
+    startHttpClient("http");
+    ContentResponse response = httpClient
+        .newRequest(server.getURI())
+        .path("/test/path")
+        .accept(MediaType.TEXT_HTML)
+        .send();
+
+    String responseValue = response.getContentAsString().toLowerCase();
 
     assertEquals(500, response.getStatus());
     assertFalse(responseValue.contains(DUMMY_EXCEPTION));
     assertFalse(responseValue.contains("caused by"));
     assertTrue(responseValue.contains("server error"));
+  }
+
+  @Test
+  public void test_https_handledServerExceptionDoesNotDisplayStackTraceFor400SNICheck()
+      throws Exception {
+    startHttpServer("https");
+
+    startHttpClient("https");
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/test/path")
+        .accept(MediaType.TEXT_HTML)
+        // make Host different from SNI (localhost)
+        .header("Host", "abc.com")
+        .send();
+
+    String responseValue = response.getContentAsString();
+    assertEquals(400, response.getStatus());
+    assertTrue(responseValue.toLowerCase().contains("host does not match sni"));
+    assertFalse(responseValue.toLowerCase().contains("caused by"));
+  }
+
+  private void startHttpClient(String scheme) throws Exception {
+    // allow to set Host header
+    System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+
+    if (scheme.equals("https")) {
+      // trust all self-signed certs.
+      SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+          .loadTrustMaterial(new TrustSelfSignedStrategy());
+      // add the client keystore if it's configured.
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystore.getAbsolutePath()),
+          SSL_PASSWORD.toCharArray(),
+          SSL_PASSWORD.toCharArray());
+      SSLContext sslContext = sslContextBuilder.build();
+
+      SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+      // this forces non-standard domains (localhost) in SNI and X509,
+      // see https://github.com/eclipse/jetty.project/pull/6296
+      sslContextFactory.setSNIProvider(
+          SslContextFactory.Client.SniProvider.NON_DOMAIN_SNI_PROVIDER);
+      sslContextFactory.setSslContext(sslContext);
+
+      httpClient = new HttpClient(sslContextFactory);
+    } else {
+      httpClient = new HttpClient();
+    }
+
+    httpClient.start();
+  }
+
+  private void startHttpServer(String scheme) throws Exception {
+    String url = scheme + "://localhost:" + getFreePort();
+    props.setProperty(RestConfig.LISTENERS_CONFIG, url);
+
+    if (scheme.equals("https")) {
+      File serverKeystore;
+      File trustStore;
+      try {
+        trustStore = File.createTempFile("SslTest-truststore", ".jks");
+        serverKeystore = File.createTempFile("SslTest-server-keystore", ".jks");
+        clientKeystore = File.createTempFile("SslTest-client-keystore", ".jks");
+      } catch (IOException ioe) {
+        throw new RuntimeException(
+            "Unable to create temporary files for trust stores and keystores.");
+      }
+      Map<String, X509Certificate> certs = new HashMap<>();
+      createKeystoreWithCert(clientKeystore, "client", certs);
+      createKeystoreWithCert(serverKeystore, "server", certs);
+      TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(SSL_PASSWORD),
+          certs);
+
+      configServerKeystore(props, serverKeystore);
+      configServerTruststore(props, trustStore);
+    }
+    TestApplication application = new TestApplication(new TestRestConfig(props));
+    server = application.createServer();
+
+    server.start();
+  }
+
+  private void configServerKeystore(Properties props, File serverKeystore) {
+    props.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, serverKeystore.getAbsolutePath());
+    props.put(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
+    props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, SSL_PASSWORD);
+  }
+
+  private void configServerTruststore(Properties props, File trustStore) {
+    props.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore.getAbsolutePath());
+    props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, SSL_PASSWORD);
+  }
+
+  private void createKeystoreWithCert(File file, String alias, Map<String, X509Certificate> certs)
+      throws Exception {
+    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
+    TestSslUtils.CertificateBuilder certificateBuilder = new TestSslUtils.CertificateBuilder(30,
+        "SHA1withRSA");
+    X509Certificate cCert = certificateBuilder
+        .sanDnsNames("localhost")
+        .generate("CN=mymachine.localhost, O=A client", keypair);
+    TestSslUtils.createKeyStore(file.getPath(), new Password(SSL_PASSWORD),
+        new Password(SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    certs.put(alias, cCert);
+  }
+
+  public static int getFreePort() {
+    for (int attempt = 0; attempt < 10; attempt++) {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        int port = socket.getLocalPort();
+        assert port > 0;
+        return port;
+      } catch (IOException e) {
+        // skip for next retry
+      }
+    }
+    return 0;
   }
 
   private static class TestApplication extends Application<TestRestConfig> {


### PR DESCRIPTION
This will make the response nicer, in term of no stack trace will show up for error on server

- [x] test to show this works