### PR TITLE
Restrict sni prefix validation to certain prefix

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -420,7 +420,7 @@ public abstract class Application<T extends RestConfig> {
 
     // Add SNI validation handler if enabled
     if (config.getPrefixSniCheckEnable()) {
-      context.insertHandler(new PrefixSniHandler());
+      context.insertHandler(new PrefixSniHandler(config.getPrefixSniPrefix()));
     } else if (config.getSniCheckEnable()) {
       context.insertHandler(new SniHandler());
     }

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -523,6 +523,12 @@ public class RestConfig extends AbstractConfig {
           + "misdirected response. Default is false.";
   protected static final boolean PREFIX_SNI_CHECK_ENABLED_DEFAULT = false;
 
+  public static final String PREFIX_SNI_PREFIX_CONFIG = "prefix.sni.prefix";
+  protected static final String PREFIX_SNI_PREFIX_DOC =
+      "The prefix to check against the Host header when prefix SNI checking is enabled. "
+          + "Default is empty string.";
+  protected static final String PREFIX_SNI_PREFIX_DEFAULT = "";
+
   public static final String SNI_HOST_CHECK_ENABLED_CONFIG = "sni.host.check.enabled";
   protected static final String SNI_HOST_CHECK_ENABLED_DOC =
       "Whether or not to enable SNI host checking in SecureRequestCustomizer. If disabled, "
@@ -1121,6 +1127,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             PREFIX_SNI_CHECK_ENABLED_DOC
         ).define(
+            PREFIX_SNI_PREFIX_CONFIG,
+            Type.STRING,
+            PREFIX_SNI_PREFIX_DEFAULT,
+            Importance.LOW,
+            PREFIX_SNI_PREFIX_DOC
+        ).define(
             LISTENER_PROTOCOL_MAP_CONFIG,
             Type.LIST,
             LISTENER_PROTOCOL_MAP_DEFAULT,
@@ -1489,6 +1501,10 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getPrefixSniCheckEnable() {
     return getBoolean(PREFIX_SNI_CHECK_ENABLED_CONFIG);
+  }
+
+  public final String getPrefixSniPrefix() {
+    return getString(PREFIX_SNI_PREFIX_CONFIG);
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/handlers/PrefixSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/PrefixSniHandler.java
@@ -33,7 +33,11 @@ public class PrefixSniHandler extends HandlerWrapper {
   private static final Logger log = LoggerFactory.getLogger(PrefixSniHandler.class);
   private static final String DOT_SEPARATOR = ".";
   private static final String DASH_SEPARATOR = "-";
-  private static final String PREFIX = "lsrc-";
+  private final String sniPrefix;
+
+  public PrefixSniHandler(String prefix) {
+    this.sniPrefix = prefix;
+  }
 
   @Override
   public void handle(String target, Request baseRequest,
@@ -41,8 +45,8 @@ public class PrefixSniHandler extends HandlerWrapper {
       HttpServletResponse response) throws IOException, ServletException {
     String hostHeader = request.getServerName();
     String sniServerName = getSniServerName(baseRequest);
-
-    if (sniServerName != null && sniServerName.startsWith(PREFIX)) {
+    log.debug("host header: {}, full sni: {}", hostHeader, sniServerName);
+    if (sniServerName != null && sniServerName.startsWith(sniPrefix)) {
       // Extract the prefix from the sniServerName, which is always the first segment before '.'
       // Example: "lsrc-123.us-east-1.aws.private.confluent.cloud" → "lsrc-123"
       String prefix = getFirstPart(sniServerName);

--- a/core/src/main/java/io/confluent/rest/handlers/PrefixSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/PrefixSniHandler.java
@@ -33,6 +33,7 @@ public class PrefixSniHandler extends HandlerWrapper {
   private static final Logger log = LoggerFactory.getLogger(PrefixSniHandler.class);
   private static final String DOT_SEPARATOR = ".";
   private static final String DASH_SEPARATOR = "-";
+  private static final String PREFIX = "lsrc-";
 
   @Override
   public void handle(String target, Request baseRequest,
@@ -41,7 +42,7 @@ public class PrefixSniHandler extends HandlerWrapper {
     String hostHeader = request.getServerName();
     String sniServerName = getSniServerName(baseRequest);
 
-    if (sniServerName != null) {
+    if (sniServerName != null && sniServerName.startsWith(PREFIX)) {
       // Extract the prefix from the sniServerName, which is always the first segment before '.'
       // Example: "lsrc-123.us-east-1.aws.private.confluent.cloud" → "lsrc-123"
       String prefix = getFirstPart(sniServerName);
@@ -57,8 +58,12 @@ public class PrefixSniHandler extends HandlerWrapper {
             hostHeader, prefix, sniServerName);
         baseRequest.setHandled(true);
         response.sendError(MISDIRECTED_REQUEST.getCode(), MISDIRECTED_REQUEST.getMessage());
-        return;
       }
+    } else if (sniServerName != null && !sniServerName.equals(hostHeader)) {
+      // fallback to the original SniHandler logic
+      log.warn("SNI check failed, host header: {}, full sni: {}", hostHeader, sniServerName);
+      baseRequest.setHandled(true);
+      response.sendError(MISDIRECTED_REQUEST.getCode(), MISDIRECTED_REQUEST.getMessage());
     }
     super.handle(target, baseRequest, request, response);
   }

--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -43,6 +43,7 @@ public class SniHandler extends HandlerWrapper {
       HttpServletResponse response) throws IOException, ServletException {
     String serverName = request.getServerName();
     String sniServerName = getSniServerName(baseRequest);
+    log.debug("host header: {}, sni value: {}", serverName, sniServerName);
     if (sniServerName != null && !sniServerName.equals(serverName)) {
       log.debug("Sni check failed, host header: {}, sni value: {}", serverName, sniServerName);
       baseRequest.setHandled(true);

--- a/core/src/test/java/io/confluent/rest/PrefixSniHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/PrefixSniHandlerIntegrationTest.java
@@ -107,6 +107,7 @@ public class PrefixSniHandlerIntegrationTest {
   public void test_http_TenantPrefixSniHandlerEnabled_no_effect(boolean http2Enabled) throws Exception {
     props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
     props.setProperty(RestConfig.PREFIX_SNI_CHECK_ENABLED_CONFIG, "true");
+    props.setProperty(RestConfig.PREFIX_SNI_PREFIX_CONFIG, "lsrc-");
     // http doesn't have SNI concept, SNI is an extension for TLS
     startHttpServer("http");
     startHttpClient("http");
@@ -151,6 +152,7 @@ public class PrefixSniHandlerIntegrationTest {
   public void test_https_TenantPrefixSniHandlerEnabled_wrong_host_421(boolean mTLSEnabled, boolean http2Enabled)
       throws Exception {
     props.setProperty(RestConfig.PREFIX_SNI_CHECK_ENABLED_CONFIG, "true");
+    props.setProperty(RestConfig.PREFIX_SNI_PREFIX_CONFIG, "lsrc-");
     props.setProperty(RestConfig.SNI_HOST_CHECK_ENABLED_CONFIG, "false");
     if (mTLSEnabled) {
       props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
@@ -178,6 +180,7 @@ public class PrefixSniHandlerIntegrationTest {
   public void test_https_TenantPrefixSniHandlerEnabled_fallback_localhost_pass(boolean mTLSEnabled, boolean http2Enabled)
       throws Exception {
     props.setProperty(RestConfig.PREFIX_SNI_CHECK_ENABLED_CONFIG, "true");
+    props.setProperty(RestConfig.PREFIX_SNI_PREFIX_CONFIG, "lsrc-");
     props.setProperty(RestConfig.SNI_HOST_CHECK_ENABLED_CONFIG, "false");
     if (mTLSEnabled) {
       props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
@@ -204,6 +207,7 @@ public class PrefixSniHandlerIntegrationTest {
   public void test_https_TenantPrefixSniHandlerEnabled_fallback_localhost_wrongHeader_421(boolean mTLSEnabled, boolean http2Enabled)
       throws Exception {
     props.setProperty(RestConfig.PREFIX_SNI_CHECK_ENABLED_CONFIG, "true");
+    props.setProperty(RestConfig.PREFIX_SNI_PREFIX_CONFIG, "lsrc-");
     props.setProperty(RestConfig.SNI_HOST_CHECK_ENABLED_CONFIG, "false");
     if (mTLSEnabled) {
       props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
@@ -234,6 +238,7 @@ public class PrefixSniHandlerIntegrationTest {
   public void test_https_TenantPrefixSniHandlerEnabled_same_tenant_pass(boolean mTLSEnabled, boolean http2Enabled)
       throws Exception {
     props.setProperty(RestConfig.PREFIX_SNI_CHECK_ENABLED_CONFIG, "true");
+    props.setProperty(RestConfig.PREFIX_SNI_PREFIX_CONFIG, "lsrc-");
     props.setProperty(RestConfig.SNI_HOST_CHECK_ENABLED_CONFIG, "false");
     if (mTLSEnabled) {
       props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,


### PR DESCRIPTION
In PrefixSniHandler, restrict sni prefix validation when sniServerName starts with `lsrc-`, otherwise fallback to the original SniHandler logic
