### PR TITLE
KREST-13041 Test that SSL cipher suites can be restricted

### DIFF
--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -71,7 +71,6 @@ public final class SslFactory {
     }
 
     if (!sslConfig.getIncludeCipherSuites().isEmpty()) {
-      log.info("MSN: setting cipher to {}", sslConfig.getIncludeCipherSuites());
       sslContextFactory.setIncludeCipherSuites(
           sslConfig.getIncludeCipherSuites().toArray(new String[0]));
     }

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -71,6 +71,7 @@ public final class SslFactory {
     }
 
     if (!sslConfig.getIncludeCipherSuites().isEmpty()) {
+      log.info("MSN: setting cipher to {}", sslConfig.getIncludeCipherSuites());
       sslContextFactory.setIncludeCipherSuites(
           sslConfig.getIncludeCipherSuites().toArray(new String[0]));
     }

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -243,6 +243,8 @@ public class SslTest {
       app.start();
 
       // Correct Cipher, returns 200.
+      // TLSv1.3 should be specified with TLS_AES_128_GCM_SHA256 only for test-setup, as this cipher is specific to TLSv1.3.
+      // NOTE - the behaviour of restricting cipher in REST is agnostic of TLS protocols.
       int statusCode = makeGetRequest(uri + "/test",
           clientKeystore.getAbsolutePath(), SSL_PASSWORD, SSL_PASSWORD, "TLSv1.3", "TLS_AES_128_GCM_SHA256");
       assertEquals(200, statusCode, EXPECTED_200_MSG);

--- a/core/src/test/java/io/confluent/rest/SslTest.java
+++ b/core/src/test/java/io/confluent/rest/SslTest.java
@@ -383,7 +383,7 @@ public class SslTest {
       String clientKeystorePassword,
       String clientKeyPassword)
       throws Exception {
-    return makeGetRequest(url, clientKeystoreLocation, clientKeystorePassword, clientKeyPassword, "TLSv1.2", null);
+    return makeGetRequest(url, clientKeystoreLocation, clientKeystorePassword, clientKeyPassword, null, null);
   }
 
   // returns the http response status code.
@@ -410,13 +410,11 @@ public class SslTest {
             clientKeyPassword.toCharArray());
       }
       SSLContext sslContext = sslContextBuilder.build();
-
-      //      SSLConnectionSocketFactory sslSf = new SSLConnectionSocketFactory(sslContext,
-      //          new String[]{"TLSv1.2"},
-      //          null, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+      String ctxTlsProtocol = tlsProtocol == null ? "TLSv1.2" : tlsProtocol;
       SSLConnectionSocketFactory sslSf = new SSLConnectionSocketFactory(sslContext,
-          new String[]{tlsProtocol},
-          new String[]{cipherSuite}, SSLConnectionSocketFactory.getDefaultHostnameVerifier());
+          new String[]{ctxTlsProtocol},
+          cipherSuite != null ? new String[]{cipherSuite}: null,
+          SSLConnectionSocketFactory.getDefaultHostnameVerifier());
 
       httpclient = HttpClients.custom()
           .setSSLSocketFactory(sslSf)


### PR DESCRIPTION
Add a test that when `ssl.cipher.suite` is set to restrict ssl ciphers, only restricted ciphers work with REST.