### PR TITLE
CPBR-2313 | Remove java-7-jdk dependency from debian build scripts

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: confluent-rest-utils
 Section: misc
 Priority: optional
 Maintainer: Confluent Packaging <packages@confluent.io>
-Build-Depends: debhelper (>= 9), java7-jdk, javahelper (>= 0.40),
+Build-Depends: debhelper (>= 9), javahelper (>= 0.40),
  make, maven
 Standards-Version: 3.9.3
 Homepage: http://confluent.io


### PR DESCRIPTION
From CP 8.0, JDK 17 is the JDK that will be used to build CP packages. Hence, remove these dependencies.