### PR TITLE
Pin JDK to 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
     </modules>
 
     <properties>
+        <java.version>17</java.version>
         <activation.version>1.1.1</activation.version>
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>


### PR DESCRIPTION
Pin JDK to 17 since common will use 11 (since some clients rely on common)