### PR TITLE
Fix jakarta usage in SpireTest.java

### DIFF
--- a/core/src/test/java/io/confluent/rest/SpireTest.java
+++ b/core/src/test/java/io/confluent/rest/SpireTest.java
@@ -22,12 +22,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import java.util.Properties;
 import org.eclipse.jetty.server.Server;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.Configurable;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.core.MediaType;
 import org.apache.kafka.test.TestSslUtils;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;


### PR DESCRIPTION
After pint-merging from 7.9.x, we noticed some build issue in the pipeline

https://semaphore.ci.confluent.io/jobs/fa93621f-a1f2-4275-b025-332b6cf960c7.

It seemed 7.9.x are still using javax while the mater branch is using jakarta instead.
We have to fix the dependency naming.