### PR TITLE
[master] Allow for upgrade to jetty and unpin jetty-servlets 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>8.0.0-0</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>
-        <jetty.servlets.version>9.4.53.v20231009</jetty.servlets.version>
     </properties>
 
     <repositories>
@@ -185,7 +184,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-servlets</artifactId>
-                <version>${jetty.servlets.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
https://github.com/confluentinc/rest-utils/pull/515 was merged to master

we can now unpin jetty-servlets version