### PR TITLE
Scoped to listener config for network connector

### DIFF
--- a/core/src/main/java/io/confluent/rest/ApplicationServer.java
+++ b/core/src/main/java/io/confluent/rest/ApplicationServer.java
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 // CHECKSTYLE_RULES.OFF: ClassDataAbstractionCoupling
 public final class ApplicationServer<T extends RestConfig> extends Server {
   // CHECKSTYLE_RULES.ON: ClassDataAbstractionCoupling
-  private final T config;
+  private final T serverConfig;
   private final List<Application<?>> applications;
   private final ImmutableMap<NamedURI, SslContextFactory> sslContextFactories;
 
@@ -101,7 +101,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   public ApplicationServer(T config, ThreadPool threadPool) {
     super(threadPool);
 
-    this.config = config;
+    this.serverConfig = config;
     this.applications = new ArrayList<>();
 
     int gracefulShutdownMs = config.getInt(RestConfig.SHUTDOWN_GRACEFUL_MS_CONFIG);
@@ -133,8 +133,8 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
     return Collections.unmodifiableList(applications);
   }
 
-  private boolean isHstsHeaderEnabled() {
-    return config.getBoolean(RestConfig.HSTS_HEADER_ENABLE_CONFIG);
+  private static boolean isHstsHeaderEnabled(RestConfig connectorConfig) {
+    return connectorConfig.getBoolean(RestConfig.HSTS_HEADER_ENABLE_CONFIG);
   }
 
   private void attachNetworkTrafficListener(RestConfig appConfig,
@@ -220,7 +220,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   @Override
   protected final void doStart() throws Exception {
     // set the default error handler
-    this.setErrorHandler(new StackTraceErrorHandler(config.getSuppressStackTraceInResponse()));
+    this.setErrorHandler(new StackTraceErrorHandler(serverConfig.getSuppressStackTraceInResponse()));
 
     Sequence handlers = new Sequence();
     Sequence wsHandlers = new Sequence();
@@ -249,45 +249,48 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   }
 
   private void configureConnectors() {
-    final HttpConfiguration httpConfiguration = new HttpConfiguration();
-    httpConfiguration.setSendServerVersion(false);
-
-    // Allow requests/responses with large URLs/token headers
-    httpConfiguration.setRequestHeaderSize(
-        config.getInt(RestConfig.MAX_REQUEST_HEADER_SIZE_CONFIG));
-    httpConfiguration.setResponseHeaderSize(
-        config.getInt(RestConfig.MAX_RESPONSE_HEADER_SIZE_CONFIG));
-
-    // Use original IP in forwarded requests
-    if (config.getBoolean(RestConfig.NETWORK_FORWARDED_REQUEST_ENABLE_CONFIG)) {
-      httpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
-    }
-
-    // Refer to https://github.com/jetty/jetty.project/issues/11890#issuecomment-2156449534
-    // In Jetty 12, using Servlet 6 and ee10+, ambiguous path separators are not allowed
-    // We must set a URI compliance to allow for this violation so that client
-    // requests are not automatically rejected
-    httpConfiguration.setUriCompliance(UriCompliance.from(Set.of(
-        UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
-        UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING)));
-
-    final HttpConnectionFactory httpConnectionFactory =
-            new HttpConnectionFactory(httpConfiguration);
-
-    // Default to supporting HTTP/2 for Java 11 and later
-    final boolean http2Enabled = isHttp2Compatible(config.getBaseSslConfig())
-                              && config.getBoolean(RestConfig.HTTP2_ENABLED_CONFIG);
-
-    final boolean proxyProtocolEnabled =
-        config.getBoolean(RestConfig.PROXY_PROTOCOL_ENABLED_CONFIG);
-
     for (NamedURI listener : listeners) {
+      RestConfig connectorConfig = serverConfig.getListenerScopedConfig(listener);
+      final HttpConfiguration httpConfiguration = new HttpConfiguration();
+      httpConfiguration.setSendServerVersion(false);
+
+      // Allow requests/responses with large URLs/token headers
+      httpConfiguration.setRequestHeaderSize(
+          connectorConfig.getInt(RestConfig.MAX_REQUEST_HEADER_SIZE_CONFIG));
+      httpConfiguration.setResponseHeaderSize(
+          connectorConfig.getInt(RestConfig.MAX_RESPONSE_HEADER_SIZE_CONFIG));
+
+      // Use original IP in forwarded requests
+      if (connectorConfig.getBoolean(RestConfig.NETWORK_FORWARDED_REQUEST_ENABLE_CONFIG)) {
+        httpConfiguration.addCustomizer(new ForwardedRequestCustomizer());
+      }
+
+      // Refer to https://github.com/jetty/jetty.project/issues/11890#issuecomment-2156449534
+      // In Jetty 12, using Servlet 6 and ee10+, ambiguous path separators are not allowed
+      // We must set a URI compliance to allow for this violation so that client
+      // requests are not automatically rejected
+      httpConfiguration.setUriCompliance(UriCompliance.from(Set.of(
+          UriCompliance.Violation.AMBIGUOUS_PATH_SEPARATOR,
+          UriCompliance.Violation.AMBIGUOUS_PATH_ENCODING)));
+
+      final HttpConnectionFactory httpConnectionFactory =
+              new HttpConnectionFactory(httpConfiguration);
+
+      // Default to supporting HTTP/2 for Java 11 and later
+      final boolean http2Enabled = isHttp2Compatible(serverConfig.getBaseSslConfig())
+                                && connectorConfig.getBoolean(RestConfig.HTTP2_ENABLED_CONFIG);
+
+      final boolean proxyProtocolEnabled =
+          connectorConfig.getBoolean(RestConfig.PROXY_PROTOCOL_ENABLED_CONFIG);
+
       if (listener.getUri().getScheme().equals("https")) {
         if (httpConfiguration.getCustomizer(SecureRequestCustomizer.class) == null) {
           SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
           // SniHostCheckEnable is enabled by default
-          if (!config.getSniHostCheckEnable()) {
+          if (!connectorConfig.getSniHostCheckEnable()) {
             secureRequestCustomizer.setSniHostCheck(false);
+            // also disable SNI required
+            secureRequestCustomizer.setSniRequired(false);
             log.info("Disabled SNI host check for listener: {}", listener);
           } else {
             // Explicitly making sure that SNI is checked against Host in HTTP request
@@ -295,19 +298,20 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
                 "Host name matching SNI certificate check must be enabled.");
           }
 
-          if (isHstsHeaderEnabled()) {
+          if (isHstsHeaderEnabled(connectorConfig)) {
             secureRequestCustomizer.setStsMaxAge(HSTS_MAX_AGE_SECONDS);
             secureRequestCustomizer.setStsIncludeSubDomains(true);
           }
           httpConfiguration.addCustomizer(secureRequestCustomizer);
         }
       }
-      addConnectorForListener(httpConfiguration, httpConnectionFactory, listener,
+      addConnectorForListener(connectorConfig, httpConfiguration, httpConnectionFactory, listener,
           http2Enabled, proxyProtocolEnabled);
     }
   }
 
-  private void addConnectorForListener(HttpConfiguration httpConfiguration,
+  private void addConnectorForListener(RestConfig connectorConfig,
+                                       HttpConfiguration httpConfiguration,
                                        HttpConnectionFactory httpConnectionFactory,
                                        NamedURI listener,
                                        boolean http2Enabled,
@@ -330,7 +334,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
 
     connector.setPort(listener.getUri().getPort());
     connector.setHost(listener.getUri().getHost());
-    connector.setIdleTimeout(config.getLong(RestConfig.IDLE_TIMEOUT_MS_CONFIG));
+    connector.setIdleTimeout(connectorConfig.getLong(RestConfig.IDLE_TIMEOUT_MS_CONFIG));
     if (listener.getName() != null) {
       connector.setName(listener.getName());
     }
@@ -407,11 +411,11 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   }
 
   private void configureConnectionLimits() {
-    int serverConnectionLimit = config.getServerConnectionLimit();
+    int serverConnectionLimit = serverConfig.getServerConnectionLimit();
     if (serverConnectionLimit > 0) {
       addBean(new ConnectionLimit(serverConnectionLimit, getServer()));
     }
-    int connectorConnectionLimit = config.getConnectorConnectionLimit();
+    int connectorConnectionLimit = serverConfig.getConnectorConnectionLimit();
     if (connectorConnectionLimit > 0) {
       addBean(new ConnectionLimit(connectorConnectionLimit, connectors.toArray(new Connector[0])));
     }
@@ -439,7 +443,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
    * @return the total number of maximum threads configured in the pool.
    */
   public int getMaxThreads() {
-    return config.getInt(RestConfig.THREAD_POOL_MAX_CONFIG);
+    return serverConfig.getInt(RestConfig.THREAD_POOL_MAX_CONFIG);
   }
 
   /**
@@ -469,7 +473,7 @@ public final class ApplicationServer<T extends RestConfig> extends Server {
   }
 
   private Handler wrapWithGzipHandler(Handler handler) {
-    return wrapWithGzipHandler(config, handler);
+    return wrapWithGzipHandler(serverConfig, handler);
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -1373,6 +1373,28 @@ public class RestConfig extends AbstractConfig {
     return new SslConfig(this);
   }
 
+  /**
+   * Returns a new RestConfig object that is scoped to the given listener.
+   * The new config will contain all the properties of the original config,
+   * with overrides for the listener-specific properties that are
+   * prefixed with "listener.name.<name>.".
+   * Unnamed https listeners will be scoped to the default
+   * 'listener.name.https.'.
+   * @param listener the listener to scope the config to
+   * @return a new RestConfig object that is scoped to the given listener
+   */
+  RestConfig getListenerScopedConfig(NamedURI listener) {
+    if (listener.getName() == null && !listener.getUri().getScheme().equals("https")) {
+      return this;
+    }
+    String prefix = "listener.name." + Optional.ofNullable(listener.getName()).orElse("https") + ".";
+
+    Map<String, Object> overridden = originals();
+    overridden.putAll(filterByAndStripPrefix(originals(), prefix));
+
+    return new RestConfig(baseConfigDef(), overridden, doLog);
+  }
+
   private SslConfig getSslConfig(NamedURI listener) {
     String prefix =
         "listener.name." + Optional.ofNullable(listener.getName()).orElse("https") + ".";


### PR DESCRIPTION
We don't provide the ability to scope config to connector for listener, this PR is to enable this.