### PR TITLE
Fix flakey test similar to

### DIFF
--- a/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
@@ -67,7 +67,7 @@ public class RequestLogHandlerIntegrationTest {
     httpClient.stop();
   }
 
-  @Disabled("KNET-15387: this test is flaky and needs to be fixed")
+  @Disabled
   @Test
   public void test_CustomRequestLog_registeredToCorrectListener() throws Exception {
     int internalPort = getFreePort();

--- a/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestLogHandlerIntegrationTest.java
@@ -38,6 +38,7 @@ import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Server;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -66,6 +67,7 @@ public class RequestLogHandlerIntegrationTest {
     httpClient.stop();
   }
 
+  @Disabled("KNET-15387: this test is flaky and needs to be fixed")
   @Test
   public void test_CustomRequestLog_registeredToCorrectListener() throws Exception {
     int internalPort = getFreePort();


### PR DESCRIPTION
https://github.com/confluentinc/rest-utils/commit/da1d8d4387f60fc38d274634ad5bcb4f4d6a7f45#diff-cf9023bb601aa95ba939f1c04b13836f88c2bf59017e769dea7f1b0c00288a50

https://confluent.slack.com/archives/C06CFQNK2BF/p1717418329306549?thread_ts=1717169007.420509&cid=C06CFQNK2BF

I didn't want to cherry-pick the commit above, as the other changes are only in files in either master or 7.5.x onwards

Test failure originally is https://semaphore.ci.confluent.io/workflows/ec3b0361-84ed-4df9-ba09-ebb655e6bfcd/summary?report_id=17990af8-cb17-371c-9a8e-215e0e201902 in 7.5.x, but I'll bring this disable right back to the beginning to avoid other releases flaking