### PR TITLE
KREST-11812 Replace EOL javaee/jaxb-api with jarkartaee/jaxb-api

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,10 +27,9 @@
             <groupId>org.glassfish.jersey.inject</groupId>
             <artifactId>jersey-hk2</artifactId>
         </dependency>
-        <!-- Jersey dependency that was available in the JDK before Java 9 -->
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
         <!-- Jersey dependency that was available in the JDK before Java 9 -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
                 <artifactId>jersey-container-servlet</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <!-- 2.3.3 is the closest major version to the EoL javaee/jaxb-api 2.3.0 -->
+                <version>2.3.3</version>
+            </dependency>
             <!-- Jersey dependency that was available in the JDK before Java 9 -->
             <dependency>
                 <groupId>javax.activation</groupId>


### PR DESCRIPTION
As the title said, this replaces an EoL dependency with a maintained one.