### PR TITLE
Refactoring downstream repos

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,11 +85,8 @@ after_pipeline:
         commands:
           - >-
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
-              sem-trigger -p schema-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p metadata-service -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ce-kafka-http-server -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p secret-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -87,7 +87,6 @@ after_pipeline:
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
               sem-trigger -p schema-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p metadata-service -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ce-kafka-http-server -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p secret-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
             fi

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -85,6 +85,7 @@ after_pipeline:
         commands:
           - >-
             if [[ -z "$SEMAPHORE_GIT_PR_BRANCH" ]] && [[ "$SEMAPHORE_PIPELINE_RESULT" == "passed" ]]; then
+              sem-trigger -p schema-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p metadata-service -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p ce-kafka-http-server -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,7 @@
 
 common {
   slackChannel = '#c3-alerts'
-  downStreamRepos = ["metadata-service", "kafka-rest",
-    "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
-    "confluent-cloud-plugins"]
+  downStreamRepos = ["metadata-service", "kafka-rest", "ce-kafka-http-server", "secret-registry"]
   pintMerge = true
   nanoVersion = true
   mvnSkipDeploy = true

--- a/service.yml
+++ b/service.yml
@@ -6,8 +6,7 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
-  downstream_projects: ["schema-registry", "metadata-service", "kafka-rest",
-    "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
-    "confluent-cloud-plugins"]
+  downstream_projects: ["schema-registry", "metadata-service", 
+    "kafka-rest", "ce-kafka-http-server", "secret-registry"]
 git:
   enable: true

--- a/service.yml
+++ b/service.yml
@@ -6,7 +6,7 @@ codeowners:
 semaphore:
   enable: true
   pipeline_type: cp
-  downstream_projects: ["schema-registry", "metadata-service", 
-    "kafka-rest", "ce-kafka-http-server", "secret-registry"]
+  downstream_projects: ["schema-registry", "metadata-service",
+    "ce-kafka-http-server", "secret-registry"]
 git:
   enable: true


### PR DESCRIPTION
`confluent-cloud-plugins` and `confluent-security-plugins` are facing excessive builds being triggered by upstream repos. The root cause is duplicate mentions of these repos in `downStreamRepos`. For example, this repo has `kafka-rest` as a downstream repo but `confluent-cloud-plugins` and `confluent-security-plugins` are also listed as downstream repo in `kafka-rest`. Furthermore, this repo has `schema-registry` as a downstream repo but `schema-registry` has `kafka-rest`,`confluent-cloud-plugins`, and `confluent-security-plugins` listed as downstream repos. 

This means that for every build in this repo, `kafka-rest` is built two times, `confluent-security-plugins`is built four times, and `confluent-cloud-plugins` is built eight times (`confluent-cloud-plugins` is also listed as downstream repo in `confluent-security-plugins`).
Removing `confluent-cloud-plugins`, `confluent-security-plugins`, and `kafka-rest` as downstream repos in this repo will still trigger the downstream builds in those repos from the `schema-registry` downstream build but this change will remove the duplicate builds from this repo directly building `kafka-rest`, `confluent-cloud-plugins` and `confluent-security-plugins`.

This commit will be pint merged all the way to master.

Slack: https://confluent.slack.com/archives/C09EP1SS3/p1702678296430679 and
https://confluent.slack.com/archives/C09EP1SS3/p1701141343781609?thread_ts=1701138034.078119&cid=C09EP1SS3