### PR TITLE
KREST-12628 only log exceptions for 5xx

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status.Family;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
 
@@ -100,7 +101,13 @@ public abstract class DebuggableExceptionMapper<E extends Throwable> implements 
    */
   public Response.ResponseBuilder createResponse(Throwable exc, int errorCode,
                                                  Response.StatusType status, String msg) {
-    log.error("Request Failed with exception " ,  exc);
+    if (status.getFamily() == Family.SERVER_ERROR) {
+      // Always log 5xx errors, as they indicate server-side issues.
+      log.error("Request Failed with exception " ,  exc);
+    } else {
+      // Only log other errors, including user-errors 4xx, if debugging enabled.
+      log.debug("Request Failed with exception " ,  exc);
+    }
     String readableMessage = msg;
     if (restConfig != null && restConfig.getBoolean(RestConfig.DEBUG_CONFIG)) {
       readableMessage += " " + exc.getClass().getName() + ": " + exc.getMessage();

--- a/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
@@ -103,10 +103,10 @@ public abstract class DebuggableExceptionMapper<E extends Throwable> implements 
                                                  Response.StatusType status, String msg) {
     if (status.getFamily() == Family.SERVER_ERROR) {
       // Always log 5xx errors, as they indicate server-side issues.
-      log.error("Request Failed with exception " ,  exc);
+      log.error("Request Failed with exception ",  exc);
     } else {
       // Only log other errors, including user-errors 4xx, if debugging enabled.
-      log.debug("Request Failed with exception " ,  exc);
+      log.debug("Request Failed with exception ",  exc);
     }
     String readableMessage = msg;
     if (restConfig != null && restConfig.getBoolean(RestConfig.DEBUG_CONFIG)) {


### PR DESCRIPTION
Remove logging of exceptions for 404. This stack-trace is confusing in the logs as it is being logged for client issues.
But logging exceptions in 5xx is useful for debugging server-side issues.