### PR TITLE
Remove confluent-cloud-plugins and confluent-security-plugins as downstream in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 common {
   slackChannel = '#c3-alerts'
   downStreamRepos = ["metadata-service", "kafka-rest", "ce-kafka-http-server",
-    "secret-registry",]
+    "secret-registry"]
   pintMerge = true
   nanoVersion = true
   mvnSkipDeploy = true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,9 +2,8 @@
 
 common {
   slackChannel = '#c3-alerts'
-  downStreamRepos = ["metadata-service", "kafka-rest",
-    "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
-    "confluent-cloud-plugins"]
+  downStreamRepos = ["metadata-service", "kafka-rest", "ce-kafka-http-server",
+    "secret-registry",]
   pintMerge = true
   nanoVersion = true
   mvnSkipDeploy = true


### PR DESCRIPTION
This PR removes the confluent-cloud-plugins and confluent-security-plugins repos as downstream repos in Jenkinsfile file (leaving them as downstream repos in service.yml/Semaphore). This change allows confluent-cloud-plugins and confluent-security-plugins to deprecate Jenkins without causing this repos downstream build to fail. A similar change to was made here: https://github.com/confluentinc/rest-utils/pull/443 to remove schema-registry from the Jenkinsfile.