### PR TITLE
Update bcfips modules (#17)

### DIFF
--- a/fips-tests/pom.xml
+++ b/fips-tests/pom.xml
@@ -38,13 +38,19 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bc-fips</artifactId>
-            <version>1.0.2.4</version>
+            <version>${bouncycastle.fips.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bctls-fips</artifactId>
-            <version>1.0.17</version>
+            <version>${bouncycastle.tls-fips.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-fips</artifactId>
+            <version>${bouncycastle.bcpkix-fips.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Rather than have our own versions of BC FIPS dependencies to keep up to date, we can rely on the versions pulled in from common. This will reduce the number of CVE updates we have to make in the future.