### PR TITLE
DP-13727 Add CodeArtifact package paths to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -7,8 +7,15 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
-  downstream_projects: ["schema-registry", "metadata-service", "kafka-rest",
-    "confluent-security-plugins", "ce-kafka-http-server", "secret-registry",
-    "confluent-cloud-plugins", "kafka-streams-examples"]
+  downstream_projects: ["schema-registry", "metadata-service", "kafka-rest", "confluent-security-plugins", "ce-kafka-http-server", "secret-registry", "confluent-cloud-plugins", "kafka-streams-examples"]
 git:
   enable: true
+code_artifact:
+  enable: true
+  package_paths:
+    - maven-snapshots/maven/io.confluent/rest-utils-package
+    - maven-snapshots/maven/io.confluent/rest-utils-examples
+    - maven-snapshots/maven/io.confluent/rest-utils-test
+    - maven-snapshots/maven/io.confluent/rest-utils
+    - maven-snapshots/maven/io.confluent/rest-utils-parent
+    - maven-snapshots/maven/io.confluent/rest-utils-fips-tests


### PR DESCRIPTION
One of the Capsaicin requirements requires that all artifacts uploaded to CodeArtifacts come from specific Semaphore jobs.
This PR adds package_paths to service.yml so that each GitHub repo can declare the path of the CodeArtifact packages that it writes to.
For newer GitHub repos, the package_paths needs to be added to the service.yml file manually before it can write to CodeArtifact in the Semaphore pipeline.
For more information about this, see https://confluent.slack.com/archives/C038ZJ00P/p1708464192287999
