### PR TITLE
[DGS-18780] Ensure p99 metrics are correctly published

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -656,6 +656,7 @@ public abstract class Application<T extends RestConfig> {
         restConfig.getBoolean(RestConfig.METRICS_LATENCY_SLO_SLA_ENABLE_CONFIG),
         restConfig.getLong(RestConfig.METRICS_LATENCY_SLO_MS_CONFIG),
         restConfig.getLong(RestConfig.METRICS_LATENCY_SLA_MS_CONFIG),
+        restConfig.getDouble(RestConfig.PERCENTILE_MAX_LATENCY_MS_CONFIG),
         restConfig.getBoolean(RestConfig.METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG)));
 
     config.property(ServerProperties.BV_SEND_ERROR_IN_RESPONSE, true);

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -194,8 +194,8 @@ public class RestConfig extends AbstractConfig {
       + " request latency meets or violates SLA";
   protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
   public static final String PERCENTILE_MAX_LATENCY_MS_CONFIG = "percentile.max.latency.ms";
-  protected static final String PERCENTILE_MAX_LATENCY_MS_DOC = "The threshold (in ms) of percentile"
-          + " maximum latency";
+  protected static final String PERCENTILE_MAX_LATENCY_MS_DOC = "The threshold (in ms) of"
+          + " percentile maximum latency";
   protected static final double PERCENTILE_MAX_LATENCY_MS_DEFAULT = 10000;
   public static final String METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG =
       "metrics.global.stats.request.tags.enable";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -193,6 +193,10 @@ public class RestConfig extends AbstractConfig {
   protected static final String METRICS_LATENCY_SLA_MS_DOC = "The threshold (in ms) of whether"
       + " request latency meets or violates SLA";
   protected static final long METRICS_LATENCY_SLA_MS_DEFAULT = 50;
+  public static final String PERCENTILE_MAX_LATENCY_MS_CONFIG = "percentile.max.latency.ms";
+  protected static final String PERCENTILE_MAX_LATENCY_MS_DOC = "The threshold (in ms) of percentile"
+          + " maximum latency";
+  protected static final double PERCENTILE_MAX_LATENCY_MS_DEFAULT = 10000;
   public static final String METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG =
       "metrics.global.stats.request.tags.enable";
   protected static final String METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DOC = "Whether to use "
@@ -761,6 +765,12 @@ public class RestConfig extends AbstractConfig {
             METRICS_LATENCY_SLA_MS_DEFAULT,
             Importance.LOW,
             METRICS_LATENCY_SLA_MS_DOC
+        ).define(
+            PERCENTILE_MAX_LATENCY_MS_CONFIG,
+            Type.DOUBLE,
+            PERCENTILE_MAX_LATENCY_MS_DEFAULT,
+            Importance.LOW,
+            PERCENTILE_MAX_LATENCY_MS_DOC
         ).define(
             METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG,
             Type.BOOLEAN,

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -141,7 +141,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       MethodMetrics m = new MethodMetrics(
           method, annotation, metrics, metricGrpPrefix, metricTags, emptyMap(),
-          enableLatencySloSla, latencySloMs, latencySlaMs, );
+          enableLatencySloSla, latencySloMs, latencySlaMs, percentileMaxLatencyInMs);
       ConstructionContext context = new ConstructionContext(method, annotation, this);
       methodMetrics.put(definitionMethod, new RequestScopedMetrics(m, context));
     }
@@ -241,7 +241,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
     public MethodMetrics(ResourceMethod method, PerformanceMetric annotation, Metrics metrics,
                          String metricGrpPrefix, Map<String, String> metricTags,
-                         Map<String, String> requestTags, double percentileMaxLatencyInMs) {
+                         Map<String, String> requestTags) {
       this(method, annotation, metrics, metricGrpPrefix, metricTags, requestTags, false, 0L, 0L, 10000);
     }
 

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -90,7 +90,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   public MetricsResourceMethodApplicationListener(Metrics metrics, String metricGrpPrefix,
                                                   Map<String, String> metricTags, Time time,
                                                   boolean enableLatencySloSla,
-                                                  long latencySloMs, long latencySlaMs, double percentileMaxLatencyInMs) {
+                                                  long latencySloMs, long latencySlaMs,
+                                                  double percentileMaxLatencyInMs) {
     this(metrics, metricGrpPrefix, metricTags, time, enableLatencySloSla, latencySloMs,
         latencySlaMs, percentileMaxLatencyInMs, false);
   }
@@ -98,7 +99,9 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   public MetricsResourceMethodApplicationListener(Metrics metrics, String metricGrpPrefix,
                                                   Map<String, String> metricTags, Time time,
                                                   boolean enableLatencySloSla,
-                                                  long latencySloMs, long latencySlaMs, double percentileMaxLatencyInMs, boolean enableGlobalStatsRequestTags) {
+                                                  long latencySloMs, long latencySlaMs,
+                                                  double percentileMaxLatencyInMs,
+                                                  boolean enableGlobalStatsRequestTags) {
     super();
     this.metrics = metrics;
     this.metricGrpPrefix = metricGrpPrefix;
@@ -242,7 +245,8 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     public MethodMetrics(ResourceMethod method, PerformanceMetric annotation, Metrics metrics,
                          String metricGrpPrefix, Map<String, String> metricTags,
                          Map<String, String> requestTags) {
-      this(method, annotation, metrics, metricGrpPrefix, metricTags, requestTags, false, 0L, 0L, 10000);
+      this(method, annotation, metrics, metricGrpPrefix, metricTags, requestTags, false,
+              0L, 0L, 10000);
     }
 
     public MethodMetrics(ResourceMethod method, PerformanceMetric annotation, Metrics metrics,

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -70,7 +70,6 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   protected static final String[] HTTP_STATUS_CODE_TEXT = {
       "unknown", "1xx", "2xx", "3xx", "4xx", "5xx", "429"};
   private static final int PERCENTILE_NUM_BUCKETS = 200;
-  private static final double PERCENTILE_MAX_LATENCY_IN_MS = TimeUnit.SECONDS.toMillis(10);
   private static final long SENSOR_EXPIRY_SECONDS = TimeUnit.HOURS.toSeconds(1);
 
   private final Metrics metrics;
@@ -81,23 +80,25 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
   private final boolean enableLatencySloSla;
   private final long latencySloMs;
   private final long latencySlaMs;
+  private final double percentileMaxLatencyInMs;
+
   // This controls whether we should use request tags in global stats, i.e., those without resource
   // method in the names, introducing this variable to keep the compatibility with downstream
   // dependencies, e.g., some applications may not want to report request tags in global stats
   private final boolean enableGlobalStatsRequestTags;
 
   public MetricsResourceMethodApplicationListener(Metrics metrics, String metricGrpPrefix,
-      Map<String, String> metricTags, Time time,
-      boolean enableLatencySloSla,
-      long latencySloMs, long latencySlaMs) {
+                                                  Map<String, String> metricTags, Time time,
+                                                  boolean enableLatencySloSla,
+                                                  long latencySloMs, long latencySlaMs, double percentileMaxLatencyInMs) {
     this(metrics, metricGrpPrefix, metricTags, time, enableLatencySloSla, latencySloMs,
-        latencySlaMs, false);
+        latencySlaMs, percentileMaxLatencyInMs, false);
   }
 
   public MetricsResourceMethodApplicationListener(Metrics metrics, String metricGrpPrefix,
-      Map<String, String> metricTags, Time time,
-      boolean enableLatencySloSla,
-      long latencySloMs, long latencySlaMs, boolean enableGlobalStatsRequestTags) {
+                                                  Map<String, String> metricTags, Time time,
+                                                  boolean enableLatencySloSla,
+                                                  long latencySloMs, long latencySlaMs, double percentileMaxLatencyInMs, boolean enableGlobalStatsRequestTags) {
     super();
     this.metrics = metrics;
     this.metricGrpPrefix = metricGrpPrefix;
@@ -106,6 +107,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     this.enableLatencySloSla = enableLatencySloSla;
     this.latencySloMs = latencySloMs;
     this.latencySlaMs = latencySlaMs;
+    this.percentileMaxLatencyInMs = percentileMaxLatencyInMs;
     this.enableGlobalStatsRequestTags = enableGlobalStatsRequestTags;
   }
 
@@ -115,7 +117,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       // Special null key is used for global stats
       MethodMetrics m = new MethodMetrics(
           null, null, this.metrics, metricGrpPrefix, metricTags, emptyMap(),
-          enableLatencySloSla, latencySloMs, latencySlaMs);
+          enableLatencySloSla, latencySloMs, latencySlaMs, percentileMaxLatencyInMs);
       methodMetrics.put(null, new RequestScopedMetrics(m, new ConstructionContext(this)));
 
       for (final Resource resource : event.getResourceModel().getResources()) {
@@ -139,7 +141,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       MethodMetrics m = new MethodMetrics(
           method, annotation, metrics, metricGrpPrefix, metricTags, emptyMap(),
-          enableLatencySloSla, latencySloMs, latencySlaMs);
+          enableLatencySloSla, latencySloMs, latencySlaMs, );
       ConstructionContext context = new ConstructionContext(method, annotation, this);
       methodMetrics.put(definitionMethod, new RequestScopedMetrics(m, context));
     }
