### PR TITLE
AUTHN-1586 Add optional latency SLO/SLA metrics in annotation

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -608,7 +608,7 @@ public abstract class Application<T extends RestConfig> {
 
     config.register(new MetricsResourceMethodApplicationListener(getMetrics(), "jersey",
         metricTags, restConfig.getTime(),
-        restConfig.getBoolean(RestConfig.METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG),
+        restConfig.getBoolean(RestConfig.METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG),
         restConfig.getLong(RestConfig.METRICS_LATENCY_SLO_MS_CONFIG),
         restConfig.getLong(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG)));
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -607,7 +607,10 @@ public abstract class Application<T extends RestConfig> {
     registerExceptionMappers(config, restConfig);
 
     config.register(new MetricsResourceMethodApplicationListener(getMetrics(), "jersey",
-        metricTags, restConfig.getTime()));
+        metricTags, restConfig.getTime(),
+        restConfig.getBoolean(RestConfig.METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG),
+        restConfig.getLong(RestConfig.METRICS_LATENCY_SLO_MS_CONFIG),
+        restConfig.getLong(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG)));
 
     config.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);
     config.property(ServerProperties.WADL_FEATURE_DISABLE, true);

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -164,6 +164,16 @@ public class RestConfig extends AbstractConfig {
       + " be used to specify additional tags during deployment like data center, instance "
       + "details, etc.";
   protected static final String METRICS_TAGS_DEFAULT = "";
+  public static final String METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG =
+      "metrics.enable.latency.slo.sla";
+  protected static final String METRICS_ENABLE_LATENCY_SLO_SLA_DOC = "Enable latency SLO and SLA";
+  protected static final boolean METRICS_ENABLE_LATENCY_SLO_SLA_DEFAULT = false;
+  public static final String METRICS_LATENCY_SLO_MS_CONFIG = "metrics.latency.slo.ms";
+  protected static final String METRICS_LATENCY_SLO_MS_DOC = "Latency SLO (in ms)";
+  protected static final long METRICS_LATENCY_SLO_MS_DEFAULT = 5;
+  public static final String METRICS_LATENCY_SLA_MS_CONFIG = "metrics.latency.sla.ms";
+  protected static final String METRICS_LATENCY_SLA_MS_DOC = "Latency SLA (in ms)";
+  protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
 
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
   protected static final String SSL_KEYSTORE_RELOAD_DOC =
@@ -667,6 +677,24 @@ public class RestConfig extends AbstractConfig {
             METRICS_TAGS_DEFAULT,
             Importance.LOW,
             METRICS_TAGS_DOC
+        ).define(
+            METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG,
+            Type.BOOLEAN,
+            METRICS_ENABLE_LATENCY_SLO_SLA_DEFAULT,
+            Importance.LOW,
+            METRICS_ENABLE_LATENCY_SLO_SLA_DOC
+        ).define(
+            METRICS_LATENCY_SLO_MS_CONFIG,
+            Type.LONG,
+            METRICS_LATENCY_SLO_MS_DEFAULT,
+            Importance.LOW,
+            METRICS_LATENCY_SLO_MS_DOC
+        ).define(
+            METRICS_LATENCY_SLA_MS_CONFIG,
+            Type.LONG,
+            METRICS_LATENCY_SLA_MS_DEFAULT,
+            Importance.LOW,
+            METRICS_LATENCY_SLA_MS_DOC
         ).define(
             SSL_KEYSTORE_RELOAD_CONFIG,
             Type.BOOLEAN,

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -166,13 +166,16 @@ public class RestConfig extends AbstractConfig {
   protected static final String METRICS_TAGS_DEFAULT = "";
   public static final String METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG =
       "metrics.enable.latency.slo.sla";
-  protected static final String METRICS_ENABLE_LATENCY_SLO_SLA_DOC = "Enable latency SLO and SLA";
+  protected static final String METRICS_ENABLE_LATENCY_SLO_SLA_DOC = "Whether to enable metrics about the "
+      + "count of requests that meet or violate latency SLO/SLA in the Performance annotation";
   protected static final boolean METRICS_ENABLE_LATENCY_SLO_SLA_DEFAULT = false;
   public static final String METRICS_LATENCY_SLO_MS_CONFIG = "metrics.latency.slo.ms";
-  protected static final String METRICS_LATENCY_SLO_MS_DOC = "Latency SLO (in ms)";
+  protected static final String METRICS_LATENCY_SLO_MS_DOC = "The threshold (in ms) of whether request"
+      + " latency meets or violates SLO";
   protected static final long METRICS_LATENCY_SLO_MS_DEFAULT = 5;
   public static final String METRICS_LATENCY_SLA_MS_CONFIG = "metrics.latency.sla.ms";
-  protected static final String METRICS_LATENCY_SLA_MS_DOC = "Latency SLA (in ms)";
+  protected static final String METRICS_LATENCY_SLA_MS_DOC = "The threshold (in ms) of whether request"
+      + " latency meets or violates SLA";
   protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
 
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -164,18 +164,19 @@ public class RestConfig extends AbstractConfig {
       + " be used to specify additional tags during deployment like data center, instance "
       + "details, etc.";
   protected static final String METRICS_TAGS_DEFAULT = "";
-  public static final String METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG =
-      "metrics.enable.latency.slo.sla";
-  protected static final String METRICS_ENABLE_LATENCY_SLO_SLA_DOC = "Whether to enable metrics about the "
-      + "count of requests that meet or violate latency SLO/SLA in the Performance annotation";
-  protected static final boolean METRICS_ENABLE_LATENCY_SLO_SLA_DEFAULT = false;
+  public static final String METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG =
+      "metrics.latency.slo.sla.enable";
+  protected static final String METRICS_LATENCY_SLO_SLA_ENABLE_DOC = "Whether to enable metrics"
+      + " about the count of requests that meet or violate latency SLO/SLA"
+      + " in the Performance annotation";
+  protected static final boolean METRICS_LATENCY_SLO_SLA_ENABLE_DEFAULT = false;
   public static final String METRICS_LATENCY_SLO_MS_CONFIG = "metrics.latency.slo.ms";
-  protected static final String METRICS_LATENCY_SLO_MS_DOC = "The threshold (in ms) of whether request"
-      + " latency meets or violates SLO";
+  protected static final String METRICS_LATENCY_SLO_MS_DOC = "The threshold (in ms) of whether"
+      + " request latency meets or violates SLO";
   protected static final long METRICS_LATENCY_SLO_MS_DEFAULT = 5;
   public static final String METRICS_LATENCY_SLA_MS_CONFIG = "metrics.latency.sla.ms";
-  protected static final String METRICS_LATENCY_SLA_MS_DOC = "The threshold (in ms) of whether request"
-      + " latency meets or violates SLA";
+  protected static final String METRICS_LATENCY_SLA_MS_DOC = "The threshold (in ms) of whether"
+      + " request latency meets or violates SLA";
   protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
 
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
@@ -681,11 +682,11 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             METRICS_TAGS_DOC
         ).define(
-            METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG,
+            METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG,
             Type.BOOLEAN,
-            METRICS_ENABLE_LATENCY_SLO_SLA_DEFAULT,
+            METRICS_LATENCY_SLO_SLA_ENABLE_DEFAULT,
             Importance.LOW,
-            METRICS_ENABLE_LATENCY_SLO_SLA_DOC
+            METRICS_LATENCY_SLO_SLA_ENABLE_DOC
         ).define(
             METRICS_LATENCY_SLO_MS_CONFIG,
             Type.LONG,

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -190,10 +190,14 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   }
 
   private static class MethodMetrics {
-    private final static String RESPONSE_BELOW_LATENCY_SLO = "response-below-latency-slo";
-    private final static String RESPONSE_ABOVE_LATENCY_SLO = "response-above-latency-slo";
-    private final static String RESPONSE_BELOW_LATENCY_SLA = "response-below-latency-sla";
-    private final static String RESPONSE_ABOVE_LATENCY_SLA = "response-above-latency-sla";
+    private static final String RESPONSE_BELOW_LATENCY_SLO =
+        "response-below-latency-slo";
+    private static final String RESPONSE_ABOVE_LATENCY_SLO =
+        "response-above-latency-slo";
+    private static final String RESPONSE_BELOW_LATENCY_SLA =
+        "response-below-latency-sla";
+    private static final String RESPONSE_ABOVE_LATENCY_SLA =
+        "response-above-latency-sla";
     private final Sensor requestSizeSensor;
     private final Sensor responseSizeSensor;
     private final Sensor requestLatencySensor;

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -190,6 +190,10 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   }
 
   private static class MethodMetrics {
+    private final static String RESPONSE_BELOW_LATENCY_SLO = "response-below-latency-slo";
+    private final static String RESPONSE_ABOVE_LATENCY_SLO = "response-above-latency-slo";
+    private final static String RESPONSE_BELOW_LATENCY_SLA = "response-below-latency-sla";
+    private final static String RESPONSE_ABOVE_LATENCY_SLA = "response-above-latency-sla";
     private final Sensor requestSizeSensor;
     private final Sensor responseSizeSensor;
     private final Sensor requestLatencySensor;
@@ -327,40 +331,40 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       MetricName metricName;
 
       final Sensor belowLatencySloSensor = metrics.sensor(
-          getName(method, annotation, "response-below-latency-slo", requestTags), null,
+          getName(method, annotation, RESPONSE_BELOW_LATENCY_SLO, requestTags), null,
           SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
-          getName(method, annotation, "response-below-latency-slo-total"), metricGrpName,
+          getName(method, annotation, RESPONSE_BELOW_LATENCY_SLO + "-total"), metricGrpName,
           "Below latency SLO request count, using a cumulative counter", allTags);
       belowLatencySloSensor.add(metricName, new CumulativeCount());
-      responseLatencySloSlaSensors.put("response-below-latency-slo", belowLatencySloSensor);
+      responseLatencySloSlaSensors.put(RESPONSE_BELOW_LATENCY_SLO, belowLatencySloSensor);
 
       final Sensor aboveLatencySloSensor = metrics.sensor(
-          getName(method, annotation, "response-above-latency-slo", requestTags), null,
+          getName(method, annotation, RESPONSE_ABOVE_LATENCY_SLO, requestTags), null,
           SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
-          getName(method, annotation, "response-above-latency-slo-total"), metricGrpName,
+          getName(method, annotation, RESPONSE_ABOVE_LATENCY_SLO + "-total"), metricGrpName,
           "Above latency SLO request count, using a cumulative counter", allTags);
       aboveLatencySloSensor.add(metricName, new CumulativeCount());
-      responseLatencySloSlaSensors.put("response-above-latency-slo", aboveLatencySloSensor);
+      responseLatencySloSlaSensors.put(RESPONSE_ABOVE_LATENCY_SLO, aboveLatencySloSensor);
 
       final Sensor belowLatencySlaSensor = metrics.sensor(
-          getName(method, annotation, "response-below-latency-sla", requestTags), null,
+          getName(method, annotation, RESPONSE_BELOW_LATENCY_SLA, requestTags), null,
           SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
-          getName(method, annotation, "response-below-latency-sla-total"), metricGrpName,
+          getName(method, annotation, RESPONSE_BELOW_LATENCY_SLA + "-total"), metricGrpName,
           "Below latency SLA request count, using a cumulative counter", allTags);
       belowLatencySlaSensor.add(metricName, new CumulativeCount());
-      responseLatencySloSlaSensors.put("response-below-latency-sla", belowLatencySlaSensor);
+      responseLatencySloSlaSensors.put(RESPONSE_BELOW_LATENCY_SLA, belowLatencySlaSensor);
 
       final Sensor aboveLatencySlaSensor = metrics.sensor(
-          getName(method, annotation, "response-above-latency-sla", requestTags), null,
+          getName(method, annotation, RESPONSE_ABOVE_LATENCY_SLA, requestTags), null,
           SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
       metricName = new MetricName(
-          getName(method, annotation, "response-above-latency-sla-total"), metricGrpName,
+          getName(method, annotation, RESPONSE_ABOVE_LATENCY_SLA + "-total"), metricGrpName,
           "Above latency SLA request count, using a cumulative counter", allTags);
       aboveLatencySlaSensor.add(metricName, new CumulativeCount());
-      responseLatencySloSlaSensors.put("response-above-latency-sla", aboveLatencySlaSensor);
+      responseLatencySloSlaSensors.put(RESPONSE_ABOVE_LATENCY_SLA, aboveLatencySlaSensor);
     }
 
     private void setErrorSensorByStatus(ResourceMethod method, PerformanceMetric annotation,
@@ -405,15 +409,15 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       if (enableLatencySloSla) {
         if (latencyMs < latencySloMs) {
-          responseLatencySloSlaSensors.get("response-below-latency-slo").record();
+          responseLatencySloSlaSensors.get(RESPONSE_BELOW_LATENCY_SLO).record();
         } else {
-          responseLatencySloSlaSensors.get("response-above-latency-slo").record();
+          responseLatencySloSlaSensors.get(RESPONSE_ABOVE_LATENCY_SLO).record();
         }
 
         if (latencyMs < latencySlaMs) {
-          responseLatencySloSlaSensors.get("response-below-latency-sla").record();
+          responseLatencySloSlaSensors.get(RESPONSE_BELOW_LATENCY_SLA).record();
         } else {
-          responseLatencySloSlaSensors.get("response-above-latency-sla").record();
+          responseLatencySloSlaSensors.get(RESPONSE_ABOVE_LATENCY_SLA).record();
         }
       }
     }

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -75,7 +75,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   private static final int PERCENTILE_NUM_BUCKETS = 200;
   private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(10);
   private static final long SENSOR_EXPIRY_SECONDS = TimeUnit.HOURS.toSeconds(1);
-  private static final String[] LATENCY_SLO_SLA_NAMES = {"response-below-latency-slo",
+  private static final String[] LATENCY_SLO_SLA_SENSOR_NAMES = {"response-below-latency-slo",
       "response-above-latency-slo", "response-below-latency-sla", "response-above-latency-sla"};
 
   private final Metrics metrics;
@@ -197,7 +197,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     private final Sensor requestLatencySensor;
     private final Sensor errorSensor;
     private final Map<String, Sensor> responseLatencySloSlaSensor =
-        new HashMap<>(LATENCY_SLO_SLA_NAMES.length);
+        new HashMap<>(LATENCY_SLO_SLA_SENSOR_NAMES.length);
     private final Map<String, Sensor> errorSensorByStatus =
         new HashMap<>(HTTP_STATUS_CODE_TEXT.length);
     private final boolean enableLatencySloSla;
@@ -327,17 +327,17 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     private void setResponseLatencySloSlaSensor(ResourceMethod method,
         PerformanceMetric annotation, Metrics metrics, Map<String, String> requestTags,
         String metricGrpName, Map<String, String> allTags) {
-      for (int i = 0; i < LATENCY_SLO_SLA_NAMES.length; i++) {
+      for (int i = 0; i < LATENCY_SLO_SLA_SENSOR_NAMES.length; i++) {
         final Sensor sensor = metrics.sensor(
-            getName(method, annotation, LATENCY_SLO_SLA_NAMES[i], requestTags),
+            getName(method, annotation, LATENCY_SLO_SLA_SENSOR_NAMES[i], requestTags),
             null, SENSOR_EXPIRY_SECONDS, Sensor.RecordingLevel.INFO, (Sensor[]) null);
         MetricName metricName = new MetricName(
-            getName(method, annotation, LATENCY_SLO_SLA_NAMES[i] + "-total"), metricGrpName,
+            getName(method, annotation, LATENCY_SLO_SLA_SENSOR_NAMES[i] + "-total"), metricGrpName,
             (i % 2 == 0 ? "Below" : "Above")
                 + " latency SLA request count, using a cumulative counter",
             allTags);
         sensor.add(metricName, new CumulativeCount());
-        responseLatencySloSlaSensor.put(LATENCY_SLO_SLA_NAMES[i], sensor);
+        responseLatencySloSlaSensor.put(LATENCY_SLO_SLA_SENSOR_NAMES[i], sensor);
       }
     }
 
@@ -383,15 +383,15 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       if (enableLatencySloSla) {
         if (latencyMs < latencySloMs) {
-          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_NAMES[0]).record();
+          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_SENSOR_NAMES[0]).record();
         } else {
-          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_NAMES[1]).record();
+          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_SENSOR_NAMES[1]).record();
         }
 
         if (latencyMs < latencySlaMs) {
-          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_NAMES[2]).record();
+          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_SENSOR_NAMES[2]).record();
         } else {
-          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_NAMES[3]).record();
+          responseLatencySloSlaSensor.get(LATENCY_SLO_SLA_SENSOR_NAMES[3]).record();
         }
       }
     }

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -66,6 +66,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     if (info.getDisplayName().contains("testMetricLatencySloSlaEnabled")) {
       props.put(RestConfig.METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG, "true");
+      props.put(RestConfig.METRICS_LATENCY_SLO_MS_CONFIG, "0");
+      props.put(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG, "10000");
     }
 
     config = new TestRestConfig(props);
