### PR TITLE
CPBR-2063: adding block level status for semaphore

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -7,6 +7,7 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
+  status_level: block
   downstream_projects: ["schema-registry", "metadata-service", "kafka-rest", "confluent-security-plugins", "ce-kafka-http-server", "secret-registry", "confluent-cloud-plugins", "kafka-streams-examples"]
 git:
   enable: true

--- a/service.yml
+++ b/service.yml
@@ -7,6 +7,9 @@ semaphore:
   enable: true
   pipeline_type: cp
   nano_version: true
+  pr_ci_gating:
+    enable: true
+    project_name: rest-utils
   status_level: block
   downstream_projects: ["schema-registry", "metadata-service", "kafka-rest", "confluent-security-plugins", "ce-kafka-http-server", "secret-registry", "confluent-cloud-plugins", "kafka-streams-examples"]
 git:


### PR DESCRIPTION
This change will allow adding non blocking cp jar build addition to master branch. Only in master branch, if [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) fails, developers will still be able to merge their changes. For all the branches, [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) will be required to pass before merging changes in any CP development branch.
More details can be found in https://confluentinc.atlassian.net/wiki/spaces/ENV/pages/2871296194/Add+SemaphoreCI#Configuration and https://docs.semaphoreci.com/using-semaphore/projects#edit-status-checks

To reduce number of PR approvals, this PR also modifies service.yml to add cp jar build block in semaphore.yml to trigger cp jar build job on every PR build.

After merging the PR, cc-service-bot (which manages cp projects semaphore.yml) will be invoked on this repo to add [cp-jar-build](https://confluentinc.atlassian.net/browse/CP-jar-build) block in master branch