### PR TITLE
KREST-12887 remove schema-registry as downstream because it is disabled in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 common {
   slackChannel = '#c3-alerts'
-  downStreamRepos = ["schema-registry", "metadata-service", "kafka-rest",
+  downStreamRepos = ["metadata-service", "kafka-rest",
     "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
     "confluent-cloud-plugins"]
   pintMerge = true


### PR DESCRIPTION
Confirmed that schema-registry is no longer in Jenkins, https://confluent.slack.com/archives/CLQ1C50JU/p1701942853179179