### PR TITLE
Don't log RestConfig value when creating DEFAULT_SSL config

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -1166,7 +1166,11 @@ public class RestConfig extends AbstractConfig {
   }
 
   public RestConfig(ConfigDef definition) {
-    this(definition, new TreeMap<>());
+    this(definition, new TreeMap<>(), false);
+  }
+
+  public RestConfig(ConfigDef definition, boolean doLog) {
+    this(definition, new TreeMap<>(), doLog);
   }
 
   public Time getTime() {

--- a/core/src/main/java/io/confluent/rest/SslConfig.java
+++ b/core/src/main/java/io/confluent/rest/SslConfig.java
@@ -25,7 +25,7 @@ public final class SslConfig {
   public static final String TLS_CONSCRYPT = "Conscrypt";
 
   private static final SslConfig DEFAULT_CONFIG =
-      new SslConfig(new RestConfig(RestConfig.baseConfigDef()));
+      new SslConfig(new RestConfig(RestConfig.baseConfigDef(), false));
 
   private final RestConfig restConfig;
 


### PR DESCRIPTION
SslConfig.DEFAULT_CONFIG will log unrelated RestConfig values, which will confuse the application log, so disable it.