### PR TITLE
Backport http2 support changes to 7.7.0-cp7

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-java-server</artifactId>
-            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
@@ -116,6 +115,12 @@
         <dependency>
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-ratelimiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.auto.service</groupId>
+            <artifactId>auto-service</artifactId>
+            <version>1.1.1</version>
+            <optional>true</optional>
         </dependency>
         <!--test-->
         <dependency>

--- a/core/src/main/java/io/confluent/rest/alpn/server/BouncyCastleServerALPNProcessor.java
+++ b/core/src/main/java/io/confluent/rest/alpn/server/BouncyCastleServerALPNProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.alpn.server;
+
+import com.google.auto.service.AutoService;
+
+import javax.net.ssl.SSLEngine;
+
+import org.eclipse.jetty.alpn.java.server.JDK9ServerALPNProcessor;
+import org.eclipse.jetty.io.ssl.ALPNProcessor;
+
+/**
+ * This class implements Server ALPN processor and is available as a service so that Jetty http/2
+ * can work with BouncyCastle's JSSE provider FIPS driver.
+ * Support for ALPN in BouncyCastle's JSSE
+ * provider is available since bc-fips-1.0.2, but there isn't an implementation of
+ * ALPNProcessor.Server available in Jetty server.
+ * This class leverages JDK9ServerALPNProcessor in
+ * Jetty server to make a service that implements ALPNProcessor.Server and is compatible with
+ * BouncyCastle's JSSE provider FIPS driver.
+ */
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+@AutoService(ALPNProcessor.Server.class)
+public class BouncyCastleServerALPNProcessor extends JDK9ServerALPNProcessor {
+
+  @Override
+  public boolean appliesTo(SSLEngine sslEngine) {
+    return sslEngine.getClass().getName().startsWith("org.bouncycastle.jsse.provider");
+  }
+}


### PR DESCRIPTION
Changes: These changes address the Bouncy Castle issue described [here](https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/3950773390/Bouncy+Castle+test+failure+analysis).

Reason for Change: The changes fix an ALPN Processor error that occurs when Bouncy Castle jars are used with HTTP/2. The fix was originally implemented https://github.com/confluentinc/rest-utils/pull/477 and is now being backported to the 7.7.0-cp7 branch in this PR.