### PR TITLE
Added validator for PERCENTILE_MAX_LATENCY

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -769,6 +769,7 @@ public class RestConfig extends AbstractConfig {
             PERCENTILE_MAX_LATENCY_MS_CONFIG,
             Type.DOUBLE,
             PERCENTILE_MAX_LATENCY_MS_DEFAULT,
+            ConfigDef.Range.atLeast(0),
             Importance.LOW,
             PERCENTILE_MAX_LATENCY_MS_DOC
         ).define(


### PR DESCRIPTION
Addressing the review comment on the previous [PR](https://github.com/confluentinc/rest-utils/pull/519) to make PERCENTILE_MAX_LATENCY configurable.
Added a validator for the value to avoid non positive values.