### PR TITLE
changing order for filter configuration [CPSEC-482]

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -403,11 +403,12 @@ public abstract class Application<T extends RestConfig> {
     configureDosFilters(context);
 
     configurePreResourceHandling(context);
+
+    applyCustomConfiguration(context, REST_SERVLET_INITIALIZERS_CLASSES_CONFIG);
+
     context.addFilter(servletHolder, "/*", null);
     configurePostResourceHandling(context);
     context.addServlet(defaultHolder, "/*");
-
-    applyCustomConfiguration(context, REST_SERVLET_INITIALIZERS_CLASSES_CONFIG);
 
     RequestLogHandler requestLogHandler = new RequestLogHandler();
     requestLogHandler.setRequestLog(requestLog);


### PR DESCRIPTION
If we add a new jetty filter holder to the filter chain through `applyCustomConfiguration` , it gets configured after the jersey servlet as the jersey servlet is configured first. Due to this the jetty filter is not triggered on incoming requests.

This PR swaps the order of configuring customConfiguration and jersey servlet, so that requests can be routed as expected.