### PR TITLE
Remove zk notice for cp 8.0.x release

### DIFF
--- a/licenses/NOTICE.confluent-common.txt
+++ b/licenses/NOTICE.confluent-common.txt
@@ -1,11 +1,5 @@
 The following libraries are included in packaged versions of this project:
 
-* Apache ZooKeeper
- * COPYRIGHT: Copyright 2009-2014 The Apache Software Foundation
- * LICENSE: licenses/LICENSE.apache2.txt
- * NOTICE: licenses/NOTICE.zookeeper.txt
- * HOMEPAGE: http://zookeeper.apache.org/
-
 * jline
  * COPYRIGHT: Copyright (c) 2002-2006, Marc Prud'hommeaux <mwp1@cornell.edu>
  * LICENSE: licenses/LICENSE.bsd.txt

--- a/licenses/NOTICE.zookeeper.txt
+++ b/licenses/NOTICE.zookeeper.txt
@@ -1,5 +1,0 @@
-Apache ZooKeeper
-Copyright 2009-2014 The Apache Software Foundation
-
-This product includes software developed at
-The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
Removing ZK related files and references since 8.0.x will not be shipped with it