### PR TITLE
KNET-17108: Bump asynchttpclient to version 2.12.4 in 7.7.0-cp6 (#18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.36</jersey.version>
-        <asynchttpclient.version>2.2.0</asynchttpclient.version>
+        <asynchttpclient.version>2.12.4</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.7.0</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
Bump asynchttpclient to version 2.12.4 in 7.7.0-cp6