### PR TITLE
Initial draft of a simple filter

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -29,6 +29,7 @@ import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
 import io.confluent.rest.exceptions.JsonParseExceptionMapper;
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
+import io.confluent.rest.filters.JettyRequestsSimpleFilter;
 import io.confluent.rest.metrics.Jetty429MetricsDosFilterListener;
 import io.confluent.rest.metrics.MetricsResourceMethodApplicationListener;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
@@ -708,7 +709,7 @@ public abstract class Application<T extends RestConfig> {
       return;
     }
     // General jetty "filter" that is used for getting the requests count
-    FilterHolder generalFilterHolder = new FilterHolder(CsrfTokenProtectionFilter.class);
+    FilterHolder generalFilterHolder = new FilterHolder(JettyRequestsSimpleFilter.class);
     generalFilterHolder.setName("Jetty level requests count filter");
     context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -346,11 +346,7 @@ public abstract class Application<T extends RestConfig> {
     }
 
     configureSecurityHandler(context);
-
-    // General jetty "filter" that is used for getting the requests count
-    FilterHolder generalFilterHolder = new FilterHolder(JettyRequestsSimpleFilter.class);
-    generalFilterHolder.setName("jetty-level-requests-count");
-    context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+    configureJettySimpleFilter(context);
 
     if (isCorsEnabled()) {
       String allowedOrigins = config.getString(RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
@@ -727,6 +723,13 @@ public abstract class Application<T extends RestConfig> {
     FilterHolder filterHolder = configureFilter(dosFilter,
         String.valueOf(config.getDosFilterMaxRequestsPerConnectionPerSec()));
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+
+  private void configureJettySimpleFilter(ServletContextHandler context) {
+    // General jetty "filter" that is used for getting the requests count
+    FilterHolder generalFilterHolder = new FilterHolder(JettyRequestsSimpleFilter.class);
+    generalFilterHolder.setName("jetty-level-requests-count");
+    context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
 
   private void configureGlobalDosFilter(ServletContextHandler context) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -707,6 +707,10 @@ public abstract class Application<T extends RestConfig> {
     if (!config.isDosFilterEnabled()) {
       return;
     }
+    // General jetty "filter" that is used for getting the requests count
+    FilterHolder generalFilterHolder = new FilterHolder(CsrfTokenProtectionFilter.class);
+    generalFilterHolder.setName("Jetty level requests count filter");
+    context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
 
     // Ensure that the per connection limiter is first - KREST-8391
     configureNonGlobalDosFilter(context);

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -732,7 +732,7 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureJettySimpleFilter(ServletContextHandler context) {
-    // General jetty "filter" that is used for getting the requests count
+    // A general jetty "filter" that is used for getting the requests count
     JettyRequestsSimpleFilter generalSimpleFilter = new JettyRequestsSimpleFilter();
     generalSimpleFilter.setListener(jettyAllRequestsListener);
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -347,6 +347,11 @@ public abstract class Application<T extends RestConfig> {
 
     configureSecurityHandler(context);
 
+    // General jetty "filter" that is used for getting the requests count
+    FilterHolder generalFilterHolder = new FilterHolder(JettyRequestsSimpleFilter.class);
+    generalFilterHolder.setName("jetty-level-requests-count");
+    context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+
     if (isCorsEnabled()) {
       String allowedOrigins = config.getString(RestConfig.ACCESS_CONTROL_ALLOW_ORIGIN_CONFIG);
       FilterHolder filterHolder = new FilterHolder(CrossOriginFilter.class);
@@ -708,11 +713,6 @@ public abstract class Application<T extends RestConfig> {
     if (!config.isDosFilterEnabled()) {
       return;
     }
-    // General jetty "filter" that is used for getting the requests count
-    FilterHolder generalFilterHolder = new FilterHolder(JettyRequestsSimpleFilter.class);
-    generalFilterHolder.setName("Jetty level requests count filter");
-    context.addFilter(generalFilterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
-
     // Ensure that the per connection limiter is first - KREST-8391
     configureNonGlobalDosFilter(context);
     configureGlobalDosFilter(context);

--- a/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
+++ b/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
@@ -19,7 +19,6 @@ import org.slf4j.LoggerFactory;
 public class JettyRequestsSimpleFilter implements Filter {
   private static final Logger log = LoggerFactory.getLogger(JettyRequestsSimpleFilter.class);
   private JettyAllRequestsListener _listener;
-
   @Override
   public void init(final FilterConfig filterConfig) throws ServletException {
   }
@@ -40,6 +39,5 @@ public class JettyRequestsSimpleFilter implements Filter {
 
   @Override
   public void destroy() {
-
   }
 }

--- a/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
+++ b/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
@@ -1,26 +1,41 @@
 package io.confluent.rest.filters;
 
+import io.confluent.rest.metrics.JettyAllRequestsListener;
 import java.io.IOException;
+import java.util.Objects;
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.kafka.common.metrics.Sensor;
+import org.eclipse.jetty.servlets.DoSFilter.Listener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class JettyRequestsSimpleFilter implements Filter {
   private static final Logger log = LoggerFactory.getLogger(JettyRequestsSimpleFilter.class);
+  private JettyAllRequestsListener _listener;
 
   @Override
   public void init(final FilterConfig filterConfig) throws ServletException {
   }
-
+  public void setListener(JettyAllRequestsListener listener) {
+    this._listener = (JettyAllRequestsListener) Objects.requireNonNull(listener, "Listener may not be null");
+  }
   @Override
   public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
       final FilterChain filterChain) throws IOException, ServletException {
-    filterChain.doFilter(servletRequest, servletResponse);
+
+    HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+    HttpServletResponse httpServletResponse = (HttpServletResponse) servletResponse;
+
+    log.debug("Getting a request of {}", httpServletRequest);
+    this._listener.onRequest(httpServletRequest);
+    filterChain.doFilter(httpServletRequest, httpServletResponse);
   }
 
   @Override

--- a/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
+++ b/core/src/main/java/io/confluent/rest/filters/JettyRequestsSimpleFilter.java
@@ -1,0 +1,30 @@
+package io.confluent.rest.filters;
+
+import java.io.IOException;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JettyRequestsSimpleFilter implements Filter {
+  private static final Logger log = LoggerFactory.getLogger(JettyRequestsSimpleFilter.class);
+
+  @Override
+  public void init(final FilterConfig filterConfig) throws ServletException {
+  }
+
+  @Override
+  public void doFilter(final ServletRequest servletRequest, final ServletResponse servletResponse,
+      final FilterChain filterChain) throws IOException, ServletException {
+    filterChain.doFilter(servletRequest, servletResponse);
+  }
+
+  @Override
+  public void destroy() {
+
+  }
+}

--- a/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
@@ -82,7 +82,7 @@ public class Jetty429MetricsDosFilterListener extends DoSFilter.Listener {
   public Action onRequestOverLimit(HttpServletRequest request, OverLimit overlimit,
       DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
-    // it will log a WARN line, in order to reduce verbosity
+    // it will log  a WARN line, in order to reduce verbosity
     Action action = Action.fromDelay(dosFilter.getDelayMs());
     if (fourTwoNineSensor != null && action.equals(Action.REJECT)) {
       fourTwoNineSensor.record();
@@ -90,7 +90,7 @@ public class Jetty429MetricsDosFilterListener extends DoSFilter.Listener {
     return action;
   }
 
-  private MetricName getMetricName(Metrics metrics, String name, String doc,
+  public static MetricName getMetricName(Metrics metrics, String name, String doc,
       Map<String, String> metricsTags) {
     return metrics.metricInstance(
         new MetricNameTemplate(name, GROUP_NAME, doc, metricsTags.keySet()), metricsTags);

--- a/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/Jetty429MetricsDosFilterListener.java
@@ -82,7 +82,7 @@ public class Jetty429MetricsDosFilterListener extends DoSFilter.Listener {
   public Action onRequestOverLimit(HttpServletRequest request, OverLimit overlimit,
       DoSFilter dosFilter) {
     // KREST-10418: we don't use super function to get action object because
-    // it will log  a WARN line, in order to reduce verbosity
+    // it will log a WARN line, in order to reduce verbosity
     Action action = Action.fromDelay(dosFilter.getDelayMs());
     if (fourTwoNineSensor != null && action.equals(Action.REJECT)) {
       fourTwoNineSensor.record();

--- a/core/src/main/java/io/confluent/rest/metrics/JettyAllRequestsListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/JettyAllRequestsListener.java
@@ -1,0 +1,50 @@
+package io.confluent.rest.metrics;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.Sensor.RecordingLevel;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.WindowedCount;
+import org.eclipse.jetty.servlets.DoSFilter;
+import org.eclipse.jetty.servlets.DoSFilter.Action;
+import org.eclipse.jetty.servlets.DoSFilter.OverLimit;
+
+public class JettyAllRequestsListener {
+  private Sensor allRequestsSensor = null;
+  private static final long SENSOR_EXPIRY_SECONDS = TimeUnit.HOURS.toSeconds(1);
+  private static final String GROUP_NAME = "jetty-metrics";
+  public JettyAllRequestsListener(Metrics metrics, Map<String, String> metricTags,
+      String jmxPrefix) {
+    if (metrics != null) {
+      String sensorNamePrefix = jmxPrefix + ":" + GROUP_NAME;
+      SortedMap<String, String> instanceMetricsTags = new TreeMap<>(metricTags);
+
+      // All requests
+      instanceMetricsTags.put("http_status_code", "xxx");
+      String sensorTags =
+          instanceMetricsTags.keySet().stream()
+              .map(key -> ":" + instanceMetricsTags.get(key))
+              .collect(Collectors.joining());
+
+      String sensorName = sensorNamePrefix + ":request-count" + sensorTags;
+      allRequestsSensor = metrics.sensor(sensorName,
+          null, SENSOR_EXPIRY_SECONDS, RecordingLevel.DEBUG, (Sensor[]) null);
+
+      allRequestsSensor.add(Jetty429MetricsDosFilterListener.getMetricName(metrics, "request-total-count",
+          "A windowed count of requests that resulted any of HTTP responses in Jetty layer",
+          instanceMetricsTags), new CumulativeCount());
+    }
+  }
+
+  public void onRequest(HttpServletRequest request) {
+    if (allRequestsSensor != null) {
+      allRequestsSensor.record();
+    }
+  }
+}


### PR DESCRIPTION
This PR is to provide Jetty layer count metrics, i.e those requests are not rejected by any of the filters. 
* A general filter that won't filter requests on the jetty layer 
* Request-total-count
* Under group name of jetty-metrics, with the tag http_status_code:xxx
