### PR TITLE
KREST-10243 Add ability to run multiple dosfilter-listeners and setup a custom-log on the app.

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -129,7 +129,7 @@ public abstract class Application<T extends RestConfig> {
     this(config, path, listenerName, null);
   }
 
-  public Application(T config, String path, String listenerName, RequestLog inputRequestLog) {
+  public Application(T config, String path, String listenerName, RequestLog customRequestLog) {
     this.config = config;
     this.path = Objects.requireNonNull(path);
     this.listenerName = listenerName;
@@ -140,13 +140,13 @@ public abstract class Application<T extends RestConfig> {
         this.getMetricsTags(),
         config.getString(RestConfig.METRICS_JMX_PREFIX_CONFIG));
 
-    if (inputRequestLog == null) {
+    if (customRequestLog == null) {
       Slf4jRequestLogWriter logWriter = new Slf4jRequestLogWriter();
       logWriter.setLoggerName(config.getString(RestConfig.REQUEST_LOGGER_NAME_CONFIG));
       // %{ms}T logs request time in milliseconds
       requestLog = new CustomRequestLog(logWriter, requestLogFormat());
     } else {
-      requestLog = inputRequestLog;
+      requestLog = customRequestLog;
     }
   }
 
@@ -829,10 +829,6 @@ public abstract class Application<T extends RestConfig> {
    * A rate-limiter that applies a single limit to the entire server.
    */
   private static final class GlobalDosFilter extends DoSFilter {
-
-    public GlobalDosFilter() {
-      super();
-    }
 
     @Override
     protected String extractUserId(ServletRequest request) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -153,19 +153,21 @@ public abstract class Application<T extends RestConfig> {
   }
 
   /**
-   * Set DosFilter.listeners for global-dosfilter
+   * Add DosFilter.listener to be called with all other listeners for global-dosfilter. This should
+   * be called before configureHandler() is called.
    */
-  public void setGlobalDosfilterListeners(
-      List<Listener> listeners) {
-    this.globalDosfilterListeners = Objects.requireNonNull(listeners);
+  public void addGlobalDosfilterListener(
+      Listener listener) {
+    this.globalDosfilterListeners.add(Objects.requireNonNull(listener));
   }
 
   /**
-   * Set DosFilter.listeners for non-global-dosfilter
+   * Add DosFilter.listener to be called with all other listeners for non-global-dosfilter.This
+   * should be called before configureHandler() is called.
    */
-  public void setNonGlobalDosfilterListeners(
-      List<Listener> listeners) {
-    this.nonGlobalDosfilterListeners = Objects.requireNonNull(listeners);
+  public void addNonGlobalDosfilterListener(
+      Listener listener) {
+    this.nonGlobalDosfilterListeners.add(Objects.requireNonNull(listener));
   }
 
   protected String requestLogFormat() {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -21,7 +21,6 @@ import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSE
 import static java.util.Collections.emptyMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import io.confluent.rest.auth.AuthUtil;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.GenericExceptionMapper;
@@ -105,7 +104,7 @@ public abstract class Application<T extends RestConfig> {
 
   protected ApplicationServer<?> server;
   protected Metrics metrics;
-  protected RequestLog requestLog;
+  protected final RequestLog requestLog;
   protected final Jetty429MetricsDosFilterListener jetty429MetricsListener;
 
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -130,8 +129,7 @@ public abstract class Application<T extends RestConfig> {
     this(config, path, listenerName, null);
   }
 
-  @VisibleForTesting
-  Application(T config, String path, String listenerName, RequestLog customRequestLog) {
+  public Application(T config, String path, String listenerName, RequestLog customRequestLog) {
     this.config = config;
     this.path = Objects.requireNonNull(path);
     this.listenerName = listenerName;

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -21,6 +21,7 @@ import static io.confluent.rest.RestConfig.WEBSOCKET_SERVLET_INITIALIZERS_CLASSE
 import static java.util.Collections.emptyMap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.rest.auth.AuthUtil;
 import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.GenericExceptionMapper;
@@ -104,7 +105,7 @@ public abstract class Application<T extends RestConfig> {
 
   protected ApplicationServer<?> server;
   protected Metrics metrics;
-  protected final RequestLog requestLog;
+  protected RequestLog requestLog;
   protected final Jetty429MetricsDosFilterListener jetty429MetricsListener;
 
   protected CountDownLatch shutdownLatch = new CountDownLatch(1);
@@ -129,7 +130,8 @@ public abstract class Application<T extends RestConfig> {
     this(config, path, listenerName, null);
   }
 
-  public Application(T config, String path, String listenerName, RequestLog customRequestLog) {
+  @VisibleForTesting
+  Application(T config, String path, String listenerName, RequestLog customRequestLog) {
     this.config = config;
     this.path = Objects.requireNonNull(path);
     this.listenerName = listenerName;

--- a/core/src/main/java/io/confluent/rest/JettyDosFilterMultiListener.java
+++ b/core/src/main/java/io/confluent/rest/JettyDosFilterMultiListener.java
@@ -49,7 +49,7 @@ public class JettyDosFilterMultiListener extends DoSFilter.Listener {
       try {
         listener.onRequestOverLimit(request, overlimit, dosFilter);
       } catch (Exception ex) {
-        log.error("DosFilter.Listener threw exception {}", ex);
+        log.debug("{} threw exception {}", listener.getClass(), ex);
       }
     }
     return action;

--- a/core/src/main/java/io/confluent/rest/JettyDosFilterMultiListener.java
+++ b/core/src/main/java/io/confluent/rest/JettyDosFilterMultiListener.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 - 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.servlets.DoSFilter;
+import org.eclipse.jetty.servlets.DoSFilter.Action;
+import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * This is used to run multiple DosFilter.Listeners, which are the input here.
+ * Any exception is thrown by a listener is simply logged, and other listeners
+ * are run.
+ */
+public class JettyDosFilterMultiListener extends DoSFilter.Listener {
+
+  private static final Logger log = LoggerFactory.getLogger(JettyDosFilterMultiListener.class
+  );
+  private List<DoSFilter.Listener> listeners;
+
+  public JettyDosFilterMultiListener(List<DoSFilter.Listener> listeners) {
+    this.listeners = listeners;
+  }
+
+  @Override
+  public Action onRequestOverLimit(HttpServletRequest request, OverLimit overlimit,
+      DoSFilter dosFilter) {
+    // KREST-10418: we don't use super function to get action object because
+    // it will log a WARN line, in order to reduce verbosity
+    Action action = Action.fromDelay(dosFilter.getDelayMs());
+    for (DoSFilter.Listener listener : listeners) {
+      try {
+        listener.onRequestOverLimit(request, overlimit, dosFilter);
+      } catch (Exception ex) {
+        log.error("DosFilter.Listener threw exception {}", ex);
+      }
+    }
+    return action;
+  }
+
+}

--- a/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
@@ -111,12 +111,8 @@ class JettyDosFilterMultiListenerIntegrationTest {
 
     TestRestConfig config = new TestRestConfig(props);
     ApplicationWithDoSFilterEnabled app = new ApplicationWithDoSFilterEnabled(config);
-    ArrayList<Listener> nonGlobalListeners = new ArrayList(
-        Arrays.asList(nonGlobalDosFilterListener));
-    app.setNonGlobalDosfilterListeners(nonGlobalListeners);
-    ArrayList<Listener> globalListeners = new ArrayList(
-        Arrays.asList(globalDosFilterListener));
-    app.setGlobalDosfilterListeners(globalListeners);
+    app.addNonGlobalDosfilterListener(nonGlobalDosFilterListener);
+    app.addGlobalDosfilterListener(globalDosFilterListener);
     app.createServer();
     server = app.createServer();
     server.start();

--- a/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerTest.java
+++ b/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerTest.java
@@ -1,0 +1,75 @@
+package io.confluent.rest;
+
+/*
+ * Copyright 2014 - 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.servlets.DoSFilter;
+import org.eclipse.jetty.servlets.DoSFilter.Action;
+import org.eclipse.jetty.servlets.DoSFilter.Listener;
+import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class JettyDosFilterMultiListenerTest {
+
+  private final DoSFilter.Listener listener1 = Mockito.mock(DoSFilter.Listener.class);
+  private final DoSFilter.Listener listener2 = Mockito.mock(DoSFilter.Listener.class);
+  private final List<Listener> listeners = Arrays.asList(listener1, listener2);
+
+  private final JettyDosFilterMultiListener multiListener = new JettyDosFilterMultiListener(
+      listeners);
+
+  private final DoSFilter dosfilter = Mockito.mock(DoSFilter.class);
+
+  private final long rejectDelayMs = -1;
+
+  @Test
+  public void test_2Listeners_bothListenersAreCalled() {
+    when(dosfilter.getDelayMs()).thenReturn(rejectDelayMs);
+    when(listener1.onRequestOverLimit(any(), any(), any())).thenReturn(Action.REJECT);
+    when(listener2.onRequestOverLimit(any(), any(), any())).thenReturn(Action.REJECT);
+    Action action = multiListener.onRequestOverLimit(Mockito.mock(HttpServletRequest.class),
+        Mockito.mock(
+            OverLimit.class), dosfilter);
+    assertEquals(action, Action.REJECT);
+    verify(listener1, times(1)).onRequestOverLimit(any(), any(), any());
+    verify(listener2, times(1)).onRequestOverLimit(any(), any(), any());
+  }
+
+  @Test
+  public void test_2Listeners_1ListenersThrows_OtherListenerIsCalled() {
+    when(dosfilter.getDelayMs()).thenReturn(rejectDelayMs);
+    // 1st listener throws, but 2nd should still get called.
+    when(listener1.onRequestOverLimit(any(), any(), any())).thenThrow(new RuntimeException());
+    when(listener2.onRequestOverLimit(any(), any(), any())).thenReturn(Action.REJECT);
+    Action action = multiListener.onRequestOverLimit(Mockito.mock(HttpServletRequest.class),
+        Mockito.mock(
+            OverLimit.class), dosfilter);
+    assertEquals(action, Action.REJECT);
+    verify(listener1, times(1)).onRequestOverLimit(any(), any(), any());
+    verify(listener2, times(1)).onRequestOverLimit(any(), any(), any());
+  }
+
+}


### PR DESCRIPTION
This PR introduces 2 changes majorly

1. `JettyDosFilterMultiListener` is type of `DosFilter.Listener` that can hold multiple such listeners and run them. This is needed as Jetty's `DosFilter.setListener()` only accepts and runs `1 listener`. Whereas Kafka-rest needs to run another listener, other than the common one for all apps `Jetty429MetricsDosFilterListener`. This other listener will add metadata to the `HttpServletRequest` for custom-logging enhancement for kafka-rest(to be followed in another PR).
* `Application` exposes setters to set-up multi-listeners for the global & non-global dos-filters.
2. `Application`'s `requestLog` was final. Make it non-final, so child-applications can reset it, if needed. This would be used by `KafkaRestApplication` in `kafka-rest`.