### PR TITLE
Disable flaky tests

### DIFF
--- a/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.Slf4jRequestLogWriter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -70,6 +71,7 @@ public class RequestLogHandlerIntegrationTest {
   }
 
   @Test
+  @Disabled("KNET-15387: this test is flaky and needs to be fixed")
   public void test_CustomRequestLog_registeredToCorrectListener() throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(RestConfig.LISTENERS_CONFIG,

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -535,6 +536,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
+  @Disabled("KNET-15387: this test is flaky and needs to be fixed")
   public void testMetricLatencySloSlaEnabled() {
     makeSuccessfulCall();
 

--- a/fips-tests/src/test/java/io/confluent/rest/Http2FipsTest.java
+++ b/fips-tests/src/test/java/io/confluent/rest/Http2FipsTest.java
@@ -55,6 +55,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This tests HTTP/2 support in the REST server with FIPS mode enabled.
  **/
+@Disabled("KNET-15387: this test is flaky and needs to be fixed")
 class Http2FipsTest {
   private static final String BC_FIPS_APPROVED_ONLY_PROP = "org.bouncycastle.fips.approved_only";
   private static final Logger log = LoggerFactory.getLogger(Http2FipsTest.class);


### PR DESCRIPTION
There are 2 kinds of flake are disabled in this PR:
- Pure flaky (pass locally but failed occasionally in CI), in `RequestLogHandlerIntegrationTest#test_CustomRequestLog_registeredToCorrectListener` and `MetricsResourceMethodApplicationListenerIntegrationTest#testMetricLatencySloSlaEnabled` 
- CI builder/upstream behaviour change (also pass locally and there isn't easy way to reproduce locally), in `Http2FipsTest`, CI was running all fine until this [build](https://semaphore.ci.confluent.io/workflows/6430372a-191f-4058-ae34-fb5d6786076c?pipeline_id=60c5681c-7fb5-429c-9dd7-444de133f38b), when all of a sudden, it starts to fail consistently. There is no change to rest-utils, so the suspect could be CI env change or upstream change.

Created a JIRA (in Disabled tag) to resolve those flaky tests.