@@ -380,9 +382,13 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
     assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-slo-total")).intValue()
         + Double.valueOf(allMetrics.get("response-above-latency-slo-total")).intValue());
-
     assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-sla-total")).intValue()
         + Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
+
+    assertEquals(0, Double.valueOf(allMetrics.get("response-below-latency-slo-total")).intValue());
+    assertEquals(1, Double.valueOf(allMetrics.get("response-above-latency-slo-total")).intValue());
+    assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-sla-total")).intValue());
+    assertEquals(0, Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
   }
 
   private void makeSuccessfulCall() {

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -385,8 +385,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         + Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
   }
 
-
-
   private void makeSuccessfulCall() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
         .target(server.getURI())

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -9,15 +9,6 @@ import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 
-import java.lang.management.ManagementFactory;
-import java.util.Iterator;
-import java.util.Set;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanRegistrationException;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectInstance;
-import javax.management.ObjectName;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.eclipse.jetty.server.Request;
@@ -25,17 +16,17 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.jersey.server.ServerProperties;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import javax.servlet.RequestDispatcher;
@@ -67,11 +58,16 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   private AtomicInteger counter;
 
   @BeforeEach
-  public void setUp() throws Exception {
+  public void setUp(TestInfo info) throws Exception {
     TestMetricsReporter.reset();
     Properties props = new Properties();
     props.setProperty("debug", "false");
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
+
+    if (info.getDisplayName().contains("testMetricLatencySloSlaEnabled")) {
+      props.put(RestConfig.METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG, "true");
+    }
+
     config = new TestRestConfig(props);
     app = new ApplicationWithFilter(config);
     server = app.createServer();
@@ -365,6 +361,31 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertTrue(reporter.getConfigs().containsKey("prop2"));
     assertEquals(reporter.getConfigs().get("prop3"), "override");
   }
+
+  @Test
+  public void testMetricLatencySloSlaEnabled() {
+    makeSuccessfulCall();
+
+    Map<String, String> allMetrics = TestMetricsReporter.getMetricTimeseries()
+        .stream()
+        .collect(Collectors.toMap(
+            x -> x.metricName().name(),
+            x -> x.metricValue().toString(),
+            (a, b) -> a));
+
+    assertTrue(allMetrics.containsKey("response-below-latency-slo-total"));
+    assertTrue(allMetrics.containsKey("response-above-latency-slo-total"));
+    assertTrue(allMetrics.containsKey("response-below-latency-sla-total"));
+    assertTrue(allMetrics.containsKey("response-above-latency-sla-total"));
+
+    assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-slo-total")).intValue()
+        + Double.valueOf(allMetrics.get("response-above-latency-slo-total")).intValue());
+
+    assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-sla-total")).intValue()
+        + Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
+  }
+
+
 
   private void makeSuccessfulCall() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())


### PR DESCRIPTION
What is it about?
---
This is to collect server-side metrics for [AUTHN-1586](https://confluentinc.atlassian.net/browse/AUTHN-1586), and is useful if others need it.

Add optional metrics about the count of requests that meet or violate latency SLO/SLA in the `Performance` annotation. 

How?
---
Add three config parameters.
1. (boolean) `METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG`
2. (long) `METRICS_LATENCY_SLO_MS_CONFIG`
3. (long) `METRICS_LATENCY_SLA_MS_CONFIG`

If `METRICS_ENABLE_LATENCY_SLO_SLA_CONFIG` is enabled, add four sensors to count the number of request whose response latency below(above) SLO(SLA) threshold.

[AUTHN-1586]: https://confluentinc.atlassian.net/browse/AUTHN-1586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