@@ -235,17 +237,18 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     private final boolean enableLatencySloSla;
     private final long latencySloMs;
     private final long latencySlaMs;
+    private final double percentileMaxLatencyInMs;
 
     public MethodMetrics(ResourceMethod method, PerformanceMetric annotation, Metrics metrics,
                          String metricGrpPrefix, Map<String, String> metricTags,
-                         Map<String, String> requestTags) {
-      this(method, annotation, metrics, metricGrpPrefix, metricTags, requestTags, false, 0L, 0L);
+                         Map<String, String> requestTags, double percentileMaxLatencyInMs) {
+      this(method, annotation, metrics, metricGrpPrefix, metricTags, requestTags, false, 0L, 0L, 10000);
     }
 
     public MethodMetrics(ResourceMethod method, PerformanceMetric annotation, Metrics metrics,
                          String metricGrpPrefix, Map<String, String> metricTags,
                          Map<String, String> requestTags, boolean enableLatencySloSla,
-                         long latencySloMs, long latencySlaMs) {
+                         long latencySloMs, long latencySlaMs, double percentileMaxLatencyInMs) {
       String metricGrpName = metricGrpPrefix + "-metrics";
       // The tags will be used to generate MBean names if JmxReporter is used,
       // sort to get consistent names
@@ -315,6 +318,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
       this.enableLatencySloSla = enableLatencySloSla;
       this.latencySloMs = latencySloMs;
       this.latencySlaMs = latencySlaMs;
+      this.percentileMaxLatencyInMs = percentileMaxLatencyInMs;
       if (enableLatencySloSla) {
         setResponseLatencySloSlaSensors(method, annotation, metrics, requestTags,
             metricGrpName, allTags);
@@ -322,7 +326,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
 
       Percentiles percs = new Percentiles(Float.SIZE / 8 * PERCENTILE_NUM_BUCKETS,
           0.0,
-          PERCENTILE_MAX_LATENCY_IN_MS,
+          percentileMaxLatencyInMs,
           Percentiles.BucketSizing.LINEAR,
           new Percentile(new MetricName(
               getName(method, annotation, "request-latency-95"), metricGrpName,


### PR DESCRIPTION
We noticed that the percentile latency metrics in rest-utils (request-latency-95 and request-latency-99) are capped out at 10s (code [ref](https://github.com/confluentinc/rest-utils/blob/7.6.x/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java#L325)). 

The PR makes PERCENTILE_MAX_LATENCY_IN_MS configurable in RestConfig, with 10s as the default value.

[Slack thread](https://confluent.slack.com/archives/C3226NBLJ/p1713808819756109)