### PR TITLE
CC-24588: Update common version to fix build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>7.7.0-286</version>
+        <version>7.7.0-351</version>
     </parent>
 
     <artifactId>rest-utils-parent</artifactId>


### PR DESCRIPTION
https://confluentinc.atlassian.net/browse/CC-24588

CP package master was failing for `confluent-security-plugins` because there was a breaking change that was introduced and a fix was proposed in this PR: https://github.com/confluentinc/confluent-security-plugins/pull/701. However this need `ce-kafka:7.7.0-202-ce` which is present in commons `7.7.0-351` ([link](https://github.com/confluentinc/common/blob/34d630f7f4b8c39e4a2b7976ebcbb5cff5b99286/pom.xml#L52)). This PR intends to create a new version for rest-utils which updates the commons version which will be used the above PR to unblock build issues.