### PR TITLE
KREST-12153 Enable pint merge in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ common {
   downStreamRepos = ["schema-registry", "metadata-service", "kafka-rest",
     "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
     "confluent-cloud-plugins"]
+  pintMerge = true
   nanoVersion = true
   pinnedNanoVersions = true
   mvnSkipDeploy = true


### PR DESCRIPTION
We often get failed builds on master due to missing pint merge, so enable automatic process.

If you don't want a commit to a release branch that gets auto pint merge, add [ci skip] at the beginning of commit message, see https://confluentinc.atlassian.net/wiki/spaces/~380501681/pages/949097613/Pint+Merge+in+CI for more details