### PR TITLE
Do not throw ConfigException in case there are different applications configured for the server

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -132,35 +132,31 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
   private void attachMetricsListener(String listenerName, Metrics metrics,
       Map<String, String> tags) {
-    boolean hasNetworkConnector = false;
     for (NetworkTrafficServerConnector connector : connectors) {
       if (Objects.equals(connector.getName(), listenerName)) {
         MetricsListener metricsListener = new MetricsListener(metrics, "jetty", tags);
         connector.addNetworkTrafficListener(metricsListener);
         log.info("Registered {} to connector of listener: {}",
             metricsListener.getClass().getSimpleName(), listenerName);
-        hasNetworkConnector = true;
       }
     }
-    if (!hasNetworkConnector) {
-      throw new ConfigException("No network connector found for listener: " + listenerName);
+    if (connectors.isEmpty()) {
+      log.warn("No network connector configured for listener: {}", listenerName);
     }
   }
 
   private void attachNetworkTrafficRateLimitListener(RestConfig appConfig, String listenerName) {
     if (appConfig.getNetworkTrafficRateLimitEnable()) {
-      boolean hasNetworkConnector = false;
       for (NetworkTrafficServerConnector connector : connectors) {
         if (Objects.equals(connector.getName(), listenerName)) {
           NetworkTrafficListener rateLimitListener = new RateLimitNetworkTrafficListener(appConfig);
           connector.addNetworkTrafficListener(rateLimitListener);
           log.info("Registered {} to connector of listener: {}",
               rateLimitListener.getClass().getSimpleName(), listenerName);
-          hasNetworkConnector = true;
         }
       }
-      if (!hasNetworkConnector) {
-        throw new ConfigException("No network connector found for listener: " + listenerName);
+      if (connectors.isEmpty()) {
+        log.warn("No network connector configured for listener: {}", listenerName);
       }
     }
   }

--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -30,7 +30,6 @@ import java.util.Objects;
 import java.util.StringTokenizer;
 import java.util.concurrent.BlockingQueue;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Gauge;
 import org.apache.kafka.common.metrics.Metrics;
 import org.eclipse.jetty.alpn.server.ALPNServerConnectionFactory;


### PR DESCRIPTION
In CP, there could be Metadata http server applications configured alongside with Kafka rest, therefore, the `ConfigException` will always throw because there is no NetworkTrafficServerConnector configured for Metadata http server application.

So we log a warn line instead.