### PR TITLE
[CC-30955]update async_http_client without upgrade of major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
-        <asynchttpclient.version>2.2.0</asynchttpclient.version>
+        <asynchttpclient.version>2.12.4</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.1.16-0</io.confluent.rest-utils.version>
     </properties>


### PR DESCRIPTION
alternate update of async_http_client going from 2.2.0 to 2.12.4 (that was just recently published) 
alternative to updating to major version 3.0.1 see #517 