### PR TITLE
Introduce request attribute to enable global metrics use runtime request tags

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -637,7 +637,8 @@ public abstract class Application<T extends RestConfig> {
         metricTags, restConfig.getTime(),
         restConfig.getBoolean(RestConfig.METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG),
         restConfig.getLong(RestConfig.METRICS_LATENCY_SLO_MS_CONFIG),
-        restConfig.getLong(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG)));
+        restConfig.getLong(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG),
+        restConfig.getBoolean(RestConfig.METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG)));
 
     config.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);
     config.property(ServerProperties.WADL_FEATURE_DISABLE, true);

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -178,6 +178,11 @@ public class RestConfig extends AbstractConfig {
   protected static final String METRICS_LATENCY_SLA_MS_DOC = "The threshold (in ms) of whether"
       + " request latency meets or violates SLA";
   protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
+  public static final String METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG =
+      "metrics.global.stats.request.tags.enable";
+  protected static final String METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DOC = "Whether to use "
+      + " runtime request tags in global stats.";
+  protected static final boolean METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DEFAULT = false;
 
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
   protected static final String SSL_KEYSTORE_RELOAD_DOC =
@@ -699,6 +704,12 @@ public class RestConfig extends AbstractConfig {
             METRICS_LATENCY_SLA_MS_DEFAULT,
             Importance.LOW,
             METRICS_LATENCY_SLA_MS_DOC
+        ).define(
+            METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG,
+            Type.BOOLEAN,
+            METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DEFAULT,
+            Importance.LOW,
+            METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DOC
         ).define(
             SSL_KEYSTORE_RELOAD_CONFIG,
             Type.BOOLEAN,

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -16,6 +16,7 @@
 
 package io.confluent.rest.metrics;
 
+import java.util.Objects;
 import org.glassfish.jersey.server.ContainerRequest;
 import org.glassfish.jersey.server.ContainerResponse;
 import org.glassfish.jersey.server.model.Resource;
@@ -553,12 +554,10 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           responseSize = 0;
         }
 
+        final MethodMetrics globalMetrics = Objects.requireNonNull(getGlobalMetrics(event));
         // Handle exceptions
         if (event.getException() != null) {
-          final MethodMetrics globalMetrics = getGlobalMetrics(event);
-          if (globalMetrics != null) {
-            globalMetrics.exception(event);
-          }
+          globalMetrics.exception(event);
 
           // get RequestScopedMetrics for a single resource method
           final MethodMetrics metrics = getMethodMetrics(event);
@@ -567,7 +566,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
           }
         }
 
-        this.metrics.get(null).metrics().finished(requestSize, responseSize, elapsed);
+        globalMetrics.finished(requestSize, responseSize, elapsed);
         final MethodMetrics metrics = getMethodMetrics(event);
         if (metrics != null) {
           metrics.finished(requestSize, responseSize, elapsed);

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -21,6 +21,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -78,7 +79,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
 
     config = new TestRestConfig(props);
-    app = new ApplicationWithFilter(config);
+    app = new ApplicationWithFilter(config,
+        info.getDisplayName().contains("WithGlobalStatsRequestTagsEnabledPropKey"));
     server = app.createServer();
     server.start();
     counter = new AtomicInteger();
@@ -243,7 +245,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   @Test
   public void test429Metrics() throws InterruptedException {
-
     make429Call();
     make429Call();
 
@@ -281,6 +282,61 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
     assertEquals(1, rateCheckpoint429); //Single rate metric for the two 429 error
     assertEquals(1, windowCheckpoint429); ///A single windowed metric for the two 4xx errors
+  }
+
+  @DisplayName("WithGlobalStatsRequestTagsEnabledPropKey")
+  @Test
+  public void test429Metrics_WithGlobalStatsRequestTagsEnabledPropKey() throws InterruptedException {
+    int totalRequests = 10;
+    IntStream.range(0, totalRequests).forEach((i) -> make429Call());
+
+    //checkpoints ensure that all the assertions are tested
+    int rateCheckpoint429 = 0;
+    int windowCheckpoint429 = 0;
+    int windowTag1Checkpoint429 = 0;
+    int windowTag2Checkpoint429 = 0;
+
+    // Frustrating, but we get a concurrent modification exception if we don't wait for the metrics to finish writing before querying the metrics list
+    Thread.sleep(500);
+
+    for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
+      if (metric.metricName().name().equals("request-error-rate")
+          && metric.metricName().group().equals("jersey-metrics")
+          && metric.metricName().tags()
+          .getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("429")) {
+        assertTrue(metric.measurable().toString().toLowerCase().startsWith("rate"));
+        Object metricValue = metric.metricValue();
+        assertTrue(metricValue instanceof Double, "Error rate metrics should be measurable");
+        double errorRateValue = (double) metricValue;
+        rateCheckpoint429++;
+        assertTrue(errorRateValue > 0, "Actual: " + errorRateValue);
+      }
+
+      if (metric.metricName().name().equals("request-error-count")
+          && metric.metricName().group().equals("jersey-metrics")
+          && metric.metricName().tags()
+          .getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("429")) {
+        assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
+        Object metricValue = metric.metricValue();
+        assertTrue(metricValue instanceof Double, "Error count metrics should be measurable");
+        Map<String, String> tags = metric.metricName().tags();
+        if (tags.containsValue("value1")) {
+          assertMetric(metric, (totalRequests + 1) / 3);
+          windowTag1Checkpoint429++;
+        }  else if (tags.containsValue("value2")) {
+          assertMetric(metric, totalRequests / 3);
+          windowTag2Checkpoint429++;
+        } else {
+          assertMetric(metric, (totalRequests + 2) / 3);
+          windowCheckpoint429++;
+        }
+      }
+    }
+
+    // Three rate metrics for the 429 errors
+    assertEquals(3, rateCheckpoint429);
+    // Three windowed metrics for the 4xx errors
+    assertEquals(3, windowCheckpoint429 + windowTag1Checkpoint429 + windowTag2Checkpoint429);
   }
 
   @Test
