### PR TITLE
KREST-12364: update bcpix

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-	        <version>${bouncycastle.jdk18.version}</version>
+            <version>${bouncycastle.jdk18.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-	    <version>${bouncycastle.jdk18.version}</version>
+	        <version>${bouncycastle.jdk18.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -105,7 +105,8 @@
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+	    <version>1.77</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-	    <version>1.77</version>
+	    <version>${bouncycastle.jdk18.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update bouncycastle to version > 1.70. 
This PR needs to be re-tested after the merge of the change in common 
https://github.com/confluentinc/common/pull/565/checks?check_run_id=18759464892 
