### PR TITLE
remove the hibernate-validator exclusion no longer needed due to updated version of jersey-bean

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,17 +49,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hibernate.validator</groupId>
-                    <artifactId>hibernate-validator</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
-        <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.1.15-0</io.confluent.rest-utils.version>
@@ -103,17 +102,6 @@
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
                 <version>${jersey.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hibernate.validator</groupId>
-                        <artifactId>hibernate-validator</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.validator</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate.validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>


### PR DESCRIPTION
Folks, 
The update of jersey-bean in :
https://github.com/confluentinc/rest-utils/commit/903dcf49f770092cc011b10d57c5a7486ad2786c 
did not account for an update of the transitive dependency that no longer needs to be excluded  / redefined. 
This addresses a bizzare zombie CVE-2023-1932:
https://nvd.nist.gov/vuln/detail/CVE-2023-1932
Note:
NVD Published Date:
11/07/2024 
CVE number from 2023. 