### PR TITLE
KREST-7955 421 misdirected request if host does not match SNI

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -413,12 +413,14 @@ public abstract class Application<T extends RestConfig> {
     requestLogHandler.setRequestLog(requestLog);
     context.insertHandler(requestLogHandler);
 
-    HandlerCollection handlerCollection = new HandlerCollection();
-    Handler[] handlers = config.getSniCheckEnable() ? new Handler[]{new SniHandler(), context}
-        : new Handler[]{context};
-    handlerCollection.setHandlers(handlers);
+    if (config.getSniCheckEnable()) {
+      context.insertHandler(new SniHandler());
+    }
 
-    return handlerCollection;
+    HandlerCollection handlers = new HandlerCollection();
+    handlers.setHandlers(new Handler[]{context});
+
+    return handlers;
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -30,6 +30,7 @@ import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
 import io.confluent.rest.exceptions.JsonParseExceptionMapper;
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
+import io.confluent.rest.handlers.SniHandler;
 import io.confluent.rest.metrics.Jetty429MetricsDosFilterListener;
 import io.confluent.rest.metrics.MetricsResourceMethodApplicationListener;
 import io.confluent.rest.validation.JacksonMessageBodyProvider;
@@ -387,7 +388,7 @@ public abstract class Application<T extends RestConfig> {
     context.insertHandler(requestLogHandler);
 
     HandlerCollection handlers = new HandlerCollection();
-    handlers.setHandlers(new Handler[]{context});
+    handlers.setHandlers(new Handler[]{new SniHandler(), context});
 
     return handlers;
   }

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -413,10 +413,12 @@ public abstract class Application<T extends RestConfig> {
     requestLogHandler.setRequestLog(requestLog);
     context.insertHandler(requestLogHandler);
 
-    HandlerCollection handlers = new HandlerCollection();
-    handlers.setHandlers(new Handler[]{new SniHandler(), context});
+    HandlerCollection handlerCollection = new HandlerCollection();
+    Handler[] handlers = config.getSniCheckEnable() ? new Handler[]{new SniHandler(), context}
+        : new Handler[]{context};
+    handlerCollection.setHandlers(handlers);
 
-    return handlers;
+    return handlerCollection;
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -495,6 +495,13 @@ public class RestConfig extends AbstractConfig {
           + "Java 11 JVM or later. Default is true.";
   protected static final boolean HTTP2_ENABLED_DEFAULT = true;
 
+  public static final String SNI_CHECK_ENABLED_CONFIG = "sni.check.enabled";
+  protected static final String SNI_CHECK_ENABLED_DOC =
+      "Whether or not to check the SNI against the Host header. If the values don't match, "
+          + "returns a 421 misdirected response. Default is false. NOTE: this check should "
+          + "not be enabled if servers have mutual TLS enabled.";
+  protected static final boolean SNI_CHECK_ENABLED_DEFAULT = false;
+
   public static final String PROXY_PROTOCOL_ENABLED_CONFIG =
       "proxy.protocol.enabled";
   protected static final String PROXY_PROTOCOL_ENABLED_DOC =
@@ -1054,6 +1061,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             HTTP2_ENABLED_DOC
         ).define(
+            SNI_CHECK_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            SNI_CHECK_ENABLED_DEFAULT,
+            Importance.LOW,
+            SNI_CHECK_ENABLED_DOC
+        ).define(
             LISTENER_PROTOCOL_MAP_CONFIG,
             Type.LIST,
             LISTENER_PROTOCOL_MAP_DEFAULT,
@@ -1389,6 +1402,10 @@ public class RestConfig extends AbstractConfig {
 
   public final int getNetworkTrafficRateLimitBytesPerSec() {
     return getInt(NETWORK_TRAFFIC_RATE_LIMIT_BYTES_PER_SEC_CONFIG);
+  }
+
+  public final boolean getSniCheckEnable() {
+    return getBoolean(SNI_CHECK_ENABLED_CONFIG);
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -498,8 +498,7 @@ public class RestConfig extends AbstractConfig {
   public static final String SNI_CHECK_ENABLED_CONFIG = "sni.check.enabled";
   protected static final String SNI_CHECK_ENABLED_DOC =
       "Whether or not to check the SNI against the Host header. If the values don't match, "
-          + "returns a 421 misdirected response. Default is false. NOTE: this check should "
-          + "not be enabled if servers have mutual TLS enabled.";
+          + "returns a 421 misdirected response. Default is false.";
   protected static final boolean SNI_CHECK_ENABLED_DEFAULT = false;
 
   public static final String PROXY_PROTOCOL_ENABLED_CONFIG =

--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -16,6 +16,8 @@
 
 package io.confluent.rest.handlers;
 
+import static org.eclipse.jetty.http.HttpStatus.Code.MISDIRECTED_REQUEST;
+
 import java.io.IOException;
 import java.util.List;
 import javax.net.ssl.ExtendedSSLSession;
@@ -44,7 +46,7 @@ public class SniHandler extends AbstractHandler {
     if (sniServerName != null && !sniServerName.equals(serverName)) {
       log.error("Sni check failed, host header: {}, sni value: {}", serverName, sniServerName);
       baseRequest.setHandled(true);
-      response.sendError(421, "Misdirected Request");
+      response.sendError(MISDIRECTED_REQUEST.getCode(), MISDIRECTED_REQUEST.getMessage());
     }
   }
 

--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -30,11 +30,11 @@ import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.ssl.SslConnection.DecryptedEndPoint;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class SniHandler extends AbstractHandler {
+public class SniHandler extends HandlerWrapper {
   private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
 
   @Override
@@ -48,6 +48,7 @@ public class SniHandler extends AbstractHandler {
       baseRequest.setHandled(true);
       response.sendError(MISDIRECTED_REQUEST.getCode(), MISDIRECTED_REQUEST.getMessage());
     }
+    super.handle(target, baseRequest, request, response);
   }
 
   private static String getSniServerName(Request baseRequest) {

--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -44,7 +44,7 @@ public class SniHandler extends AbstractHandler {
     String serverName = request.getServerName();
     String sniServerName = getSniServerName(baseRequest);
     if (sniServerName != null && !sniServerName.equals(serverName)) {
-      log.error("Sni check failed, host header: {}, sni value: {}", serverName, sniServerName);
+      log.debug("Sni check failed, host header: {}, sni value: {}", serverName, sniServerName);
       baseRequest.setHandled(true);
       response.sendError(MISDIRECTED_REQUEST.getCode(), MISDIRECTED_REQUEST.getMessage());
     }

--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2014 - 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.handlers;
+
+import java.io.IOException;
+import java.util.List;
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLSession;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.ssl.SslConnection.DecryptedEndPoint;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.AbstractHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SniHandler extends AbstractHandler {
+  private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
+
+  @Override
+  public void handle(String target, Request baseRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) throws IOException, ServletException {
+    String serverName = request.getServerName();
+    String sniServerName = getSniServerName(baseRequest);
+    if (sniServerName != null && !sniServerName.equals(serverName)) {
+      log.error("Sni check failed, host header: {}, sni value: {}", serverName, sniServerName);
+      baseRequest.setHandled(true);
+      response.sendError(421, "Misdirected Request");
+    }
+  }
+
+  private static String getSniServerName(Request baseRequest) {
+    EndPoint endpoint = baseRequest.getHttpChannel().getEndPoint();
+    if (endpoint instanceof DecryptedEndPoint) {
+      SSLSession session = ((DecryptedEndPoint) endpoint)
+          .getSslConnection()
+          .getSSLEngine()
+          .getSession();
+      if (session instanceof ExtendedSSLSession) {
+        List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
+        if (servers != null) {
+          return servers.stream()
+              .findAny()
+              .filter(SNIHostName.class::isInstance)
+              .map(SNIHostName.class::cast)
+              .map(SNIHostName::getAsciiName)
+              .orElse(null);
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/core/src/test/java/io/confluent/rest/SniHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/SniHandlerIntegrationTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright 2014 - 2023 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static io.confluent.rest.TestUtils.getFreePort;
+import static org.eclipse.jetty.http.HttpStatus.Code.MISDIRECTED_REQUEST;
+import static org.eclipse.jetty.http.HttpStatus.Code.OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.MediaType;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.test.TestSslUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+@Tag("IntegrationTest")
+public class SniHandlerIntegrationTest {
+
+  public static final String TEST_SSL_PASSWORD = "test1234";
+  public static final String KAFKA_REST_HOST = "localhost";
+  public static final String KSQL_HOST = "anotherhost";
+
+  private Server server;
+  private HttpClient httpClient;
+  private Properties props;
+  private File clientKeystore;
+
+  @BeforeEach
+  public void setup(TestInfo info) throws Exception {
+    props = new Properties();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    httpClient.stop();
+    server.stop();
+    server.join();
+  }
+
+  @Test
+  public void test_http_SniHandlerEnabled_no_effect() throws Exception {
+    props.setProperty(RestConfig.SNI_CHECK_ENABLED_CONFIG, "true");
+    // http doesn't have SNI concept, SNI is an extension for TLS
+    startHttpServer("http");
+    startHttpClient("http");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_HTML)
+        // make Host different from SNI
+        .header(HttpHeader.HOST, "host.value.does.not.matter")
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void test_https_SniHandlerDisabled_wrong_host_pass(boolean mTLSEnabled) throws Exception {
+    props.setProperty(RestConfig.SNI_CHECK_ENABLED_CONFIG, "false");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    startHttpServer("https");
+    startHttpClient("https");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        // SNI is localhost but Host is anotherhost
+        .header(HttpHeader.HOST, KSQL_HOST)
+        .send();
+
+    // the request is successful because anotherhost is SAN in certificate
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void test_https_SniHandlerEnabled_wrong_host_421(boolean mTLSEnabled) throws Exception {
+    props.setProperty(RestConfig.SNI_CHECK_ENABLED_CONFIG, "true");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    startHttpServer("https");
+    startHttpClient("https");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        // SNI is localhost but Host is anotherhost
+        .header(HttpHeader.HOST, KSQL_HOST)
+        .send();
+
+    // 421 because SNI check is enabled
+    assertEquals(MISDIRECTED_REQUEST.getCode(), response.getStatus());
+    String responseContent = response.getContentAsString();
+    assertThat(responseContent, containsString(MISDIRECTED_REQUEST.getMessage()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void test_https_SniHandlerEnabled_same_host_pass(boolean mTLSEnabled) throws Exception {
+    props.setProperty(RestConfig.SNI_CHECK_ENABLED_CONFIG, "true");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    startHttpServer("https");
+    startHttpClient("https");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+
+    response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        .header(HttpHeader.HOST, KAFKA_REST_HOST)
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  private void startHttpClient(String scheme) throws Exception {
+    // allow setting Host header
+    System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+
+    if (scheme.equals("https")) {
+      // trust all self-signed certs.
+      SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+          .loadTrustMaterial(new TrustSelfSignedStrategy());
+      // add the client keystore if it's configured.
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystore.getAbsolutePath()),
+          TEST_SSL_PASSWORD.toCharArray(),
+          TEST_SSL_PASSWORD.toCharArray());
+      SSLContext sslContext = sslContextBuilder.build();
+
+      SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+      // this forces non-standard domains (localhost) in SNI and X509,
+      // see https://github.com/eclipse/jetty.project/pull/6296
+      sslContextFactory.setSNIProvider(
+          SslContextFactory.Client.SniProvider.NON_DOMAIN_SNI_PROVIDER);
+      sslContextFactory.setSslContext(sslContext);
+
+      httpClient = new HttpClient(sslContextFactory);
+    } else {
+      httpClient = new HttpClient();
+    }
+
+    httpClient.start();
+  }
+
+  private void startHttpServer(String scheme) throws Exception {
+    String url = scheme + "://" + KAFKA_REST_HOST + ":" + getFreePort();
+    props.setProperty(RestConfig.LISTENERS_CONFIG, url);
+
+    if (scheme.equals("https")) {
+      File serverKeystore;
+      File trustStore;
+      try {
+        trustStore = File.createTempFile("SslTest-truststore", ".jks");
+        serverKeystore = File.createTempFile("SslTest-server-keystore", ".jks");
+        clientKeystore = File.createTempFile("SslTest-client-keystore", ".jks");
+      } catch (IOException ioe) {
+        throw new RuntimeException(
+            "Unable to create temporary files for truststores and keystores.");
+      }
+      Map<String, X509Certificate> certs = new HashMap<>();
+      createKeystoreWithCert(clientKeystore, ServiceType.CLIENT, certs);
+      createKeystoreWithCert(serverKeystore, ServiceType.SERVER, certs);
+      TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(TEST_SSL_PASSWORD),
+          certs);
+
+      configServerKeystore(props, serverKeystore);
+      configServerTruststore(props, trustStore);
+    }
+    TestApp application = new TestApp(new TestRestConfig(props), "/");
+    server = application.createServer();
+
+    server.start();
+  }
+
+  private void configServerKeystore(Properties props, File serverKeystore) {
+    props.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, serverKeystore.getAbsolutePath());
+    props.put(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+    props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+  }
+
+  private void configServerTruststore(Properties props, File trustStore) {
+    props.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore.getAbsolutePath());
+    props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+  }
+
+  private void createKeystoreWithCert(File file, ServiceType type,
+      Map<String, X509Certificate> certs)
+      throws Exception {
+    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
+    TestSslUtils.CertificateBuilder certificateBuilder = new TestSslUtils.CertificateBuilder(30,
+        "SHA1withRSA");
+
+    X509Certificate cCert = certificateBuilder
+        // create two SANs (Subject Alternative Name) in the certificate,
+        // imagine "localhost" is kafka rest, and "anotherhost" is ksql
+        .sanDnsNames(KAFKA_REST_HOST, KSQL_HOST)
+        .generate("CN=mymachine.local, O=A client", keypair);
+
+    String alias = type.toString().toLowerCase();
+    TestSslUtils.createKeyStore(file.getPath(), new Password(TEST_SSL_PASSWORD),
+        new Password(TEST_SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    certs.put(alias, cCert);
+  }
+
+  private static class TestApp extends Application<TestRestConfig> implements AutoCloseable {
+
+    TestApp(TestRestConfig config, String path) {
+      super(config, path);
+    }
+
+    @Override
+    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) {
+      config.register(RestResource.class);
+    }
+
+    @Override
+    public void close() throws Exception {
+      stop();
+    }
+  }
+
+  @Path("/")
+  public static class RestResource {
+
+    @GET
+    @Path("/resource")
+    public String get() {
+      return "Hello";
+    }
+  }
+
+  private enum ServiceType {
+    CLIENT,
+    SERVER
+  }
+}


### PR DESCRIPTION
This PR adds SniHandler that checks for SNI against the host of the request, if they don't match, response with 421.

This handler is controlled by configuration to turn off/on, default is disabled.
`sni.check.enabled`

[Jira ticket](https://confluentinc.atlassian.net/browse/KREST-7955) 