### PR TITLE
Enable Jenkins to build artifacts on 7.6.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ common {
   pintMerge = true
   nanoVersion = true
   pinnedNanoVersions = true
-  mvnSkipDeploy = true
+  // commenting out this line to temporarily enable Jenkins to build artifacts
+  //  mvnSkipDeploy = true
 }
 //change

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,6 +8,6 @@ common {
   nanoVersion = true
   pinnedNanoVersions = true
   // commenting out this line to temporarily enable Jenkins to build artifacts
-  //  mvnSkipDeploy = true
+  // mvnSkipDeploy = true
 }
 //change


### PR DESCRIPTION
7.6.x builds on Semaphore have been flaky causing downstream build issues in other repos. This is blocking time sensitive prod releases. A temporary fix is to enable Jenkins to build artifacts since Jenkins builds have been mostly green on 7.6.x branch.