### PR TITLE
Fix log4j2 pattern config

### DIFF
--- a/core/src/test/resources/log4j2.yaml
+++ b/core/src/test/resources/log4j2.yaml
@@ -20,7 +20,7 @@ Configuration:
       name: "STDOUT"
       target: "SYSTEM_OUT"
       PatternLayout:
-        pattern: "[%d] %v1Level %m (%c:%L)%n"
+        pattern: "[%d] %p %m (%c:%L)%n"
   Loggers:
     Root:
       level: "INFO"

--- a/examples/src/main/resources/log4j2.yaml
+++ b/examples/src/main/resources/log4j2.yaml
@@ -5,7 +5,7 @@ Configuration:
       name: "STDOUT"
       target: "SYSTEM_OUT"
       PatternLayout:
-        pattern: "[%d] %v1Level %m (%c:%L)%n"
+        pattern: "[%d] %p %m (%c:%L)%n"
   Loggers:
     Root:
       level: "INFO"

--- a/fips-tests/src/test/resources/log4j2.yaml
+++ b/fips-tests/src/test/resources/log4j2.yaml
@@ -20,7 +20,7 @@ Configuration:
       name: "STDOUT"
       target: "SYSTEM_OUT"
       PatternLayout:
-        pattern: "[%d] %v1Level %m (%c:%L)%n"
+        pattern: "[%d] %p %m (%c:%L)%n"
   Loggers:
     Root:
       level: "INFO"


### PR DESCRIPTION
Use `%p` for including log level in log output.