@@ -358,6 +414,96 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals((non5xxCount + 1) * 2, caughtTag2CheckpointNon5xx); //include 429s
   }
 
+  @DisplayName("WithGlobalStatsRequestTagsEnabledPropKey")
+  @Test
+  public void testException5xxMetrics_WithGlobalStatsRequestTagsEnabledPropKey() {
+    int totalRequests = 10;
+    IntStream.range(0, totalRequests).forEach((i) -> makeFailedCall());
+
+    int totalCheckpoint = 0;
+    int totalCheckpoint5xx = 0;
+    int totalCheckpointNon5xx = 0;
+    int caughtCheckpoint5xx = 0;
+    int caughtCheckpointNon5xx = 0;
+    int caughtTag1Checkpoint5xx = 0;
+    int caughtTag1CheckpointNon5xx = 0;
+    int caughtTag2Checkpoint5xx = 0;
+    int caughtTag2CheckpointNon5xx = 0;
+
+    for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
+      if (metric.metricName().group().equals("jersey-metrics")) {
+        Map<String, String> tags = metric.metricName().tags();
+        switch (metric.metricName().name()) {
+          case "request-error-count": // global metrics
+          case "request-error-total": // global metrics
+            if (is5xxError(tags)) {
+              if (tags.containsValue("value1")) {
+                assertMetric(metric, (totalRequests + 1) / 3);
+              } else if (tags.containsValue("value2")) {
+                assertMetric(metric, totalRequests / 3);
+              } else {
+                assertMetric(metric, (totalRequests + 2) / 3);
+              }
+              totalCheckpoint5xx++;
+            } else if (tags.containsKey(HTTP_STATUS_CODE_TAG)) {
+              assertMetric(metric, 0);
+              totalCheckpointNon5xx++;
+            } else {
+              if (tags.containsValue("value1")) {
+                assertMetric(metric, (totalRequests + 1) / 3);
+              } else if (tags.containsValue("value2")) {
+                assertMetric(metric, totalRequests / 3);
+              } else {
+                assertMetric(metric, (totalRequests + 2) / 3);
+              }
+              totalCheckpoint++;
+            }
+            break;
+          case "caught.request-error-count": // method metrics
+          case "caught.request-error-total": // method metrics
+            if (tags.containsValue("value1")) {
+              if (is5xxError(tags)) {
+                assertMetric(metric, (totalRequests + 1) / 3);
+                caughtTag1Checkpoint5xx++;
+              } else if (tags.containsKey(HTTP_STATUS_CODE_TAG)) {
+                assertMetric(metric, 0);
+                caughtTag1CheckpointNon5xx++;
+              }
+            } else if (tags.containsValue("value2")) {
+              if (is5xxError(tags)) {
+                assertMetric(metric, totalRequests / 3);
+                caughtTag2Checkpoint5xx++;
+              } else if (tags.containsKey(HTTP_STATUS_CODE_TAG)) {
+                assertMetric(metric, 0);
+                caughtTag2CheckpointNon5xx++;
+              }
+            } else {
+              if (is5xxError(tags)) {
+                assertMetric(metric, (totalRequests + 2) / 3);
+                caughtCheckpoint5xx++;
+              } else if (tags.containsKey(HTTP_STATUS_CODE_TAG)) {
+                assertMetric(metric, 0);
+                caughtCheckpointNon5xx++;
+              }
+            }
+            break;
+        }
+      }
+    }
+    int non5xxCount = HTTP_STATUS_CODE_TEXT.length - 2;
+    int tagVariants = 3;
+    assertEquals(2 * tagVariants, totalCheckpoint);
+    assertEquals(2 * tagVariants, totalCheckpoint5xx);
+    assertEquals((non5xxCount + 1) * 2 * tagVariants, totalCheckpointNon5xx); //include 429s
+
+    assertEquals(2, caughtCheckpoint5xx);
+    assertEquals((non5xxCount + 1) * 2, caughtCheckpointNon5xx); //include 429s
+    assertEquals(2, caughtTag1Checkpoint5xx);
+    assertEquals((non5xxCount + 1) * 2, caughtTag1CheckpointNon5xx); //include 429s
+    assertEquals(2, caughtTag2Checkpoint5xx);
+    assertEquals((non5xxCount + 1) * 2, caughtTag2CheckpointNon5xx); //include 429s
+  }
+
   @Test
   public void testMetricReporterConfiguration() {
     ApplicationWithFilter app;
@@ -370,7 +516,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
     props.put("not.prefixed.config", "val3");
 
-    app = new ApplicationWithFilter(new TestRestConfig(props));
+    app = new ApplicationWithFilter(new TestRestConfig(props), false);
     TestMetricsReporter reporter = (TestMetricsReporter) app.getMetrics().reporters().get(0);
 
     assertTrue(reporter.getConfigs().containsKey("not.prefixed.config"));
@@ -447,9 +593,11 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   private class ApplicationWithFilter extends Application<TestRestConfig> {
 
     Configurable resourceConfig;
+    private final boolean useFilterWithGlobalStatsRequestTags;
 
-    ApplicationWithFilter(TestRestConfig props) {
+    ApplicationWithFilter(TestRestConfig props, boolean useFilterWithGlobalStatsRequestTags) {
       super(props);
+      this.useFilterWithGlobalStatsRequestTags = useFilterWithGlobalStatsRequestTags;
     }
 
     @Override
@@ -457,7 +605,11 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       resourceConfig = config;
       config.register(PrivateResource.class);
       config.register(new PublicResource());
-      config.register(new Filter());
+      if (this.useFilterWithGlobalStatsRequestTags) {
+        config.register(new FilterWithGlobalStatsRequestTagsEnabled());
+      } else {
+        config.register(new Filter());
+      }
       config.register(new MyExceptionMapper(appConfig));
 
       // ensures the dispatch error message gets shown in the response
@@ -530,7 +682,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   }
 
-  public class Filter implements ContainerRequestFilter {
+  private class Filter implements ContainerRequestFilter {
 
     private final String[] tags = new String[]{"", "value1", "value2"};
 
@@ -545,7 +697,18 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
   }
 
-  public final class MyExceptionMapper extends KafkaExceptionMapper {
+  private class FilterWithGlobalStatsRequestTagsEnabled extends Filter {
+
+    @Override
+    public void filter(ContainerRequestContext context) {
+      super.filter(context);
+      context.setProperty(
+          MetricsResourceMethodApplicationListener.GLOBAL_STATS_REQUEST_TAGS_ENABLED_PROP_KEY,
+          true);
+    }
+  }
+
+  private final class MyExceptionMapper extends KafkaExceptionMapper {
 
     public MyExceptionMapper(final RestConfig restConfig) {
       super(restConfig);
@@ -562,7 +725,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
   }
 
-  public static class StatusCodeException extends RuntimeException {
+  private static class StatusCodeException extends RuntimeException {
 
     private final Status status;
     private final int code;

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -288,6 +288,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   @DisplayName("WithGlobalStatsRequestTagsEnabled")
   @Test
+  // This tests validates that with METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG enabled true,
+  // the request-tags "value1" "value2" are on the global metrics for 429
   public void test429Metrics_WithGlobalStatsRequestTagsEnabled() throws InterruptedException {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> make429Call());
@@ -418,6 +420,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   @DisplayName("WithGlobalStatsRequestTagsEnabled")
   @Test
+  // This tests validates that with METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG enabled true,
+  // the request-tags "value1" "value2" are on the global metrics for 5XX
   public void testException5xxMetrics_WithGlobalStatsRequestTagsEnabled() {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> makeFailedCall());


### PR DESCRIPTION
This PR introduces a request attribute `GLOBAL_STATS_REQUEST_TAGS_ENABLED_PROP_KEY` to enable global stats (metrics for all resource methods) to include runtime tags from the requests. 

This will enable us to have tenant metrics whenever tenant tag is set in application resources (from ce-kafka-rest) for example.

This attributes is also used to keep the compatibility with all downstream apps that use `rest-utils`.

PR for `ce-kafka-rest` will be followup after this.