### PR TITLE
Remove test jar dependency from fips-tests module

### DIFF
--- a/fips-tests/pom.xml
+++ b/fips-tests/pom.xml
@@ -20,13 +20,6 @@
             <version>${io.confluent.rest-utils.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>rest-utils</artifactId>
-            <version>${io.confluent.rest-utils.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>

--- a/fips-tests/src/test/java/io/confluent/rest/SslFactoryFipsTest.java
+++ b/fips-tests/src/test/java/io/confluent/rest/SslFactoryFipsTest.java
@@ -16,10 +16,19 @@
 
 package io.confluent.rest;
 
+import java.io.FileWriter;
+import java.security.KeyStore;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.common.errors.InvalidConfigurationException;
+import org.apache.kafka.test.TestUtils;
 import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
 import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -29,8 +38,18 @@ import java.nio.file.Paths;
 import java.security.Security;
 import java.util.Map;
 import java.util.Objects;
+import org.junit.jupiter.api.Test;
 
-public class SslFactoryFipsTest extends SslFactoryTest {
+public class SslFactoryFipsTest {
+  private static final String PEM_TYPE = "PEM";
+
+  protected String CA1;
+  protected String CA2;
+  protected String CERTCHAIN;
+  protected String KEY;
+  protected String ENCRYPTED_KEY;
+  protected RestConfig config;
+
   @BeforeAll
   public static void setupAll() {
     Security.insertProviderAt(new BouncyCastleFipsProvider(), 1);
@@ -72,23 +91,144 @@ public class SslFactoryFipsTest extends SslFactoryTest {
     }
   }
 
-  @Override
   protected void setConfigs(Map<String, String> configs) {
     configs.put(RestConfig.SSL_PROVIDER_CONFIG, SslFactoryPemHelper.FIPS_SSL_PROVIDER);
     config = new RestConfig(RestConfig.baseConfigDef(), configs);
   }
 
-  @Override
   protected String getKeyStoreType() {
     return SslFactoryPemHelper.FIPS_KEYSTORE_TYPE;
   }
 
-  @Override
   protected String getEncryptedKey() {
     return KEY;
   }
 
   protected Password getKeyPassword() {
     return null;
+  }
+
+  @Test
+  public void testPemKeyStoreSuccessKeyNoPassword() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    setConfigs(rawConfig);
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertNotNull(factory.getKeyStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getKeyStore().getType());
+    verifyKeyStore(factory.getKeyStore(), null);
+  }
+
+  @Test
+  public void testPemKeyStoreSuccessKeyPassword() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(getEncryptedKey(), CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    if (getKeyPassword() != null) {
+      rawConfig.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, getKeyPassword().value());
+    }
+    setConfigs(rawConfig);
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertNotNull(factory.getKeyStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getKeyStore().getType());
+    verifyKeyStore(factory.getKeyStore(), getKeyPassword());
+  }
+
+  @Test
+  public void testBadPemKeyStoreFailure() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    setConfigs(rawConfig);
+    Assertions.assertThrows(InvalidConfigurationException.class, () -> SslFactory.createSslContextFactory(new SslConfig(config)));
+  }
+
+  @Test
+  public void testPemKeyStoreReload() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    String storeLocation = asFile(asString(getEncryptedKey(), CERTCHAIN));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, storeLocation);
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    if (getKeyPassword() != null) {
+      rawConfig.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, getKeyPassword().value());
+    }
+    rawConfig.put(RestConfig.SSL_KEYSTORE_RELOAD_CONFIG, "true");
+    setConfigs(rawConfig);
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertNotNull(factory.getKeyStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getKeyStore().getType());
+    verifyKeyStore(factory.getKeyStore(), getKeyPassword());
+
+    org.apache.kafka.test.TestUtils.waitForCondition(() -> !SslFactory.lastLoadFailure().isPresent(), "could not load keystore");
+
+    // rewrite file (invalid)
+    try (FileWriter writer = new FileWriter(storeLocation)) {
+      writer.write(asString(KEY, CERTCHAIN));
+      writer.flush();
+    }
+
+    // rewrite file (valid)
+    try (FileWriter writer = new FileWriter(storeLocation)) {
+      writer.write(asString(getEncryptedKey(), CERTCHAIN));
+      writer.flush();
+    }
+
+    org.apache.kafka.test.TestUtils.waitForCondition(() -> !SslFactory.lastLoadFailure().isPresent(), "keystore not loaded unexpectedly");
+
+    verifyKeyStore(factory.getKeyStore(), getKeyPassword());
+  }
+
+  @Test
+  public void testPemTrustStoreSuccessSingleCert() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, asFile(asString(CA1)));
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+    setConfigs(rawConfig);
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertNotNull(factory.getTrustStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getTrustStore().getType());
+  }
+
+  @Test
+  public void testPemTrustStoreSuccessMultiCert() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, asFile(asString(CA1, CA2)));
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+    setConfigs(rawConfig);
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertNotNull(factory.getTrustStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getTrustStore().getType());
+  }
+
+  @Test
+  public void testBadPemTrustStoreFailure() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, asFile(asString(KEY)));
+    rawConfig.put(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
+    setConfigs(rawConfig);
+    Assertions.assertThrows(InvalidConfigurationException.class, () -> SslFactory.createSslContextFactory(new SslConfig(config)));
+  }
+
+  private String asString(String... pems) {
+    StringBuilder builder = new StringBuilder();
+    for (String pem : pems) {
+      builder.append(pem);
+      builder.append("\n");
+    }
+    return builder.toString().trim();
+  }
+
+  private String asFile(String pem) throws Exception {
+    return TestUtils.tempFile(pem).getAbsolutePath();
+  }
+
+  private void verifyKeyStore(KeyStore ks, Password keyPassword) throws Exception {
+    List<String> aliases = Collections.list(ks.aliases());
+    Assertions.assertEquals(Collections.singletonList("kafka"), aliases);
+    Assertions.assertNotNull(ks.getCertificate("kafka"), "Certificate not loaded");
+    Assertions.assertNotNull(ks.getKey("kafka", keyPassword == null ? null : keyPassword.value().toCharArray()),
+        "Private key not loaded");
+    Assertions.assertEquals(getKeyStoreType(), ks.getType());
   }
 }


### PR DESCRIPTION
We have problem in CP packaging that fips-tests module needs rest-utils jar in order to compile, but in CP packaging rest-utils is compiled with `mvn -Dmaven.test.skip=true`, so no test jar is produced (because we don't release package with test jar), which breaks the build.

This PR breaks the deadlock by removing test jar dependency from fips-tests with the price of we have similar test code between `SslFactoryTest` and `SslFactoryFipsTest`.

However, there is no much we can do on this as fips and non-fips cannot be used together in a module.