### PR TITLE
Don't use DosFilter.Listener.onRequestOverLimit default to avoid verbosity

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
@@ -81,8 +81,9 @@ public class Jetty429MetricsDosFilterListener extends DoSFilter.Listener {
   @Override
   public Action onRequestOverLimit(HttpServletRequest request, OverLimit overlimit,
       DoSFilter dosFilter) {
-    Action action = super.onRequestOverLimit(request, overlimit, dosFilter);
-
+    // KREST-10418: we don't use super function to get action object because
+    // it will log a WARN line, in order to reduce verbosity
+    Action action = Action.fromDelay(dosFilter.getDelayMs());
     if (fourTwoNineSensor != null && action.equals(Action.REJECT)) {
       fourTwoNineSensor.record();
     }


### PR DESCRIPTION
The default function DosFilter.Listener.onRequestOverLimit will log this line 
```
[WARN] 2023-05-11 09:36:40,954 [qtp787738572-1439] org.eclipse.jetty.servlets.DoSFilter - DOS ALERT: Request rejected ip=127.0.0.1, overlimit=OverLimit@11dd96d5[type=IP, id=127.0.0.1, duration=PT0.361698758S, count=100], session=null, user=null
```
whenever a request is overlimited by DosFilter, this add unnecessary verbosity.

This PR disables this log line programmatically.

There is an alternative to disable this log line is by setting log level of `org.eclipse.jetty.servlets.DoSFilter` class to ERROR level.

