### PR TITLE
Set nodeLabel for nightly master build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,5 +8,6 @@ common {
   nanoVersion = true
   pinnedNanoVersions = true
   mvnSkipDeploy = true
+  nodeLabel = 'docker-debian-jdk17'
 }
 //change


### PR DESCRIPTION
PR build is with JDK17 while master build is with JDK8 on Jenkins, this creates a gap where we have this test `SslTest.test_WhenCalledWithRestrictedCipher_ConnFails` consistently fails in [Jenkins](https://jenkins.confluent.io/job/confluentinc/job/rest-utils/job/master/9796/console) while it passes in PRs. Attempt to reproduce this failure in local machine is also unsuccessful (it passes with JDK8 on my Macbook).

Therefore, it is better just set the same JDK across PRs and master builds, also we're migrating from Jenkins to Semaphore (which uses JDK17 by default) anyway, so this is to reduce the toll of oncall resolving failed builds.