### PR TITLE
Log unexpected SNI headers in REST

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -29,6 +29,7 @@ import io.confluent.rest.exceptions.JsonMappingExceptionMapper;
 import io.confluent.rest.exceptions.JsonParseExceptionMapper;
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
+import io.confluent.rest.handlers.ExpectedSniHandler;
 import io.confluent.rest.handlers.SniHandler;
 import io.confluent.rest.metrics.Jetty429MetricsDosFilterListener;
 import io.confluent.rest.metrics.JettyRequestMetricsFilter;
@@ -414,8 +415,11 @@ public abstract class Application<T extends RestConfig> {
     requestLogHandler.setRequestLog(requestLog);
     context.insertHandler(requestLogHandler);
 
+    List<String> expectedSniHeaders = config.getExpectedSniHeaders();
     if (config.getSniCheckEnable()) {
       context.insertHandler(new SniHandler());
+    } else if (!expectedSniHeaders.isEmpty()) {
+      context.insertHandler(new ExpectedSniHandler(expectedSniHeaders));
     }
 
     HandlerCollection handlers = new HandlerCollection();

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -511,8 +511,8 @@ public class RestConfig extends AbstractConfig {
 
   public static final String EXPECTED_SNI_HEADERS_CONFIG = "expected.sni.headers";
   protected static final String EXPECTED_SNI_HEADERS_DOC =
-      "Comma-separated list of expected SNI headers for incoming connections. If a value is present, "
-          + "log a warning when handling connections, but do not reject the connection.";
+      "Comma-separated list of expected SNI headers for incoming connections. If a value is "
+          + "present, log a warning when handling connections, but do not reject the connection.";
   protected static final String EXPECTED_SNI_HEADERS_DEFAULT = "";
 
   public static final String PROXY_PROTOCOL_ENABLED_CONFIG =

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -509,6 +509,12 @@ public class RestConfig extends AbstractConfig {
           + "returns a 421 misdirected response. Default is false.";
   protected static final boolean SNI_CHECK_ENABLED_DEFAULT = false;
 
+  public static final String EXPECTED_SNI_HEADERS_CONFIG = "expected.sni.headers";
+  protected static final String EXPECTED_SNI_HEADERS_DOC =
+      "Comma-separated list of expected SNI headers for incoming connections. If a value is present, "
+          + "log a warning when handling connections, but do not reject the connection.";
+  protected static final String EXPECTED_SNI_HEADERS_DEFAULT = "";
+
   public static final String PROXY_PROTOCOL_ENABLED_CONFIG =
       "proxy.protocol.enabled";
   protected static final String PROXY_PROTOCOL_ENABLED_DOC =
@@ -1076,6 +1082,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             SNI_CHECK_ENABLED_DOC
         ).define(
+            EXPECTED_SNI_HEADERS_CONFIG,
+            Type.LIST,
+            EXPECTED_SNI_HEADERS_DEFAULT,
+            Importance.LOW,
+            EXPECTED_SNI_HEADERS_DOC
+        ).define(
             LISTENER_PROTOCOL_MAP_CONFIG,
             Type.LIST,
             LISTENER_PROTOCOL_MAP_DEFAULT,
@@ -1430,6 +1442,10 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getSniCheckEnable() {
     return getBoolean(SNI_CHECK_ENABLED_CONFIG);
+  }
+
+  public final List<String> getExpectedSniHeaders() {
+    return getList(EXPECTED_SNI_HEADERS_CONFIG);
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -1,0 +1,38 @@
+package io.confluent.rest.handlers;
+
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.HandlerWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+
+import static org.eclipse.jetty.http.HttpStatus.Code.MISDIRECTED_REQUEST;
+
+public class ExpectedSniHandler extends HandlerWrapper {
+    private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
+    private final List<String> expectedSniHeaders;
+
+    public ExpectedSniHandler(List<String> expectedSniHeaders) {
+        this.expectedSniHeaders = expectedSniHeaders;
+    }
+
+    @Override
+    public void handle(String target, Request baseRequest,
+                       HttpServletRequest request,
+                       HttpServletResponse response) throws IOException, ServletException {
+        String sniServerName = SniUtils.getSniServerName(baseRequest);
+        if (sniServerName == null) {
+            log.warn("No SNI header present on request");
+        }
+        else if (!expectedSniHeaders.contains(sniServerName)) {
+            log.warn("SNI header {} is not in the configured list of expected headers", sniServerName);
+        }
+
+        super.handle(target, baseRequest, request, response);
+    }
+}

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -28,7 +28,7 @@ import java.io.IOException;
 import java.util.List;
 
 public class ExpectedSniHandler extends HandlerWrapper {
-  private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
+  private static final Logger log = LoggerFactory.getLogger(ExpectedSniHandler.class);
   private final List<String> expectedSniHeaders;
 
   public ExpectedSniHandler(List<String> expectedSniHeaders) {

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -43,7 +43,7 @@ public class ExpectedSniHandler extends HandlerWrapper {
     if (sniServerName == null) {
       log.warn("No SNI header present on request");
     } else if (!expectedSniHeaders.contains(sniServerName)) {
-      log.warn("SNI header {} is not in the configured list of expected headers", sniServerName);
+      log.warn("SNI header {} is not in the configured list of expected headers {}", sniServerName, this.expectedSniHeaders);
     }
 
     super.handle(target, baseRequest, request, response);

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -43,7 +43,8 @@ public class ExpectedSniHandler extends HandlerWrapper {
     if (sniServerName == null) {
       log.warn("No SNI header present on request");
     } else if (!expectedSniHeaders.contains(sniServerName)) {
-      log.warn("SNI header {} is not in the configured list of expected headers {}", sniServerName, this.expectedSniHeaders);
+      log.warn("SNI header {} is not in the configured list of expected headers {}",
+          sniServerName, this.expectedSniHeaders);
     }
 
     super.handle(target, baseRequest, request, response);

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.rest.handlers;
 
 import org.eclipse.jetty.server.Request;
@@ -11,28 +27,25 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
 
-import static org.eclipse.jetty.http.HttpStatus.Code.MISDIRECTED_REQUEST;
-
 public class ExpectedSniHandler extends HandlerWrapper {
-    private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
-    private final List<String> expectedSniHeaders;
+  private static final Logger log = LoggerFactory.getLogger(SniHandler.class);
+  private final List<String> expectedSniHeaders;
 
-    public ExpectedSniHandler(List<String> expectedSniHeaders) {
-        this.expectedSniHeaders = expectedSniHeaders;
+  public ExpectedSniHandler(List<String> expectedSniHeaders) {
+    this.expectedSniHeaders = expectedSniHeaders;
+  }
+
+  @Override
+  public void handle(String target, Request baseRequest,
+      HttpServletRequest request,
+      HttpServletResponse response) throws IOException, ServletException {
+    String sniServerName = SniUtils.getSniServerName(baseRequest);
+    if (sniServerName == null) {
+      log.warn("No SNI header present on request");
+    } else if (!expectedSniHeaders.contains(sniServerName)) {
+      log.warn("SNI header {} is not in the configured list of expected headers", sniServerName);
     }
 
-    @Override
-    public void handle(String target, Request baseRequest,
-                       HttpServletRequest request,
-                       HttpServletResponse response) throws IOException, ServletException {
-        String sniServerName = SniUtils.getSniServerName(baseRequest);
-        if (sniServerName == null) {
-            log.warn("No SNI header present on request");
-        }
-        else if (!expectedSniHeaders.contains(sniServerName)) {
-            log.warn("SNI header {} is not in the configured list of expected headers", sniServerName);
-        }
-
-        super.handle(target, baseRequest, request, response);
-    }
+    super.handle(target, baseRequest, request, response);
+  }
 }

--- a/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
@@ -1,0 +1,35 @@
+package io.confluent.rest.handlers;
+
+import org.eclipse.jetty.io.EndPoint;
+import org.eclipse.jetty.io.ssl.SslConnection;
+import org.eclipse.jetty.server.Request;
+
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.SSLSession;
+import java.util.List;
+
+public class SniUtils {
+    public static String getSniServerName(Request baseRequest) {
+        EndPoint endpoint = baseRequest.getHttpChannel().getEndPoint();
+        if (endpoint instanceof SslConnection.DecryptedEndPoint) {
+            SSLSession session = ((SslConnection.DecryptedEndPoint) endpoint)
+                .getSslConnection()
+                .getSSLEngine()
+                .getSession();
+            if (session instanceof ExtendedSSLSession) {
+                List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
+                if (servers != null) {
+                    return servers.stream()
+                        .findAny()
+                        .filter(SNIHostName.class::isInstance)
+                        .map(SNIHostName.class::cast)
+                        .map(SNIHostName::getAsciiName)
+                        .orElse(null);
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2014 - 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.confluent.rest.handlers;
 
 import org.eclipse.jetty.io.EndPoint;
@@ -11,25 +27,25 @@ import javax.net.ssl.SSLSession;
 import java.util.List;
 
 public class SniUtils {
-    public static String getSniServerName(Request baseRequest) {
-        EndPoint endpoint = baseRequest.getHttpChannel().getEndPoint();
-        if (endpoint instanceof SslConnection.DecryptedEndPoint) {
-            SSLSession session = ((SslConnection.DecryptedEndPoint) endpoint)
-                .getSslConnection()
-                .getSSLEngine()
-                .getSession();
-            if (session instanceof ExtendedSSLSession) {
-                List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
-                if (servers != null) {
-                    return servers.stream()
-                        .findAny()
-                        .filter(SNIHostName.class::isInstance)
-                        .map(SNIHostName.class::cast)
-                        .map(SNIHostName::getAsciiName)
-                        .orElse(null);
-                }
-            }
+  public static String getSniServerName(Request baseRequest) {
+    EndPoint endpoint = baseRequest.getHttpChannel().getEndPoint();
+    if (endpoint instanceof SslConnection.DecryptedEndPoint) {
+      SSLSession session = ((SslConnection.DecryptedEndPoint) endpoint)
+          .getSslConnection()
+          .getSSLEngine()
+          .getSession();
+      if (session instanceof ExtendedSSLSession) {
+        List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
+        if (servers != null) {
+          return servers.stream()
+              .findAny()
+              .filter(SNIHostName.class::isInstance)
+              .map(SNIHostName.class::cast)
+              .map(SNIHostName::getAsciiName)
+              .orElse(null);
         }
-        return null;
+      }
     }
+    return null;
+  }
 }


### PR DESCRIPTION
Add support for a list of expected SNI headers, configured using `expected.sni.headers`. If this is present, and the SNI check is not enabled, it logs a warning when an unexpected SNI header is present on a connection. This can be used prior to enabling the SNI check to validate that the check will not be disruptive.