### PR TITLE
KSTREAMS-5725: Make kafka-streams-examples a downsteam project of rest-utils

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -9,6 +9,6 @@ semaphore:
   nano_version: true
   downstream_projects: ["schema-registry", "metadata-service", "kafka-rest",
     "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
-    "confluent-cloud-plugins"]
+    "confluent-cloud-plugins", "kafka-streams-examples"]
 git:
   enable: true


### PR DESCRIPTION
Part of migrating kafka-streams-examples from Jenkins to semaphore.

In Jenkins, we were use `upstreamProjects` to make sure that `kafka-streams-examples` is rebuilt when `rest-utils` is updated. See this line: [confluentinc/kafka-streams-examples@master/Jenkinsfile#L7](https://github.com/confluentinc/kafka-streams-examples/blob/master/Jenkinsfile?rgh-link-date=2024-01-10T10%3A26%3A16Z#L7)

This is not supported by the new semaphore tooling. Instead, we need to list `kafka-streams-examples` in the `downstream-projects` of `rest-utils`, see the feature gap section of the migration guide:

[confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3211693075/Jenkins+-+Semaphore+self+migration+guide#Features-gaps](https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/3211693075/Jenkins+-+Semaphore+self+migration+guide#Features-gaps)