### PR TITLE
KREST-11276 - Fixing cert reload with multiple registered listeners

### DIFF
--- a/core/src/main/java/io/confluent/rest/FileWatcher.java
+++ b/core/src/main/java/io/confluent/rest/FileWatcher.java
@@ -31,19 +31,10 @@ import java.nio.file.WatchEvent;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadFactory;
 
 // reference https://gist.github.com/danielflower/f54c2fe42d32356301c68860a4ab21ed
 public class FileWatcher implements Runnable {
   private static final Logger log = LoggerFactory.getLogger(FileWatcher.class);
-  private static final ExecutorService executor = Executors.newFixedThreadPool(1,
-        new ThreadFactory() {
-          public Thread newThread(Runnable r) {
-            Thread t = Executors.defaultThreadFactory().newThread(r);
-            t.setDaemon(true);
-            return t;
-          }
-        });
 
   public interface Callback {
     void run() throws Exception;
@@ -53,6 +44,12 @@ public class FileWatcher implements Runnable {
   private final WatchService watchService;
   private final Path file;
   private final Callback callback;
+  private final ExecutorService executorService = Executors.newSingleThreadExecutor(
+      r -> {
+        Thread thread = new Thread(r, "file-watcher");
+        thread.setDaemon(true);
+        return thread;
+      });
 
   public FileWatcher(Path file, Callback callback) throws IOException {
     this.file = file;
@@ -75,10 +72,11 @@ public class FileWatcher implements Runnable {
   public static void onFileChange(Path file, Callback callback) throws IOException {
     log.info("Constructing a new watch service: " + file);
     FileWatcher fileWatcher = new FileWatcher(file, callback);
-    executor.submit(fileWatcher);
+    fileWatcher.executorService.submit(fileWatcher);
   }
 
   public void run() {
+    log.info("Running file watcher service thread");
     try {
       while (!shutdown) {
         try {
@@ -147,6 +145,7 @@ public class FileWatcher implements Runnable {
     shutdown = true;
     try {
       watchService.close();
+      executorService.shutdown();
     } catch (IOException e) {
       log.info("Error closing watch service", e);
     }


### PR DESCRIPTION
Though Multiple FileWatchers are created for multiple listeners but they execute on `static` single thread pool. As the `run` method continuously executes hence only one among multiple submitted FileWatcher will run.

```
jmap -histo 1 | grep -e FileWatcher
4360:             2             64  io.confluent.rest.FileWatcher
8205:             1             16  io.confluent.rest.FileWatcher$1
```

When SslFactory registers multiple listeners for cert dynamic reload then only one among listener will get new certificate.

Current PR creates individual thread executor which guarantees execution of all FileWatcher and cert reload on all listener. 

We might do better here in future with registering all file change notifications. Rather than creating multiple file watcher services we can register for change notification over common single executor.