### PR TITLE
Map UnknownTopicIdException to 404 code

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
@@ -37,6 +37,7 @@ import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
@@ -94,6 +95,8 @@ public class KafkaExceptionMapper extends GenericExceptionMapper {
     errorMap.put(UnknownServerException.class, new ResponsePair(Status.BAD_REQUEST,
         KAFKA_BAD_REQUEST_ERROR_CODE));
     errorMap.put(UnknownTopicOrPartitionException.class, new ResponsePair(Status.NOT_FOUND,
+        KAFKA_UNKNOWN_TOPIC_PARTITION_CODE));
+    errorMap.put(UnknownTopicIdException.class, new ResponsePair(Status.NOT_FOUND,
         KAFKA_UNKNOWN_TOPIC_PARTITION_CODE));
     errorMap.put(PolicyViolationException.class, new ResponsePair(Status.BAD_REQUEST,
         KAFKA_BAD_REQUEST_ERROR_CODE));

--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -45,6 +45,7 @@ import org.apache.kafka.common.errors.TopicDeletionDisabledException;
 import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.TransactionalIdAuthorizationException;
 import org.apache.kafka.common.errors.UnknownServerException;
+import org.apache.kafka.common.errors.UnknownTopicIdException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.junit.jupiter.api.BeforeEach;
@@ -121,6 +122,8 @@ public class KafkaExceptionMapperTest {
     verifyMapperResponse(new UnknownServerException("some message"), Status.BAD_REQUEST,
         KAFKA_BAD_REQUEST_ERROR_CODE);
     verifyMapperResponse(new UnknownTopicOrPartitionException("some message"), Status.NOT_FOUND,
+        KAFKA_UNKNOWN_TOPIC_PARTITION_CODE);
+    verifyMapperResponse(new UnknownTopicIdException("some message"), Status.NOT_FOUND,
         KAFKA_UNKNOWN_TOPIC_PARTITION_CODE);
     verifyMapperResponse(new PolicyViolationException("some message"), Status.BAD_REQUEST,
         KAFKA_BAD_REQUEST_ERROR_CODE);


### PR DESCRIPTION
We don't handle UnknownTopicIdException gracefully, which leads to 500 error response, so this is to fix this.

The exception can happen if the user issuing topic deletion multiple times for the same topic.

Refs:
- https://confluentinc.atlassian.net/browse/KOP-192