### PR TITLE
KREST-13506 Ensure we log timeout errors that result in a 500 error

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
@@ -135,6 +135,7 @@ public class KafkaExceptionMapper extends GenericExceptionMapper {
         log.debug("Topic not present in metadata exception");
         return getResponse(exception, Status.NOT_FOUND, TOPIC_NOT_FOUND_ERROR_CODE);
       }
+      log.error("Internal Server Error returned to REST client after TimeoutException", exception);
       return getResponse(exception, Status.INTERNAL_SERVER_ERROR,
           KAFKA_RETRIABLE_ERROR_ERROR_CODE);
     } else if (exception instanceof InvalidTopicException) {


### PR DESCRIPTION
A 500 internal server error should be considered unusual, and so be followed up on.

We have 1 case in our logs, where the reason for the 500 is not written to logs, so I've added a line to show which timeout exception is causing the issue so that we have more of a change of diagnosing what's gone wrong