### PR TITLE
CNC-397: unpin jetty to use the version defined in common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
         <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
-        <jetty.version>9.4.51.v20230217</jetty.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>


### PR DESCRIPTION
Jetty version is defined in common. Unpin the version here and use the one defined globally