### PR TITLE
Downgrade jetty-servlets package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.8.0-0</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>
-        <jetty.version>9.4.53.v20231009</jetty.version>
+        <jetty.servlets.version>9.4.53.v20231009</jetty.servlets.version>
     </properties>
 
     <repositories>
@@ -197,7 +197,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.version}</version>
+                <version>${jetty.servlets.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
#478 downgraded `jetty`, which has a vulnerability: [CVE-2023-36478](https://github.com/advisories/GHSA-wgh7-54f2-x98r). This PR reverts #478 and only downgrades `jetty-servlets`.

Dependencies after this change:
```
❯ mvn dependency:tree -Dincludes=org.eclipse.jetty
[INFO] Scanning for projects...
[INFO] ------------------------------------------------------------------------
[INFO] Detecting the operating system and CPU architecture
[INFO] ------------------------------------------------------------------------
[INFO] os.detected.name: osx
[INFO] os.detected.arch: aarch_64
[INFO] os.detected.bitness: 64
[INFO] os.detected.version: 14.3
[INFO] os.detected.version.major: 14
[INFO] os.detected.version.minor: 3
[INFO] os.detected.classifier: osx-aarch_64
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Build Order:
[INFO]
[INFO] rest-utils-parent                                                  [pom]
[INFO] rest-utils                                                         [jar]
[INFO] rest-utils-test                                                    [jar]
[INFO] rest-utils-example                                                 [jar]
[INFO] rest-utils-package                                                 [pom]
[INFO] rest-utils-fips-tests                                              [jar]
[INFO]
[INFO] -------------------< io.confluent:rest-utils-parent >-------------------
[INFO] Building rest-utils-parent 7.8.0-0                                 [1/6]
[INFO]   from pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils-parent ---
[INFO]
[INFO] ----------------------< io.confluent:rest-utils >-----------------------
[INFO] Building rest-utils 7.8.0-0                                        [2/6]
[INFO]   from core/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils ---
[INFO] io.confluent:rest-utils:jar:7.8.0-0
[INFO] +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.54.v20240208:compile
[INFO] |  \- org.eclipse.jetty:jetty-annotations:jar:9.4.54.v20240208:compile
[INFO] |     +- org.eclipse.jetty:jetty-plus:jar:9.4.54.v20240208:compile
[INFO] |     |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.54.v20240208:compile
[INFO] |     \- org.eclipse.jetty:jetty-webapp:jar:9.4.54.v20240208:compile
[INFO] |        \- org.eclipse.jetty:jetty-xml:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-jmx:jar:9.4.54.v20240208:compile
[INFO] |  \- org.eclipse.jetty:jetty-util:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-server:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-http:jar:9.4.54.v20240208:compile
[INFO] |  \- org.eclipse.jetty:jetty-io:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-alpn-conscrypt-server:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-servlet:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:9.4.54.v20240208:compile
[INFO] |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-servlets:jar:9.4.53.v20231009:compile
[INFO] |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-jaas:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty.http2:http2-client:jar:9.4.54.v20240208:test
[INFO] |  \- org.eclipse.jetty:jetty-alpn-client:jar:9.4.54.v20240208:test
[INFO] \- org.eclipse.jetty.http2:http2-http-client-transport:jar:9.4.54.v20240208:test
[INFO]    +- org.eclipse.jetty:jetty-client:jar:9.4.54.v20240208:compile
[INFO]    \- org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.54.v20240208:test
[INFO]
[INFO] --------------------< io.confluent:rest-utils-test >--------------------
[INFO] Building rest-utils-test 7.8.0-0                                   [3/6]
[INFO]   from test/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils-test ---
[INFO] io.confluent:rest-utils-test:jar:7.8.0-0
[INFO] \- io.confluent:rest-utils:jar:7.8.0-0:compile
[INFO]    +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-annotations:jar:9.4.54.v20240208:compile
[INFO]    |  |  +- org.eclipse.jetty:jetty-plus:jar:9.4.54.v20240208:compile
[INFO]    |  |  |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.54.v20240208:compile
[INFO]    |  |  \- org.eclipse.jetty:jetty-webapp:jar:9.4.54.v20240208:compile
[INFO]    |  |     \- org.eclipse.jetty:jetty-xml:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty.websocket:javax-websocket-client-impl:jar:9.4.54.v20240208:compile
[INFO]    |     \- org.eclipse.jetty.websocket:websocket-client:jar:9.4.54.v20240208:compile
[INFO]    |        \- org.eclipse.jetty:jetty-client:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-jmx:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-conscrypt-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlet:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-security:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlets:jar:9.4.53.v20231009:compile
[INFO]    |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.54.v20240208:compile
[INFO]    \- org.eclipse.jetty:jetty-jaas:jar:9.4.54.v20240208:compile
[INFO]
[INFO] ------------------< io.confluent:rest-utils-examples >------------------
[INFO] Building rest-utils-example 7.8.0-0                                [4/6]
[INFO]   from examples/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils-examples ---
[INFO] io.confluent:rest-utils-examples:jar:7.8.0-0
[INFO] \- io.confluent:rest-utils:jar:7.8.0-0:compile
[INFO]    +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-annotations:jar:9.4.54.v20240208:compile
[INFO]    |  |  +- org.eclipse.jetty:jetty-plus:jar:9.4.54.v20240208:compile
[INFO]    |  |  |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.54.v20240208:compile
[INFO]    |  |  \- org.eclipse.jetty:jetty-webapp:jar:9.4.54.v20240208:compile
[INFO]    |  |     \- org.eclipse.jetty:jetty-xml:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty.websocket:javax-websocket-client-impl:jar:9.4.54.v20240208:compile
[INFO]    |     \- org.eclipse.jetty.websocket:websocket-client:jar:9.4.54.v20240208:compile
[INFO]    |        \- org.eclipse.jetty:jetty-client:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-jmx:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-conscrypt-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlet:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-security:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlets:jar:9.4.53.v20231009:compile
[INFO]    |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.54.v20240208:compile
[INFO]    \- org.eclipse.jetty:jetty-jaas:jar:9.4.54.v20240208:compile
[INFO]
[INFO] ------------------< io.confluent:rest-utils-package >-------------------
[INFO] Building rest-utils-package 7.8.0-0                                [5/6]
[INFO]   from package/pom.xml
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils-package ---
[INFO] io.confluent:rest-utils-package:pom:7.8.0-0
[INFO] \- io.confluent:rest-utils:jar:7.8.0-0:compile
[INFO]    +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-annotations:jar:9.4.54.v20240208:compile
[INFO]    |  |  +- org.eclipse.jetty:jetty-plus:jar:9.4.54.v20240208:compile
[INFO]    |  |  |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.54.v20240208:compile
[INFO]    |  |  \- org.eclipse.jetty:jetty-webapp:jar:9.4.54.v20240208:compile
[INFO]    |  |     \- org.eclipse.jetty:jetty-xml:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty.websocket:javax-websocket-client-impl:jar:9.4.54.v20240208:compile
[INFO]    |     \- org.eclipse.jetty.websocket:websocket-client:jar:9.4.54.v20240208:compile
[INFO]    |        \- org.eclipse.jetty:jetty-client:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-jmx:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-server:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-http:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-io:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-alpn-conscrypt-server:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlet:jar:9.4.54.v20240208:compile
[INFO]    |  +- org.eclipse.jetty:jetty-security:jar:9.4.54.v20240208:compile
[INFO]    |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.54.v20240208:compile
[INFO]    +- org.eclipse.jetty:jetty-servlets:jar:9.4.53.v20231009:compile
[INFO]    |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.54.v20240208:compile
[INFO]    \- org.eclipse.jetty:jetty-jaas:jar:9.4.54.v20240208:compile
[INFO]
[INFO] -----------------< io.confluent:rest-utils-fips-tests >-----------------
[INFO] Building rest-utils-fips-tests 7.8.0-0                             [6/6]
[INFO]   from fips-tests/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.3.0:tree (default-cli) @ rest-utils-fips-tests ---
[INFO] io.confluent:rest-utils-fips-tests:jar:7.8.0-0
[INFO] +- io.confluent:rest-utils:jar:7.8.0-0:compile
[INFO] |  +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.54.v20240208:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-annotations:jar:9.4.54.v20240208:compile
[INFO] |  |     +- org.eclipse.jetty:jetty-plus:jar:9.4.54.v20240208:compile
[INFO] |  |     |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.54.v20240208:compile
[INFO] |  |     \- org.eclipse.jetty:jetty-webapp:jar:9.4.54.v20240208:compile
[INFO] |  |        \- org.eclipse.jetty:jetty-xml:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-jmx:jar:9.4.54.v20240208:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-util:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-server:jar:9.4.54.v20240208:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-http:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-alpn-conscrypt-server:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-servlet:jar:9.4.54.v20240208:compile
[INFO] |  |  +- org.eclipse.jetty:jetty-security:jar:9.4.54.v20240208:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.54.v20240208:compile
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.53.v20231009:compile
[INFO] |  |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.54.v20240208:compile
[INFO] |  \- org.eclipse.jetty:jetty-jaas:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.54.v20240208:test
[INFO] |  \- org.eclipse.jetty:jetty-io:jar:9.4.54.v20240208:compile
[INFO] +- org.eclipse.jetty:jetty-alpn-java-client:jar:9.4.54.v20240208:test
[INFO] |  \- org.eclipse.jetty:jetty-alpn-client:jar:9.4.54.v20240208:test
[INFO] \- org.eclipse.jetty.http2:http2-http-client-transport:jar:9.4.54.v20240208:test
[INFO]    \- org.eclipse.jetty:jetty-client:jar:9.4.54.v20240208:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for rest-utils-parent 7.8.0-0:
[INFO]
[INFO] rest-utils-parent .................................. SUCCESS [  0.339 s]
[INFO] rest-utils ......................................... SUCCESS [  0.265 s]
[INFO] rest-utils-test .................................... SUCCESS [  0.021 s]
[INFO] rest-utils-example ................................. SUCCESS [  0.012 s]
[INFO] rest-utils-package ................................. SUCCESS [  0.009 s]
[INFO] rest-utils-fips-tests .............................. SUCCESS [  0.020 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.008 s
[INFO] Finished at: 2024-04-01T17:34:26-04:00
[INFO] ------------------------------------------------------------------------
```

Only jetty-servlets is downgraded.