### PR TITLE
Remove hardcoded hibenate-validator version to fix CVE-2023-1932

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -46,17 +46,6 @@
         <dependency>
             <groupId>org.glassfish.jersey.ext</groupId>
             <artifactId>jersey-bean-validation</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.hibernate.validator</groupId>
-                    <artifactId>hibernate-validator</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate.validator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
-        <hibernate.validator.version>6.1.7.Final</hibernate.validator.version>
         <asynchttpclient.version>2.2.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.7.0</io.confluent.rest-utils.version>
@@ -117,17 +116,6 @@
                 <groupId>org.glassfish.jersey.ext</groupId>
                 <artifactId>jersey-bean-validation</artifactId>
                 <version>${jersey.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.hibernate.validator</groupId>
-                        <artifactId>hibernate-validator</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>org.hibernate.validator</groupId>
-                <artifactId>hibernate-validator</artifactId>
-                <version>${hibernate.validator.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jersey.inject</groupId>


### PR DESCRIPTION
This removes hardcoded hibernate validator version, so it will pick up from the fix version `6.2.0.Final` for resolving CVE-2023-1932.

```
mvn dependency:tree | grep hibernate-validator
[INFO] |  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
[INFO] |  |  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
[INFO] |  |  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
[INFO] |  |  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
[INFO] |  |  +- org.hibernate.validator:hibernate-validator:jar:6.2.0.Final:compile
```