### PR TITLE
CIAM-2673: initialize start time in metrics before onEvent() is called

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -536,7 +536,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       this.metrics = metrics;
       this.time = time;
       this.enableGlobalStatsRequestTags = enableGlobalStatsRequestTags;
-      // CIAM-2673: if an exception occurs, MATCHING_START is never reached, resulting in false latency metrics
+      // CIAM-2673: if an exception occur in a filter that runs before this method listener,
+      // MATCHING_START is never reached, resulting in false latency metrics
       this.started = time.milliseconds();
     }
 

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -536,6 +536,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       this.metrics = metrics;
       this.time = time;
       this.enableGlobalStatsRequestTags = enableGlobalStatsRequestTags;
+      // CIAM-2673: if an exception occurs, MATCHING_START is never reached, resulting in false latency metrics
+      this.started = time.milliseconds();
     }
 
     @Override

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -544,7 +544,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     @Override
     public void onEvent(RequestEvent event) {
       if (event.getType() == RequestEvent.Type.MATCHING_START) {
-        started = time.milliseconds();
         final ContainerRequest request = event.getContainerRequest();
         wrappedRequestStream = new CountingInputStream(request.getEntityStream());
         request.setEntityStream(wrappedRequestStream);

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -12,22 +12,13 @@ import io.confluent.rest.exceptions.ConstraintViolationExceptionMapper;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
 import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 
+import javax.ws.rs.container.PreMatching;
 import javax.ws.rs.core.Response.Status;
 import org.apache.kafka.common.metrics.KafkaMetric;
-import org.eclipse.jetty.security.AbstractLoginService;
-import org.eclipse.jetty.security.ConstraintMapping;
-import org.eclipse.jetty.security.ConstraintSecurityHandler;
-import org.eclipse.jetty.security.IdentityService;
-import org.eclipse.jetty.security.LoginService;
-import org.eclipse.jetty.security.ServerAuthException;
-import org.eclipse.jetty.security.authentication.LoginAuthenticator;
-import org.eclipse.jetty.server.Authentication;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.UserIdentity;
 import org.eclipse.jetty.server.handler.ErrorHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.util.security.Constraint;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,8 +37,6 @@ import java.util.stream.IntStream;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.ws.rs.GET;
@@ -57,19 +46,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
 import javax.ws.rs.core.Configurable;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.IntStream;
 
 import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.HTTP_STATUS_CODE_TAG;
 import static io.confluent.rest.metrics.MetricsResourceMethodApplicationListener.HTTP_STATUS_CODE_TEXT;
@@ -80,6 +59,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("IntegrationTest")
 public class MetricsResourceMethodApplicationListenerIntegrationTest {
+
   TestRestConfig config;
   ApplicationWithFilter app;
   private Server server;
@@ -103,7 +83,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     }
 
     config = new TestRestConfig(props);
-    app = new ApplicationWithFilter(config, false);
+    app = new ApplicationWithFilter(config);
     server = app.createServer();
     server.start();
     counter = new AtomicInteger();
@@ -534,56 +514,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void testFilterExceptionLatencyMetric() {
-    // custom setup for throwing exceptions in a Jetty filter
-    app = new ApplicationWithFilter(config, true);
-    try {
-      server = app.createServer();
-      server.start();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-
-    try {
-      Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
-              .target(server.getURI())
-              .path("/public/hello")
-              .request(MediaType.APPLICATION_JSON_TYPE)
-              .get();
-
-      //String totalUri = correctURI+"public/query?=%";
-      //String totalUri = correctURI+"public/hello";
-/*
-      HttpClient client = HttpClients.createDefault();
-      HttpGet getRequest = new HttpGet(totalUri);
-      HttpResponse response = client.execute(getRequest);
-/* */
-      /*
-      final URL url = new URL(totalUri);
-      final HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-      connection.setRequestMethod("GET");
-
-      final InputStream inputStream = connection.getInputStream();
-      final Response response = new ObjectMapper().readValue(inputStream, Response.class);
-      /* */
-      /*
-      while (true) {
-        System.err.print((char)inputStream.read());
-      }
-      */
-      assertEquals(500, response.getStatus());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-
-    for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
-      if (metric.metricName().name().equals("request-latency")) {
-        assertMetricLessThan(metric, 1000);
-      }
-    }
-  }
-
-  @Test
   public void testMetricReporterConfiguration() {
     ApplicationWithFilter app;
     Properties props = new Properties();
@@ -595,7 +525,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
     props.put("not.prefixed.config", "val3");
 
-    app = new ApplicationWithFilter(new TestRestConfig(props), false);
+    app = new ApplicationWithFilter(new TestRestConfig(props));
     TestMetricsReporter reporter = (TestMetricsReporter) app.getMetrics().reporters().get(0);
 
     assertTrue(reporter.getConfigs().containsKey("not.prefixed.config"));
@@ -631,6 +561,21 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(0, Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
   }
 
+  @Test
+  public void testValidLatencyMetricsForErrorBeforeResourceMatching() {
+    makeFilterError();
+
+    Map<String, String> allMetrics = TestMetricsReporter.getMetricTimeseries()
+        .stream()
+        .collect(Collectors.toMap(
+            x -> x.metricName().name(),
+            x -> x.metricValue().toString(),
+            (a, b) -> a));
+
+    assertTrue(Double.valueOf(allMetrics.get("request-latency-avg")) < 1000);
+    assertTrue(Double.valueOf(allMetrics.get("request-latency-max")) < 1000);
+   }
+
   private void makeSuccessfulCall() {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
         .target(server.getURI())
@@ -658,6 +603,15 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(500, response.getStatus());
   }
 
+  private void makeFilterError() {
+    Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
+        .target(server.getURI())
+        .path("/public/filterError")
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .get();
+    assertEquals(500, response.getStatus());
+  }
+
   private boolean is5xxError(Map<String, String> tags) {
     return tags.getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("5xx");
   }
@@ -669,21 +623,12 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(expectedValue, countValue, "Actual: " + countValue);
   }
 
-  private void assertMetricLessThan(KafkaMetric metric, int expectedValue) {
-    Object metricValue = metric.metricValue();
-    assertTrue(metricValue instanceof Double, "Metrics should be measurable");
-    double countValue = (double) metricValue;
-    assertTrue(countValue < expectedValue, "Expected: "+ expectedValue + "Actual: " + countValue);
-  }
-
   private class ApplicationWithFilter extends Application<TestRestConfig> {
-    private Configurable<?> resourceConfig;
-    // simulates an exception being thrown in a filter
-    private final boolean registerExplodingFilter;
 
-    ApplicationWithFilter(TestRestConfig props, boolean registerExplodingFilter) {
+    Configurable resourceConfig;
+
+    ApplicationWithFilter(TestRestConfig props) {
       super(props);
-      this.registerExplodingFilter = registerExplodingFilter;
     }
 
     @Override
@@ -691,19 +636,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       resourceConfig = config;
       config.register(PrivateResource.class);
       config.register(new PublicResource());
-      if (registerExplodingFilter) {
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-        config.register(new ExplodingFilter());
-      }
       config.register(new Filter());
+      config.register(new PreMatchingErrorFilter());
       config.register(new MyExceptionMapper(appConfig));
 
       // ensures the dispatch error message gets shown in the response
@@ -736,27 +670,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       });
     }
 
-    @Override
-    protected void configureSecurityHandler(ServletContextHandler context) {
-      if (registerExplodingFilter) {
-        return;
-      }
-
-      ConstraintSecurityHandler securityHandler = new ConstraintSecurityHandler();
-      Constraint constraint = new Constraint();
-      constraint.setAuthenticate( true );
-      constraint.setRoles(new String[] { "user", "admin" });
-
-      ConstraintMapping mapping = new ConstraintMapping();
-      mapping.setPathSpec("/*");
-      mapping.setConstraint( constraint );
-      //final ConstraintSecurityHandler securityHandler = createSecurityHandler();
-
-      securityHandler.setConstraintMappings(Collections.singletonList(mapping));
-      securityHandler.setAuthenticator(new ExplodingAuthenticator());
-      securityHandler.setLoginService(new BlahLoginService());
-      context.setSecurityHandler(securityHandler);
-    }
   }
 
   @Produces(MediaType.APPLICATION_JSON)
@@ -794,6 +707,13 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     public String fourTwoNine() {
       throw new StatusCodeException(Status.TOO_MANY_REQUESTS, new RuntimeException("kaboom"));
     }
+
+    @GET
+    @Path("/filterError")
+    @PerformanceMetric("filterError")
+    public String filterError() {
+      return "should never get here";
+    }
   }
 
   private class Filter implements ContainerRequestFilter {
@@ -808,6 +728,17 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         maps.put("tag", value);
       }
       context.setProperty(MetricsResourceMethodApplicationListener.REQUEST_TAGS_PROP_KEY, maps);
+    }
+  }
+
+  @PreMatching
+  private class PreMatchingErrorFilter implements ContainerRequestFilter {
+    @Override
+    public void filter(ContainerRequestContext context) {
+      String path = context.getUriInfo().getPath();
+      if (path.equals("public/filterError")) {
+        throw new RuntimeException("Error before resource matching");
+      }
     }
   }
 
@@ -847,4 +778,5 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
       return code;
     }
   }
+
 }


### PR DESCRIPTION
We have been getting paged once or twice every week of latency metrics that fire. When investigating usually these metrics are completely off. The root cause of the issue is the way we calculate the latency metric where the start time is stamped after resource matching. If we have filters that execute before matching, then the start time is not stamped and at the end when global metrics are calculated:

`final long elapsed = time.milliseconds() - started;`

The final time is just the current elapsed time since epoch. To fix this we need to move the start time stamping before resource matching. https://eclipse-ee4j.github.io/jersey.github.io/apidocs/2.34/jersey/org/glassfish/jersey/server/monitoring/ApplicationEventListener.html#onRequest-org.glassfish.jersey.server.monitoring.RequestEvent-

@confluent-altang Had already worked on this: https://github.com/confluentinc/rest-utils/pull/373. I just added a test and removed another line of code.