### PR TITLE
Add comment about keeping SslFactoryTest and SslFactoryFipsTest tests insync

### DIFF
--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -35,6 +35,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+/**
+ * Non-FIPS specific tests for SslFactory, please see SslFactoryFipsTest for FIPS tests.
+ * Please also keep tests in this class in sync with SslFactoryFipsTest.
+ */
 public class SslFactoryTest {
   protected String CA1;
   protected String CA2;

--- a/fips-tests/src/test/java/io/confluent/rest/SslFactoryFipsTest.java
+++ b/fips-tests/src/test/java/io/confluent/rest/SslFactoryFipsTest.java
@@ -40,6 +40,10 @@ import java.util.Map;
 import java.util.Objects;
 import org.junit.jupiter.api.Test;
 
+/**
+ * FIPS specific tests for SslFactory, please see SslFactoryTest for non-FIPS tests.
+ * Please also keep tests in this class in sync with SslFactoryTest.
+ */
 public class SslFactoryFipsTest {
   private static final String PEM_TYPE = "PEM";
 


### PR DESCRIPTION
Since https://github.com/confluentinc/rest-utils/pull/468, it is recommended that we need to keep tests insync for two classes SslFactoryFipsTest and SslFactoryTest