### PR TITLE
[KNET-17344] Map GroupAuthorizationException to 403 code

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/KafkaExceptionMapper.java
@@ -23,6 +23,7 @@ import org.apache.kafka.common.errors.ApiException;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.common.errors.InvalidPartitionsException;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
@@ -77,6 +78,8 @@ public class KafkaExceptionMapper extends GenericExceptionMapper {
   private static Map<Class<? extends ApiException>, ResponsePair> errorMap() {
     Map<Class<? extends ApiException>, ResponsePair> errorMap = new HashMap<>();
 
+    errorMap.put(GroupAuthorizationException.class, new ResponsePair(Status.FORBIDDEN,
+        KAFKA_AUTHORIZATION_ERROR_CODE));
     errorMap.put(BrokerNotAvailableException.class, new ResponsePair(Status.SERVICE_UNAVAILABLE,
         BROKER_NOT_AVAILABLE_ERROR_CODE));
     errorMap.put(InvalidReplicationFactorException.class, new ResponsePair(Status.BAD_REQUEST,


### PR DESCRIPTION
We don't handle GroupAuthorizationException gracefully, which leads to 5xx error response, instead we want to return 403 in these cases.

Example commands which can trigger this:
```
"GET /kafka/v3/clusters/lkc-o3koxp/consumer-groups/<invalid-consumer-group-name>/lags HTTP/1.1"
"GET /kafka/v3/clusters/lkc-o3koxp/consumer-groups/<invalid-consumer-group-name>/lag-summary HTTP/1.1" 
```