### PR TITLE
temp: for inc-3209, we return a 429 instead of 500

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -616,6 +616,13 @@ public class RestConfig extends AbstractConfig {
 
   protected static final boolean SUPPRESS_STACK_TRACE_IN_RESPONSE_DEFAULT = true;
 
+  public static final String RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG = "sni.host.check.enabled";
+  protected static final String RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DOC =
+          "If true, return 429 Too Many Requests instead of 500 Internal Server Error for errors coming from Jetty " +
+                  "response handlers, the particular error being 'Response does not exist (likely recycled)'. " +
+                  "Default is false.";
+  protected static final boolean RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DEFAULT = false;
+
   static final List<String> SUPPORTED_URI_SCHEMES =
       unmodifiableList(Arrays.asList("http", "https"));
 
@@ -1236,6 +1243,12 @@ public class RestConfig extends AbstractConfig {
             NETWORK_TRAFFIC_RATE_LIMIT_BYTES_PER_SEC_VALIDATOR,
             Importance.LOW,
             NETWORK_TRAFFIC_RATE_LIMIT_BYTES_PER_SEC_DOC
+        ).define(
+            RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG,
+            Type.BOOLEAN,
+            RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DEFAULT,
+            Importance.LOW,
+            RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DOC
         );
   }
 
@@ -1381,6 +1394,10 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getSuppressStackTraceInResponse() {
     return getBoolean(SUPPRESS_STACK_TRACE_IN_RESPONSE);
+  }
+
+  public final boolean getReturn429InsteadOf500ForJettyResponseErrors() {
+    return getBoolean(RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG);
   }
 
   public final List<NamedURI> getListeners() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -616,12 +616,15 @@ public class RestConfig extends AbstractConfig {
 
   protected static final boolean SUPPRESS_STACK_TRACE_IN_RESPONSE_DEFAULT = true;
 
-  public static final String RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG = "sni.host.check.enabled";
+  public static final String RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG =
+          "return.429.instead.of.500.for.jetty.response.errors";
   protected static final String RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DOC =
-          "If true, return 429 Too Many Requests instead of 500 Internal Server Error for errors coming from Jetty " +
-                  "response handlers, the particular error being 'Response does not exist (likely recycled)'. " +
-                  "Default is false.";
-  protected static final boolean RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DEFAULT = false;
+          "If true, return 429 Too Many Requests instead of 500 Internal Server Error "
+                  + "for errors coming from Jetty response handlers, the particular error being "
+                  + "'Response does not exist (likely recycled)'. "
+                  + "Default is false.";
+  protected static final boolean RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_DEFAULT =
+          false;
 
   static final List<String> SUPPORTED_URI_SCHEMES =
       unmodifiableList(Arrays.asList("http", "https"));

--- a/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
@@ -37,13 +37,16 @@ public class GenericExceptionMapper extends DebuggableExceptionMapper<Throwable>
   public Response toResponse(Throwable exc) {
     log.error("Unhandled exception resulting in internal server error response", exc);
 
-    // #inc-3209, instead of returning a 500 error, we return a 429 error temporarily
-    if (exc instanceof IllegalStateException && exc.getMessage() != null
-            && exc.getMessage().contains("Response does not exist (likely recycled)")) {
-      return createResponse(exc, Response.Status.TOO_MANY_REQUESTS.getStatusCode(),
-              Response.Status.TOO_MANY_REQUESTS,
-              Response.Status.TOO_MANY_REQUESTS.getReasonPhrase()).build();
+    if (restConfig.getReturn429InsteadOf500ForJettyResponseErrors()) {
+      // #inc-3209, instead of returning a 500 error, we return a 429 error temporarily
+      if (exc instanceof IllegalStateException && exc.getMessage() != null
+              && exc.getMessage().contains("Response does not exist (likely recycled)")) {
+        return createResponse(exc, Response.Status.TOO_MANY_REQUESTS.getStatusCode(),
+                Response.Status.TOO_MANY_REQUESTS,
+                Response.Status.TOO_MANY_REQUESTS.getReasonPhrase()).build();
+      }
     }
+
     // There's no more specific information about the exception that can be passed back to the user,
     // so we can only use the generic message. Debug mode will append the exception info.
     return createResponse(exc, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),

--- a/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java
@@ -37,6 +37,13 @@ public class GenericExceptionMapper extends DebuggableExceptionMapper<Throwable>
   public Response toResponse(Throwable exc) {
     log.error("Unhandled exception resulting in internal server error response", exc);
 
+    // #inc-3209, instead of returning a 500 error, we return a 429 error temporarily
+    if (exc instanceof IllegalStateException && exc.getMessage() != null
+            && exc.getMessage().contains("Response does not exist (likely recycled)")) {
+      return createResponse(exc, Response.Status.TOO_MANY_REQUESTS.getStatusCode(),
+              Response.Status.TOO_MANY_REQUESTS,
+              Response.Status.TOO_MANY_REQUESTS.getReasonPhrase()).build();
+    }
     // There's no more specific information about the exception that can be passed back to the user,
     // so we can only use the generic message. Debug mode will append the exception info.
     return createResponse(exc, Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(),

--- a/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/KafkaExceptionMapperTest.java
@@ -19,6 +19,7 @@ package io.confluent.rest;
 import io.confluent.rest.entities.ErrorMessage;
 import io.confluent.rest.exceptions.KafkaExceptionMapper;
 import org.apache.kafka.clients.consumer.CommitFailedException;
+import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.errors.AuthenticationException;
 import org.apache.kafka.common.errors.AuthorizationException;
 import org.apache.kafka.common.errors.BrokerNotAvailableException;
@@ -53,6 +54,9 @@ import org.junit.jupiter.api.Test;
 
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
+
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
@@ -74,7 +78,10 @@ public class KafkaExceptionMapperTest {
 
   @BeforeEach
   public void setUp() {
-    exceptionMapper = new KafkaExceptionMapper(null);
+    Map<String, Object> props = new HashMap<>();
+    props.put(RestConfig.RETURN_429_INSTEAD_OF_500_FOR_JETTY_RESPONSE_ERRORS_CONFIG, "false");
+    RestConfig config = new RestConfig(RestConfig.baseConfigDef(), props);
+    exceptionMapper = new KafkaExceptionMapper(config);
   }
 
   @Test


### PR DESCRIPTION
DELETE ACL call is returning 500, the root cause of it is something to do with how jetty is returning the response and having an error in that. We have not figured it out, however the customer is facing severe degradation because of it.

We see that the 500 error is being mapped by the `GenericExceptionMapper`. Based on the conversation in the incident - https://confluent.slack.com/archives/C092AD71BQQ/p1751624023427379?thread_ts=1751556210.161449&cid=C092AD71BQQ the plan is to instead return 429 specifically for this error so that the customer retries the call instead of just exiting.

We also see [this](https://github.com/confluentinc/rest-utils/blob/146b606db52117e4568955a3c5f7f6ba4fe2d655/core/src/main/java/io/confluent/rest/exceptions/GenericExceptionMapper.java#L38) log which suggests `GenericExceptionMapper` is exactly where the Jetty error is being mapped to 500. The openSearch logs - https://opensearch.logs.aws.confluent.cloud/_dashboards/goto/b148c4c70099844063ce1ef7eec19a49?security_tenant=global