### PR TITLE
KNET-10736: Add tenant rate limiting to alleviate noisy neighbor problem

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -807,11 +807,9 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureTenantDosFilter(ServletContextHandler context) {
-    log.info("NNAU: configure tenant dos filter.");
     if (!config.isDosFilterTenantEnabled()) {
       return;
     }
-    log.info("NNAU: tenant dos filter configured.");
 
     TenantDosFilter dosFilter = new TenantDosFilter();
     tenantDosfilterListeners.add(jetty429MetricsListener);
@@ -821,7 +819,6 @@ public abstract class Application<T extends RestConfig> {
     String tenantLimit = String.valueOf(config.getDosFilterTenantMaxRequestsPerSec());
     FilterHolder filterHolder = configureDosFilter(dosFilter, tenantLimit);
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
-    log.info("NNAU: tenant dos filter added to context with limit: {}", tenantLimit);
   }
 
   private void configureGlobalDosFilter(ServletContextHandler context) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -807,6 +807,12 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureTenantDosFilter(ServletContextHandler context) {
+    log.info("NNAU: configure tenant dos filter.");
+    if (!config.isDosFilterTenantEnabled()) {
+      return;
+    }
+    log.info("NNAU: tenant dos filter configured.");
+
     TenantDosFilter dosFilter = new TenantDosFilter(config.getDosFilterTenantExtractionMode());
     tenantDosfilterListeners.add(jetty429MetricsListener);
     JettyDosFilterMultiListener multiListener = new JettyDosFilterMultiListener(
@@ -815,6 +821,7 @@ public abstract class Application<T extends RestConfig> {
     String tenantLimit = String.valueOf(config.getDosFilterTenantMaxRequestsPerSec());
     FilterHolder filterHolder = configureDosFilter(dosFilter, tenantLimit);
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+    log.info("NNAU: tenant dos filter added to context with limit: {}", tenantLimit);
   }
 
   private void configureGlobalDosFilter(ServletContextHandler context) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -124,6 +124,8 @@ public abstract class Application<T extends RestConfig> {
 
   private final List<DoSFilter.Listener> nonGlobalDosfilterListeners = new ArrayList<>();
 
+  private final List<DoSFilter.Listener> tenantDosfilterListeners = new ArrayList<>();
+
   public Application(T config) {
     this(config, "/", null, null, null);
   }
@@ -191,6 +193,15 @@ public abstract class Application<T extends RestConfig> {
   public void addNonGlobalDosfilterListener(
       DoSFilter.Listener listener) {
     this.nonGlobalDosfilterListeners.add(Objects.requireNonNull(listener));
+  }
+
+  /**
+   * Add DosFilter.listener to be called with all other listeners for tenant-dosfilter. This
+   * should be called before configureHandler() is called.
+   */
+  public void addTenantDosfilterListener(
+      DoSFilter.Listener listener) {
+    this.tenantDosfilterListeners.add(Objects.requireNonNull(listener));
   }
 
   protected String requestLogFormat() {
@@ -776,6 +787,11 @@ public abstract class Application<T extends RestConfig> {
 
     // Ensure that the per connection limiter is first - KREST-8391
     configureNonGlobalDosFilter(context);
+
+    if (config.isDosFilterTenantEnabled()) {
+      configureTenantDosFilter(context);
+    }
+
     configureGlobalDosFilter(context);
   }
 
@@ -787,6 +803,17 @@ public abstract class Application<T extends RestConfig> {
     dosFilter.setListener(multiListener);
     FilterHolder filterHolder = configureDosFilter(dosFilter,
         String.valueOf(config.getDosFilterMaxRequestsPerConnectionPerSec()));
+    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+
+  private void configureTenantDosFilter(ServletContextHandler context) {
+    TenantDosFilter dosFilter = new TenantDosFilter(config.getDosFilterTenantExtractionMode());
+    tenantDosfilterListeners.add(jetty429MetricsListener);
+    JettyDosFilterMultiListener multiListener = new JettyDosFilterMultiListener(
+        tenantDosfilterListeners);
+    dosFilter.setListener(multiListener);
+    String tenantLimit = String.valueOf(config.getDosFilterTenantMaxRequestsPerSec());
+    FilterHolder filterHolder = configureDosFilter(dosFilter, tenantLimit);
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
 

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -807,10 +807,6 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureTenantDosFilter(ServletContextHandler context) {
-    if (!config.isDosFilterTenantEnabled()) {
-      return;
-    }
-
     TenantDosFilter dosFilter = new TenantDosFilter();
     tenantDosfilterListeners.add(jetty429MetricsListener);
     JettyDosFilterMultiListener multiListener = new JettyDosFilterMultiListener(

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -813,7 +813,7 @@ public abstract class Application<T extends RestConfig> {
     }
     log.info("NNAU: tenant dos filter configured.");
 
-    TenantDosFilter dosFilter = new TenantDosFilter(config.getDosFilterTenantExtractionMode());
+    TenantDosFilter dosFilter = new TenantDosFilter();
     tenantDosfilterListeners.add(jetty429MetricsListener);
     JettyDosFilterMultiListener multiListener = new JettyDosFilterMultiListener(
         tenantDosfilterListeners);

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -498,7 +498,7 @@ public class RestConfig extends AbstractConfig {
   private static final String DOS_FILTER_TENANT_ENABLED_DOC =
       "Whether to enable per-tenant DoS filtering. This prevents noisy tenants from exhausting "
           + "the global DoS filter. Default is false.";
-  private static final boolean DOS_FILTER_TENANT_ENABLED_DEFAULT = false;
+  private static final boolean DOS_FILTER_TENANT_ENABLED_DEFAULT = true;
 
   private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG =
       "dos.filter.tenant.max.requests.per.sec";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -504,8 +504,8 @@ public class RestConfig extends AbstractConfig {
       "dos.filter.tenant.max.requests.per.sec";
   private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC =
       "Maximum number of requests per second per tenant. Requests in excess of this "
-          + "are first delayed, then throttled. Default is 25.";
-  private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
+          + "are first delayed, then throttled. Default is 10.";
+  private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 10;
 
   public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG =
       "dos.filter.tenant.extraction.mode";

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -498,31 +498,14 @@ public class RestConfig extends AbstractConfig {
   private static final String DOS_FILTER_TENANT_ENABLED_DOC =
       "Whether to enable per-tenant DoS filtering. This prevents noisy tenants from exhausting "
           + "the global DoS filter. Default is false.";
-  private static final boolean DOS_FILTER_TENANT_ENABLED_DEFAULT = true;
+  private static final boolean DOS_FILTER_TENANT_ENABLED_DEFAULT = false;
 
   private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG =
       "dos.filter.tenant.max.requests.per.sec";
   private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC =
       "Maximum number of requests per second per tenant. Requests in excess of this "
           + "are first delayed, then throttled. Default is 10.";
-  private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 10;
-
-  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG =
-      "dos.filter.tenant.extraction.mode";
-  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_V3 = "V3";
-  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_V4 = "V4";
-  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO = "AUTO";
-  protected static final String DOS_FILTER_TENANT_EXTRACTION_MODE_DOC =
-      "Method for extracting tenant ID from requests. V3: extract from URL path "
-          + "(e.g., /kafka/v3/clusters/lkc-xxx/), V4: extract from hostname/SNI "
-          + "(e.g., lkc-xxx-env.domain.com), AUTO: automatically detect based on request. "
-          + "Default is AUTO.";
-  public static final ConfigDef.ValidString DOS_FILTER_TENANT_EXTRACTION_MODE_VALIDATOR =
-      ConfigDef.ValidString.in(
-          DOS_FILTER_TENANT_EXTRACTION_MODE_V3,
-          DOS_FILTER_TENANT_EXTRACTION_MODE_V4,
-          DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO
-      );
+  private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
   private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";
   private static final String SERVER_CONNECTION_LIMIT_DOC =
@@ -1174,13 +1157,6 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC
         ).define(
-            DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG,
-            Type.STRING,
-            DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO,
-            DOS_FILTER_TENANT_EXTRACTION_MODE_VALIDATOR,
-            Importance.LOW,
-            DOS_FILTER_TENANT_EXTRACTION_MODE_DOC
-        ).define(
             SERVER_CONNECTION_LIMIT,
             Type.INT,
             SERVER_CONNECTION_LIMIT_DEFAULT,
@@ -1442,10 +1418,6 @@ public class RestConfig extends AbstractConfig {
 
   public final int getDosFilterTenantMaxRequestsPerSec() {
     return getInt(DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG);
-  }
-
-  public final String getDosFilterTenantExtractionMode() {
-    return getString(DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG);
   }
 
   public final int getServerConnectionLimit() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -494,6 +494,36 @@ public class RestConfig extends AbstractConfig {
           + "Default is false.";
   private static final boolean DOS_FILTER_MANAGED_ATTR_DEFAULT = false;
 
+  private static final String DOS_FILTER_TENANT_ENABLED_CONFIG = "dos.filter.tenant.enabled";
+  private static final String DOS_FILTER_TENANT_ENABLED_DOC =
+      "Whether to enable per-tenant DoS filtering. This prevents noisy tenants from exhausting "
+          + "the global DoS filter. Default is false.";
+  private static final boolean DOS_FILTER_TENANT_ENABLED_DEFAULT = false;
+
+  private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG =
+      "dos.filter.tenant.max.requests.per.sec";
+  private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC =
+      "Maximum number of requests per second per tenant. Requests in excess of this "
+          + "are first delayed, then throttled. Default is 25.";
+  private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
+
+  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG =
+      "dos.filter.tenant.extraction.mode";
+  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_V3 = "V3";
+  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_V4 = "V4";
+  public static final String DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO = "AUTO";
+  protected static final String DOS_FILTER_TENANT_EXTRACTION_MODE_DOC =
+      "Method for extracting tenant ID from requests. V3: extract from URL path "
+          + "(e.g., /kafka/v3/clusters/lkc-xxx/), V4: extract from hostname/SNI "
+          + "(e.g., lkc-xxx-env.domain.com), AUTO: automatically detect based on request. "
+          + "Default is AUTO.";
+  public static final ConfigDef.ValidString DOS_FILTER_TENANT_EXTRACTION_MODE_VALIDATOR =
+      ConfigDef.ValidString.in(
+          DOS_FILTER_TENANT_EXTRACTION_MODE_V3,
+          DOS_FILTER_TENANT_EXTRACTION_MODE_V4,
+          DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO
+      );
+
   private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";
   private static final String SERVER_CONNECTION_LIMIT_DOC =
       "Limits the number of active connections on that server to the configured number. Once that "
@@ -1132,6 +1162,25 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_MANAGED_ATTR_DOC
         ).define(
+            DOS_FILTER_TENANT_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_TENANT_ENABLED_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_TENANT_ENABLED_DOC
+        ).define(
+            DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG,
+            Type.INT,
+            DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC
+        ).define(
+            DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG,
+            Type.STRING,
+            DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO,
+            DOS_FILTER_TENANT_EXTRACTION_MODE_VALIDATOR,
+            Importance.LOW,
+            DOS_FILTER_TENANT_EXTRACTION_MODE_DOC
+        ).define(
             SERVER_CONNECTION_LIMIT,
             Type.INT,
             SERVER_CONNECTION_LIMIT_DEFAULT,
@@ -1385,6 +1434,18 @@ public class RestConfig extends AbstractConfig {
 
   public final boolean getDosFilterManagedAttr() {
     return getBoolean(DOS_FILTER_MANAGED_ATTR_CONFIG);
+  }
+
+  public final boolean isDosFilterTenantEnabled() {
+    return getBoolean(DOS_FILTER_TENANT_ENABLED_CONFIG);
+  }
+
+  public final int getDosFilterTenantMaxRequestsPerSec() {
+    return getInt(DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG);
+  }
+
+  public final String getDosFilterTenantExtractionMode() {
+    return getString(DOS_FILTER_TENANT_EXTRACTION_MODE_CONFIG);
   }
 
   public final int getServerConnectionLimit() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -504,7 +504,7 @@ public class RestConfig extends AbstractConfig {
       "dos.filter.tenant.max.requests.per.sec";
   private static final String DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC =
       "Maximum number of requests per second per tenant. Requests in excess of this "
-          + "are first delayed, then throttled. Default is 10.";
+          + "are first delayed, then throttled. Default is 25";
   private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
   private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -44,7 +44,6 @@ public class TenantDosFilter extends DoSFilter {
     }
 
     HttpServletRequest httpRequest = (HttpServletRequest) request;
-
     String tenantId = TenantUtils.extractTenantId(httpRequest);
     
     if (tenantId.equals(UNKNOWN_TENANT)) {
@@ -52,15 +51,11 @@ public class TenantDosFilter extends DoSFilter {
       // This results in the base DoSFilter to fall back to session-based (if enabled) or
       // IP-based rate limiting as this is the best we can do in this scenario.
       log.warn("Skipping tenant-based rate limiting for unidentified tenant. "
-              + "Request: {} '{}' (Host: '{}')",
+          + "Request: {} '{}' (Host: '{}'), falling back to IP-based rate limiting",
           httpRequest.getMethod(), httpRequest.getRequestURI(), httpRequest.getServerName());
       return null;
     }
 
-    log.debug("Final result - tenant ID: '{}' for request: {} '{}' (Host: '{}')",
-        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(),
-        httpRequest.getServerName());
-    
     return tenantId;
   }
 }

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -60,5 +60,10 @@ public class TenantDosFilter extends DoSFilter {
 
     return tenantId;
   }
+
+  @Override
+  protected boolean isTenantBasedTracking() {
+    return true;
+  }
 }
 

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -29,29 +29,21 @@ import org.slf4j.LoggerFactory;
  * Extends the base DoSFilter to extract tenant IDs from requests and rate limit by tenant.
  */
 public class TenantDosFilter extends DoSFilter {
-  
+
   private static final Logger log = LoggerFactory.getLogger(TenantDosFilter.class);
   
   public TenantDosFilter() {
     super();
-    log.info("NNAU: TenantDosFilter constructor - using automatic tenant extraction");
   }
 
   @Override
   protected String extractUserId(ServletRequest request) {
     if (!(request instanceof HttpServletRequest)) {
-      log.info("NNAU: TENANT DOS: FAILED - Request is not an HttpServletRequest, "
-          + "cannot extract tenant ID");
+      log.warn("Request is not an HttpServletRequest, cannot extract tenant ID");
       return null;
     }
 
     HttpServletRequest httpRequest = (HttpServletRequest) request;
-    log.info("NNAU: TENANT DOS: processing request - Method: {}, URI: '{}', Host: '{}', "
-        + "Query: '{}'", 
-        httpRequest.getMethod(), 
-        httpRequest.getRequestURI(),
-        httpRequest.getServerName(),
-        httpRequest.getQueryString());
 
     String tenantId = TenantUtils.extractTenantId(httpRequest);
     
@@ -59,15 +51,14 @@ public class TenantDosFilter extends DoSFilter {
       // If we can't identify the tenant, return null to skip tenant-based rate limiting.
       // This results in the base DoSFilter to fall back to session-based (if enabled) or
       // IP-based rate limiting as this is the best we can do in this scenario.
-      log.info("NNAU: TENANT DOS: Skipping tenant-based rate limiting for unidentified tenant. "
-          + "Request: {} '{}' (Host: '{}')", 
+      log.warn("Skipping tenant-based rate limiting for unidentified tenant. "
+              + "Request: {} '{}' (Host: '{}')",
           httpRequest.getMethod(), httpRequest.getRequestURI(), httpRequest.getServerName());
       return null;
     }
-    
-    log.info("NNAU: TENANT DOS: final result - tenant ID: '{}' for request: {} '{}' "
-        + "(Host: '{}')",
-        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(), 
+
+    log.debug("Final result - tenant ID: '{}' for request: {} '{}' (Host: '{}')",
+        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(),
         httpRequest.getServerName());
     
     return tenantId;

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -32,12 +32,9 @@ public class TenantDosFilter extends DoSFilter {
   
   private static final Logger log = LoggerFactory.getLogger(TenantDosFilter.class);
   
-  private final String tenantExtractionMode;
-
-  public TenantDosFilter(String tenantExtractionMode) {
+  public TenantDosFilter() {
     super();
-    this.tenantExtractionMode = tenantExtractionMode;
-    log.info("NNAU: TenantDosFilter constructor - extraction mode: '{}'", tenantExtractionMode);
+    log.info("NNAU: TenantDosFilter constructor - using automatic tenant extraction");
   }
 
   @Override
@@ -56,7 +53,7 @@ public class TenantDosFilter extends DoSFilter {
         httpRequest.getServerName(),
         httpRequest.getQueryString());
 
-    String tenantId = TenantUtils.extractTenantId(httpRequest, tenantExtractionMode);
+    String tenantId = TenantUtils.extractTenantId(httpRequest);
     
     if (tenantId.equals(UNKNOWN_TENANT)) {
       // If we can't identify the tenant, return null to skip tenant-based rate limiting.

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import io.confluent.rest.jetty.DoSFilter;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A DoS filter that applies rate limiting per tenant.
+ * This prevents noisy tenants from exhausting the global rate limiter
+ * by grouping requests by tenant ID
+ */
+public final class TenantDosFilter extends DoSFilter {
+
+  private static final Logger log = LoggerFactory.getLogger(TenantDosFilter.class);
+
+  private final String tenantExtractionMode;
+
+  /**
+   * Creates a new TenantDosFilter with the specified tenant extraction mode.
+   *
+   * @param tenantExtractionMode the mode for extracting tenant IDs (V3, V4, or AUTO)
+   */
+  public TenantDosFilter(String tenantExtractionMode) {
+    super();
+    this.tenantExtractionMode = tenantExtractionMode;
+    log.info("TenantDosFilter initialized with extraction mode: {}", tenantExtractionMode);
+  }
+
+  /**
+   * Extracts the tenant ID from the request to use as key for rate limiting.
+   *
+   * @param request the servlet request
+   * @return the tenant ID to use for rate limiting, or "UNKNOWN" if extraction fails
+   */
+  @Override
+  protected String extractUserId(ServletRequest request) {
+    if (!(request instanceof HttpServletRequest)) {
+      log.debug("Request is not an HttpServletRequest, cannot extract tenant ID");
+      return "UNKNOWN";
+    }
+
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    String tenantId = TenantUtils.extractTenantId(httpRequest, tenantExtractionMode);
+
+    log.debug("Extracted tenant ID: {} for request: {} {}",
+        tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
+
+    return tenantId;
+  }
+}
+

--- a/core/src/main/java/io/confluent/rest/TenantDosFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDosFilter.java
@@ -41,7 +41,7 @@ public final class TenantDosFilter extends DoSFilter {
   public TenantDosFilter(String tenantExtractionMode) {
     super();
     this.tenantExtractionMode = tenantExtractionMode;
-    log.info("TenantDosFilter initialized with extraction mode: {}", tenantExtractionMode);
+    log.info("NNAU: TenantDosFilter constructor - extraction mode: {}", tenantExtractionMode);
   }
 
   /**
@@ -53,14 +53,20 @@ public final class TenantDosFilter extends DoSFilter {
   @Override
   protected String extractUserId(ServletRequest request) {
     if (!(request instanceof HttpServletRequest)) {
-      log.debug("Request is not an HttpServletRequest, cannot extract tenant ID");
+      log.info("NNAU: Request is not an HttpServletRequest, cannot extract tenant ID");
       return "UNKNOWN";
     }
 
     HttpServletRequest httpRequest = (HttpServletRequest) request;
+    log.info("NNAU: TENANT DOS: url {}, query {}, host {}, method {}", 
+        httpRequest.getRequestURL(), 
+        httpRequest.getQueryString(),
+        httpRequest.getServerName(),
+        httpRequest.getMethod());
+    
     String tenantId = TenantUtils.extractTenantId(httpRequest, tenantExtractionMode);
 
-    log.debug("Extracted tenant ID: {} for request: {} {}",
+    log.info("NNAU: TENANT DOS: extracted tenant ID: {} for request: {} {}",
         tenantId, httpRequest.getMethod(), httpRequest.getRequestURI());
 
     return tenantId;

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -27,11 +27,10 @@ import org.slf4j.LoggerFactory;
 public final class TenantUtils {
 
   private static final Logger log = LoggerFactory.getLogger(TenantUtils.class);
-
+  public static final String UNKNOWN_TENANT = "UNKNOWN";
 
   private static final String V3_CLUSTER_PREFIX = "/kafka/v3/clusters/";
   private static final String LKC_ID_PREFIX = "lkc-";
-  private static final String UNKNOWN_TENANT = "UNKNOWN";
 
   private TenantUtils() {}
 

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class for extracting tenant IDs from HTTP requests.
+ * Supports both V3 and V4 network for tenant identification.
+ */
+public final class TenantUtils {
+
+  private static final Logger log = LoggerFactory.getLogger(TenantUtils.class);
+
+  // V3 pattern: /kafka/v3/clusters/lkc-xxx/...
+  // TODO: Regex matching is slow, optimize if performance becomes an issue
+  private static final Pattern V3_TENANT_PATTERN =
+      Pattern.compile("/kafka/v3/clusters/(lkc-[a-zA-Z0-9]+)/");
+
+  // V4 pattern: lkc-xxx-env.domain.com
+  private static final Pattern V4_TENANT_PATTERN =
+      Pattern.compile("^(lkc-[a-zA-Z0-9]+)-");
+
+  private TenantUtils() {}
+
+  /**
+   * Extracts tenant ID from an HTTP request based on the specified extraction mode.
+   *
+   * @param request the HTTP request
+   * @param extractionMode the extraction mode (V3, V4, or AUTO)
+   * @return the tenant ID, or "UNKNOWN" if extraction fails
+   */
+  public static String extractTenantId(HttpServletRequest request, String extractionMode) {
+    switch (extractionMode.toUpperCase()) {
+      case RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3:
+        return extractTenantIdFromV3(request);
+      case RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4:
+        return extractTenantIdFromV4(request);
+      case RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO:
+        return extractTenantIdAuto(request);
+      default:
+        log.warn("Unknown tenant extraction mode: {}, falling back to AUTO", extractionMode);
+        return extractTenantIdAuto(request);
+    }
+  }
+
+  /**
+   * Extracts tenant ID from URL path (V3 pattern).
+   * Example: /kafka/v3/clusters/lkc-devccovmzyj/topics => lkc-devccovmzyj
+   */
+  private static String extractTenantIdFromV3(HttpServletRequest request) {
+    String requestURI = request.getRequestURI();
+    if (requestURI == null) {
+      log.debug("Request URI is null, cannot extract tenant ID from path");
+      return "UNKNOWN";
+    }
+
+    Matcher matcher = V3_TENANT_PATTERN.matcher(requestURI);
+    if (matcher.find()) {
+      String tenantId = matcher.group(1);
+      log.debug("Extracted tenant ID from path: {} from URI: {}", tenantId, requestURI);
+      return tenantId;
+    }
+
+    log.debug("Could not extract tenant ID from path: {}", requestURI);
+    return "UNKNOWN";
+  }
+
+  /**
+   * Extracts tenant ID from hostname (V4 pattern).
+   * Example: lkc-6787w2-env5qj75n.us-west-2.aws.private.glb.stag.cpdev.cloud => lkc-6787w2
+   */
+  private static String extractTenantIdFromV4(HttpServletRequest request) {
+    String serverName = request.getServerName();
+    if (serverName == null) {
+      log.debug("Server name is null, cannot extract tenant ID from hostname");
+      return "UNKNOWN";
+    }
+
+    Matcher matcher = V4_TENANT_PATTERN.matcher(serverName);
+    if (matcher.find()) {
+      String tenantId = matcher.group(1);
+      log.debug("Extracted tenant ID from hostname: {} from server: {}", tenantId, serverName);
+      return tenantId;
+    }
+
+    log.debug("Could not extract tenant ID from hostname: {}", serverName);
+    return "UNKNOWN";
+  }
+
+  /**
+   * Automatically detects the tenant extraction method by trying both V3 and V4 patterns.
+   */
+  private static String extractTenantIdAuto(HttpServletRequest request) {
+    String tenantId = extractTenantIdFromV3(request);
+    if (!"UNKNOWN".equals(tenantId)) {
+      return tenantId;
+    }
+
+    tenantId = extractTenantIdFromV4(request);
+    if (!"UNKNOWN".equals(tenantId)) {
+      return tenantId;
+    }
+
+    log.debug("Could not extract tenant ID from request. URI: {}, Host: {}",
+        request.getRequestURI(), request.getServerName());
+    return "UNKNOWN";
+  }
+}

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -86,11 +86,11 @@ public final class TenantUtils {
 
     int endIndex = startIndex + LKC_ID_PREFIX.length();
     while (endIndex < requestURI.length() 
-           && requestURI.charAt(endIndex) != '/' 
            && Character.isLetterOrDigit(requestURI.charAt(endIndex))) {
       endIndex++;
     }
 
+    // Validate we found at least one character after the prefix
     if (endIndex == startIndex + LKC_ID_PREFIX.length()) {
       log.info("NNAU: TENANT V3: No valid tenant ID characters found in path: {}", requestURI);
       return UNKNOWN_TENANT;
@@ -120,10 +120,8 @@ public final class TenantUtils {
       endIndex++;
     }
 
-    // Validate we found at least one character and ended at a dash
-    if (endIndex == LKC_ID_PREFIX.length()
-        || endIndex >= serverName.length() 
-        || serverName.charAt(endIndex) != '-') {
+    // Validate we found at least one character after the prefix
+    if (endIndex == LKC_ID_PREFIX.length()) {
       log.info("NNAU: TENANT V4: Invalid tenant ID format in hostname: {}", serverName);
       return UNKNOWN_TENANT;
     }

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -49,6 +49,7 @@ public final class TenantUtils {
    * @return the tenant ID, or "UNKNOWN" if extraction fails
    */
   public static String extractTenantId(HttpServletRequest request, String extractionMode) {
+    log.info("NNAU: TENANT UTILS: extracting tenant ID with mode: {}", extractionMode);
     switch (extractionMode.toUpperCase()) {
       case RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3:
         return extractTenantIdFromV3(request);
@@ -68,19 +69,20 @@ public final class TenantUtils {
    */
   private static String extractTenantIdFromV3(HttpServletRequest request) {
     String requestURI = request.getRequestURI();
+    log.info("NNAU: TENANT V3: checking URI: {}", requestURI);
     if (requestURI == null) {
-      log.debug("Request URI is null, cannot extract tenant ID from path");
+      log.info("NNAU: Request URI is null, cannot extract tenant ID from path");
       return "UNKNOWN";
     }
 
     Matcher matcher = V3_TENANT_PATTERN.matcher(requestURI);
     if (matcher.find()) {
       String tenantId = matcher.group(1);
-      log.debug("Extracted tenant ID from path: {} from URI: {}", tenantId, requestURI);
+      log.info("NNAU: TENANT V3: extracted tenant ID: {} from URI: {}", tenantId, requestURI);
       return tenantId;
     }
 
-    log.debug("Could not extract tenant ID from path: {}", requestURI);
+    log.info("NNAU: TENANT V3: could not extract tenant ID from path: {}", requestURI);
     return "UNKNOWN";
   }
 
@@ -90,19 +92,20 @@ public final class TenantUtils {
    */
   private static String extractTenantIdFromV4(HttpServletRequest request) {
     String serverName = request.getServerName();
+    log.info("NNAU: TENANT V4: checking hostname: {}", serverName);
     if (serverName == null) {
-      log.debug("Server name is null, cannot extract tenant ID from hostname");
+      log.info("NNAU: Server name is null, cannot extract tenant ID from hostname");
       return "UNKNOWN";
     }
 
     Matcher matcher = V4_TENANT_PATTERN.matcher(serverName);
     if (matcher.find()) {
       String tenantId = matcher.group(1);
-      log.debug("Extracted tenant ID from hostname: {} from server: {}", tenantId, serverName);
+      log.info("NNAU: TENANT V4: extracted tenant ID: {} from server: {}", tenantId, serverName);
       return tenantId;
     }
 
-    log.debug("Could not extract tenant ID from hostname: {}", serverName);
+    log.info("NNAU: TENANT V4: could not extract tenant ID from hostname: {}", serverName);
     return "UNKNOWN";
   }
 
@@ -110,17 +113,21 @@ public final class TenantUtils {
    * Automatically detects the tenant extraction method by trying both V3 and V4 patterns.
    */
   private static String extractTenantIdAuto(HttpServletRequest request) {
+    log.info("NNAU: TENANT AUTO: trying V3 extraction first");
     String tenantId = extractTenantIdFromV3(request);
     if (!"UNKNOWN".equals(tenantId)) {
+      log.info("NNAU: TENANT AUTO: V3 extraction successful: {}", tenantId);
       return tenantId;
     }
 
+    log.info("NNAU: TENANT AUTO: V3 failed, trying V4 extraction");
     tenantId = extractTenantIdFromV4(request);
     if (!"UNKNOWN".equals(tenantId)) {
+      log.info("NNAU: TENANT AUTO: V4 extraction successful: {}", tenantId);
       return tenantId;
     }
 
-    log.debug("Could not extract tenant ID from request. URI: {}, Host: {}",
+    log.info("NNAU: TENANT AUTO: both V3 and V4 failed. URI: {}, Host: {}",
         request.getRequestURI(), request.getServerName());
     return "UNKNOWN";
   }

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -43,7 +43,7 @@ public final class TenantUtils {
    * @return the tenant ID, or "UNKNOWN" if extraction fails
    */
   public static String extractTenantId(HttpServletRequest request, String extractionMode) {
-    log.info("NNAU: TENANT UTILS: extracting tenant ID with mode: {} for URI: {} and Host: {}", 
+    log.info("NNAU: TENANT UTILS: extracting tenant ID with mode: {} for URI: {} and Host: {}",
         extractionMode, request.getRequestURI(), request.getServerName());
     switch (extractionMode.toUpperCase()) {
       case RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3:
@@ -65,7 +65,7 @@ public final class TenantUtils {
    */
   private static String extractTenantIdFromV3(HttpServletRequest request) {
     String requestURI = request.getRequestURI();
-    log.info("NNAU: TENANT V3: checking URI: {}", requestURI);
+    log.info("NNAU: TENANT V3 (String parse): checking URI: {}", requestURI);
     if (requestURI == null) {
       log.info("NNAU: TENANT V3: Request URI is null, cannot extract tenant ID from path");
       return UNKNOWN_TENANT;
@@ -107,7 +107,7 @@ public final class TenantUtils {
    */
   private static String extractTenantIdFromV4(HttpServletRequest request) {
     String serverName = request.getServerName();
-    log.info("NNAU: TENANT V4: checking hostname: {}", serverName);
+    log.info("NNAU: TENANT V4 (String parse): checking hostname: {}", serverName);
     if (serverName == null || !serverName.startsWith(LKC_ID_PREFIX)) {
       log.info("NNAU: TENANT V4: Server name is null or doesn't start with tenant prefix: {}", 
           serverName);
@@ -137,7 +137,7 @@ public final class TenantUtils {
    * Automatically detects the tenant extraction method by trying both V3 and V4 patterns.
    */
   private static String extractTenantIdAuto(HttpServletRequest request) {
-    log.info("NNAU: TENANT AUTO: trying V3 extraction first for URI: '{}' and Host: '{}'", 
+    log.info("NNAU: TENANT AUTO: trying V3 extraction first for URI: '{}' and Host: '{}'",
         request.getRequestURI(), request.getServerName());
     String tenantId = extractTenantIdFromV3(request);
     if (!UNKNOWN_TENANT.equals(tenantId)) {

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -71,7 +71,7 @@ public final class TenantUtils {
     String requestURI = request.getRequestURI();
     log.info("NNAU: TENANT V3: checking URI: {}", requestURI);
     if (requestURI == null) {
-      log.info("NNAU: Request URI is null, cannot extract tenant ID from path");
+      log.info("NNAU: TENANT V3: Request URI is null, cannot extract tenant ID from path");
       return "UNKNOWN";
     }
 
@@ -94,7 +94,7 @@ public final class TenantUtils {
     String serverName = request.getServerName();
     log.info("NNAU: TENANT V4: checking hostname: {}", serverName);
     if (serverName == null) {
-      log.info("NNAU: Server name is null, cannot extract tenant ID from hostname");
+      log.info("NNAU: TENANT V4: Server name is null, cannot extract tenant ID from hostname");
       return "UNKNOWN";
     }
 

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -28,11 +28,10 @@ public final class TenantUtils {
 
   private static final Logger log = LoggerFactory.getLogger(TenantUtils.class);
 
-  // V3 path prefix to search for
+
   private static final String V3_CLUSTER_PREFIX = "/kafka/v3/clusters/";
-  
-  // V4 tenant prefix
   private static final String LKC_ID_PREFIX = "lkc-";
+  private static final String UNKNOWN_TENANT = "UNKNOWN";
 
   private TenantUtils() {}
 
@@ -69,20 +68,20 @@ public final class TenantUtils {
     log.info("NNAU: TENANT V3: checking URI: {}", requestURI);
     if (requestURI == null) {
       log.info("NNAU: TENANT V3: Request URI is null, cannot extract tenant ID from path");
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     // Find the V3 cluster prefix
     int prefixIndex = requestURI.indexOf(V3_CLUSTER_PREFIX);
     if (prefixIndex == -1) {
       log.info("NNAU: TENANT V3: V3 cluster prefix not found in path: {}", requestURI);
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     int startIndex = prefixIndex + V3_CLUSTER_PREFIX.length();
     if (startIndex >= requestURI.length() || !requestURI.startsWith(LKC_ID_PREFIX, startIndex)) {
       log.info("NNAU: TENANT V3: No tenant ID found after cluster prefix in path: {}", requestURI);
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     int endIndex = startIndex + LKC_ID_PREFIX.length();
@@ -94,7 +93,7 @@ public final class TenantUtils {
 
     if (endIndex == startIndex + LKC_ID_PREFIX.length()) {
       log.info("NNAU: TENANT V3: No valid tenant ID characters found in path: {}", requestURI);
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     String tenantId = requestURI.substring(startIndex, endIndex);
@@ -112,7 +111,7 @@ public final class TenantUtils {
     if (serverName == null || !serverName.startsWith(LKC_ID_PREFIX)) {
       log.info("NNAU: TENANT V4: Server name is null or doesn't start with tenant prefix: {}", 
           serverName);
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     int endIndex = LKC_ID_PREFIX.length();
@@ -126,7 +125,7 @@ public final class TenantUtils {
         || endIndex >= serverName.length() 
         || serverName.charAt(endIndex) != '-') {
       log.info("NNAU: TENANT V4: Invalid tenant ID format in hostname: {}", serverName);
-      return "UNKNOWN";
+      return UNKNOWN_TENANT;
     }
 
     String tenantId = serverName.substring(0, endIndex);
@@ -141,7 +140,7 @@ public final class TenantUtils {
     log.info("NNAU: TENANT AUTO: trying V3 extraction first for URI: '{}' and Host: '{}'", 
         request.getRequestURI(), request.getServerName());
     String tenantId = extractTenantIdFromV3(request);
-    if (!"UNKNOWN".equals(tenantId)) {
+    if (!UNKNOWN_TENANT.equals(tenantId)) {
       log.info("NNAU: TENANT AUTO: V3 extraction successful: '{}'", tenantId);
       return tenantId;
     }
@@ -149,13 +148,13 @@ public final class TenantUtils {
     log.info("NNAU: TENANT AUTO: V3 failed, trying V4 extraction for Host: '{}'", 
         request.getServerName());
     tenantId = extractTenantIdFromV4(request);
-    if (!"UNKNOWN".equals(tenantId)) {
+    if (!UNKNOWN_TENANT.equals(tenantId)) {
       log.info("NNAU: TENANT AUTO: V4 extraction successful: '{}'", tenantId);
       return tenantId;
     }
 
     log.info("NNAU: TENANT AUTO: both V3 and V4 failed. URI: {}, Host: {}",
         request.getRequestURI(), request.getServerName());
-    return "UNKNOWN";
+    return UNKNOWN_TENANT;
   }
 }

--- a/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.TestInfo;
  * This test makes sure when DosFilter rejects requests, then configured dosfilter-listeners are
  * run, including the mandatory Jetty429MetricsDosFilterListener.
  */
-// @Tag("IntegrationTest") - Temporarily removed for testing
+@Tag("IntegrationTest")
 class JettyDosFilterMultiListenerIntegrationTest {
 
   private static final int DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC = 25;

--- a/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
@@ -60,7 +60,7 @@ import org.junit.jupiter.api.TestInfo;
  * This test makes sure when DosFilter rejects requests, then configured dosfilter-listeners are
  * run, including the mandatory Jetty429MetricsDosFilterListener.
  */
-@Tag("IntegrationTest")
+// @Tag("IntegrationTest") - Temporarily removed for testing
 class JettyDosFilterMultiListenerIntegrationTest {
 
   private static final int DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC = 25;
@@ -85,6 +85,7 @@ class JettyDosFilterMultiListenerIntegrationTest {
     props.put(RestConfig.METRICS_REPORTER_CLASSES_CONFIG, "io.confluent.rest.TestMetricsReporter");
     // enabled dos filters
     props.put("dos.filter.enabled", true);
+    props.put("dos.filter.tenant.enabled", true);
     props.put("dos.filter.delay.ms", -1L); // to reject request, i.e 429
     
     String testName = testInfo.getDisplayName();

--- a/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/JettyDosFilterMultiListenerIntegrationTest.java
@@ -71,12 +71,14 @@ class JettyDosFilterMultiListenerIntegrationTest {
   private Client client;
   private final TestDosFilterListener nonGlobalDosFilterListener = new TestDosFilterListener();
   private final TestDosFilterListener globalDosFilterListener = new TestDosFilterListener();
+  private final TestDosFilterListener tenantDosFilterListener = new TestDosFilterListener();
 
   @BeforeEach
   public void setUp(TestInfo testInfo) throws Exception {
     TestMetricsReporter.reset();
     nonGlobalDosFilterListener.rejectedCounter.set(0);
     globalDosFilterListener.rejectedCounter.set(0);
+    tenantDosFilterListener.rejectedCounter.set(0);
 
     Properties props = new Properties();
     props.setProperty("debug", "false");
@@ -84,31 +86,42 @@ class JettyDosFilterMultiListenerIntegrationTest {
     // enabled dos filters
     props.put("dos.filter.enabled", true);
     props.put("dos.filter.delay.ms", -1L); // to reject request, i.e 429
-    if (testInfo.getDisplayName().contains(
-        "test_dosFilterMultiListener_withGlobalDosFilterRejecting_CheckRelevantListenersCalled")) {
-      // Make sure global-dos-filter kicks in before non-global-dos-filter. So
-      // set non-global/per-connection limit to be higher, 100, than the global limit, 25.
-      // Set non-global limit.
-      props.put("dos.filter.max.requests.per.connection.per.sec",
-          100);
-      // Set the global limit
-      props.put("dos.filter.max.requests.per.sec",
-          DOS_FILTER_MAX_REQUESTS_PER_SEC);
+    
+    String testName = testInfo.getDisplayName();
+    if (testName.contains("test_dosFilterMultiListener_withGlobalDosFilterRejecting_CheckRelevantListenersCalled")) {
+      // Configure so global DoS filter triggers first
+      // Execution order: non-global -> tenant -> global
+      // Set limits: global(25) < non-global(100) < tenant(150)
+      props.put("dos.filter.max.requests.per.connection.per.sec", 100);
+      props.put("dos.filter.max.requests.per.sec", DOS_FILTER_MAX_REQUESTS_PER_SEC); // 25
+      props.put("dos.filter.tenant.max.requests.per.sec", 150);
+    } else if (testName.contains("test_dosFilterMultiListener_withTenantDosFilterRejecting_CheckRelevantListenersCalled")) {
+      // Configure so tenant DoS filter triggers first  
+      // Execution order: non-global -> tenant -> global
+      // Set limits: tenant(25) < non-global(100) < global(150)
+      props.put("dos.filter.max.requests.per.connection.per.sec", 100);
+      props.put("dos.filter.max.requests.per.sec", 150);
+      props.put("dos.filter.tenant.max.requests.per.sec", DOS_FILTER_MAX_REQUESTS_PER_SEC); // 25
+    } else if (testName.contains("test_dosFilterMultiListener_withNonGlobalDosFilterRejecting_CheckRelevantListenersCalled")) {
+      // Configure so non-global DoS filter triggers first
+      // Execution order: non-global -> tenant -> global  
+      // Set limits: non-global(25) < tenant(100) < global(150)
+      props.put("dos.filter.max.requests.per.connection.per.sec", DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC); // 25
+      props.put("dos.filter.max.requests.per.sec", 150);
+      props.put("dos.filter.tenant.max.requests.per.sec", 100);
     } else {
-      // Make sure non-global-dos-filter kicks in before the global-dos-filter. So
-      // set non-global/per-connection limit to be lower, 25, than the global limit, 100.
-      // Set non-global limit.
-      props.put("dos.filter.max.requests.per.connection.per.sec",
-          DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC);
-      // Set the global limit
-      props.put("dos.filter.max.requests.per.sec",
-          100);
+      // Default configuration for tests that don't expect rejections
+      // Set all limits high enough that no filter should trigger with normal test loads
+      props.put("dos.filter.max.requests.per.connection.per.sec", 1000);
+      props.put("dos.filter.max.requests.per.sec", 1000);
+      props.put("dos.filter.tenant.max.requests.per.sec", 1000);
     }
 
     TestRestConfig config = new TestRestConfig(props);
     ApplicationWithDoSFilterEnabled app = new ApplicationWithDoSFilterEnabled(config);
     app.addNonGlobalDosfilterListener(nonGlobalDosFilterListener);
     app.addGlobalDosfilterListener(globalDosFilterListener);
+    app.addTenantDosfilterListener(tenantDosFilterListener);
     app.createServer();
     server = app.createServer();
     server.start();
@@ -186,6 +199,8 @@ class JettyDosFilterMultiListenerIntegrationTest {
     assertEquals(nonGlobalDosFilterListener.rejectedCounter.get(), 0);
     // Verify that global-dos-filter-listener wasn't called.
     assertEquals(globalDosFilterListener.rejectedCounter.get(), 0);
+    // Verify that tenant-dos-filter-listener wasn't called.
+    assertEquals(tenantDosFilterListener.rejectedCounter.get(), 0);
   }
 
   /**
@@ -272,6 +287,8 @@ class JettyDosFilterMultiListenerIntegrationTest {
         (totalRequests - DOS_FILTER_MAX_REQUESTS_PER_CONNECTION_PER_SEC)) <= 1);
     // Verify that global-dos-filter-listener wasn't called.
     assertEquals(globalDosFilterListener.rejectedCounter.get(), 0);
+    // Verify that tenant-dos-filter-listener wasn't called.
+    assertEquals(tenantDosFilterListener.rejectedCounter.get(), 0);
   }
 
   /**
@@ -355,6 +372,93 @@ class JettyDosFilterMultiListenerIntegrationTest {
         (totalRequests - DOS_FILTER_MAX_REQUESTS_PER_SEC)) <= 1);
     // Verify that non-global-dos-filter-listener wasn't called.
     assertEquals(nonGlobalDosFilterListener.rejectedCounter.get(), 0);
+    // Verify that tenant-dos-filter-listener wasn't called.
+    assertEquals(tenantDosFilterListener.rejectedCounter.get(), 0);
+  }
+
+  /**
+   * This test will query such that tenant dos-filter kicks-in, so requests are rejected. Check
+   * that tenant-dos-filter-listener and Jetty429MetricsDosFilterListener are called.
+   */
+  @RepeatedTest(value = 5, name = LONG_DISPLAY_NAME)
+  @DisplayName("test_dosFilterMultiListener_withTenantDosFilterRejecting_CheckRelevantListenersCalled")
+  public void test_dosFilterMultiListener_withTenantDosFilterRejecting_CheckRelevantListenersCalled() {
+    // send 100 requests, in which 20 are warmup, in theory,
+    // - the first 25 (including warmups) are accepted, so response200s=5
+    // - the rest of 75 are rejected
+    final int warmupRequests = 20;
+    final int totalRequests = 100;
+
+    int response200s = hammerAtConstantRate(server.getURI(),
+        "/public/hello", Duration.ofMillis(1),
+        warmupRequests, totalRequests
+    );
+
+    // Verify Jetty429MetricsDosFilterListener is called.
+    // check for 200s
+    // due to the timing of exactly 1 second in DosFilter,
+    // sometime we might get one more response200,
+    // so the assertion is changed to relax the condition
+    assertTrue(Math.abs((DOS_FILTER_MAX_REQUESTS_PER_SEC - warmupRequests) - response200s) <= 1);
+    // Check 429 metrics
+    for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
+      if (metric.metricName().name().equals("request-error-count")
+          && metric.metricName().group().equals("jetty-metrics")
+          && metric.metricName().tags()
+          .getOrDefault("http_status_code", "").equals("429")) {
+        assertTrue(metric.measurable().toString().toLowerCase().startsWith("sampledstat"));
+        Object metricValue = metric.metricValue();
+        assertTrue(metricValue instanceof Double, "Error count metrics should be measurable");
+        double errorCountValue = (double) metricValue;
+        // due to the timing of exactly 1 second in DosFilter,
+        // sometime we might get one more response200,
+        // so the assertion is changed to relax the condition
+        assertTrue(Math.abs((totalRequests - DOS_FILTER_MAX_REQUESTS_PER_SEC) -
+            errorCountValue) <= 1);
+      }
+
+      if (metric.metricName().name().equals("request-error-total")
+          && metric.metricName().group().equals("jetty-metrics")
+          && metric.metricName().tags()
+          .getOrDefault("http_status_code", "").equals("429")) {
+        assertTrue(metric.measurable().toString().toLowerCase().startsWith("cumulativesum"));
+        Object metricValue = metric.metricValue();
+        assertTrue(metricValue instanceof Double, "Error total metrics should be measurable");
+        double errorTotalValue = (double) metricValue;
+        // due to the timing of exactly 1 second in DosFilter,
+        // sometime we might get one more response200,
+        // so the assertion is changed to relax the condition
+        assertTrue(Math.abs((totalRequests - DOS_FILTER_MAX_REQUESTS_PER_SEC) -
+            errorTotalValue) <= 1);
+      }
+
+      if (metric.metricName().name().equals("request-error-rate")
+          && metric.metricName().group().equals("jetty-metrics")
+          && metric.metricName().tags()
+          .getOrDefault("http_status_code", "").equals("429")) {
+        assertTrue(metric.measurable().toString().toLowerCase().startsWith("rate"));
+        Object metricValue = metric.metricValue();
+        assertTrue(metricValue instanceof Double, "Error rate metrics should be measurable");
+        double errorRateValue = (double) metricValue;
+        assertEquals(
+            // 30 seconds is the approximate window size for Rate that comes from the calculation of
+            // org.apache.kafka.common.metrics.stats.Rate.windowSize
+            Math.floor(
+                (double) (totalRequests - DOS_FILTER_MAX_REQUESTS_PER_SEC) / 30),
+            Math.floor(errorRateValue), "Actual: " + errorRateValue);
+      }
+    }
+
+    // Verify that tenant-dos-filter-listener was called.
+    // due to the timing of exactly 1 second in DosFilter,
+    // sometime we might get one more response200,
+    // so the assertion is changed to relax the condition
+    assertTrue(Math.abs(tenantDosFilterListener.rejectedCounter.get() -
+        (totalRequests - DOS_FILTER_MAX_REQUESTS_PER_SEC)) <= 1);
+    // Verify that non-global-dos-filter-listener wasn't called.
+    assertEquals(nonGlobalDosFilterListener.rejectedCounter.get(), 0);
+    // Verify that global-dos-filter-listener wasn't called.
+    assertEquals(globalDosFilterListener.rejectedCounter.get(), 0);
   }
 
   // Send many concurrent requests and return the number of requests with 200 status

--- a/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
+++ b/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
@@ -26,42 +26,42 @@ import org.junit.jupiter.api.Test;
 public class TenantUtilsTest {
 
   @Test
-  public void testV3TenantIdExtraction() {
+  public void testPathBasedTenantIdExtraction() {
     HttpServletRequest request = mock(HttpServletRequest.class);
     
-    // test successful V3 extraction - standard case
+    // test successful path-based extraction - standard case
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devccovmzyj/topics");
-    String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    String tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-devccovmzyj", tenantId);
     
     // test V3 extraction with different endpoint
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-abc123def/consumer-groups");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123def", tenantId);
     
     // test V3 extraction with realistic tenant ID from documentation
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-6787w2/topics");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-6787w2", tenantId);
     
     // test V3 extraction with path ending at tenant ID (previously failing case)
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devc80y73q");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-devc80y73q", tenantId);
     
     // test V3 extraction failure - wrong pattern
     when(request.getRequestURI()).thenReturn("/api/v1/some/other/path");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     // test V3 extraction failure - null URI
     when(request.getRequestURI()).thenReturn(null);
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
   }
 
   @Test
-  public void testV4TenantIdExtraction() {
+  public void testHostnameBasedTenantIdExtraction() {
     HttpServletRequest request = mock(HttpServletRequest.class);
 
     // ========================================================================================
@@ -70,69 +70,69 @@ public class TenantUtilsTest {
 
     // === Basic V4 patterns ===
     when(request.getServerName()).thenReturn("lkc-6787w2-env5qj75n.us-west-2.aws.private.glb.stag.cpdev.cloud");
-    String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    String tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-6787w2", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-abc123def-prod789.us-east-1.aws.private.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123def", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-xyz123-env.eu-central-1.azure.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-xyz123", tenantId);
 
     // === V4 GLB-based patterns ===
     when(request.getServerName()).thenReturn("lkc-2v531-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-2v531", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-3d253-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-3d253", tenantId);
 
     // === V4 non-GLB (Private DNS Phase 1) patterns ===
     when(request.getServerName()).thenReturn("lkc-2v531.domz6wj0p.us-west-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-2v531", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-2v531-00aa.usw1-az1.domz6wj0p.us-west-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-2v531", tenantId);
 
     // === V4 concurrent endpoints (Private DNS Phase 2) ===
     when(request.getServerName()).thenReturn("lkc-2v531-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-2v531", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-2v531.lg1y3.us-west-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-2v531", tenantId);
 
     // === Enterprise SKU patterns ===
     when(request.getServerName()).thenReturn("lkc-abc123.us-west-2.aws.private.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-abc123-9ae1.us-west-2.aws.private.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123", tenantId);
 
     // === Private Network Interface-Based (Freight/Enterprise) patterns ===
     when(request.getServerName()).thenReturn("lkc-devc2qrwyy-apxxx.us-west-2.aws.accesspoint.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-devc2qrwyy", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-devc2qrwyy-1234-apxxx.usw2-az2.us-west-2.aws.accesspoint.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-devc2qrwyy", tenantId);
 
     // === Trusted shared network scheme patterns ===
     when(request.getServerName()).thenReturn("lkc-abc123.us-west-2.aws.intranet.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123", tenantId);
     
     when(request.getServerName()).thenReturn("lkc-abc123-9ae1.usw2-az1.us-west-2.aws.intranet.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123", tenantId);
 
     // ========================================================================================
@@ -141,81 +141,81 @@ public class TenantUtilsTest {
 
     // === Broker endpoints (start with e-) ===
     when(request.getServerName()).thenReturn("e-00aa-usw1-az1-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     when(request.getServerName()).thenReturn("e-1d39.use1-az1.domjpe506kp.us-east-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
 
     // === Kafka API endpoints (start with lkaclkc-) ===
     when(request.getServerName()).thenReturn("lkaclkc-3d253-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     when(request.getServerName()).thenReturn("lkaclkc-2v531.domz6wj0p.us-west-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
 
     // === KSQL endpoints (start with pksqlc-) ===
     when(request.getServerName()).thenReturn("pksqlc-3d235-lg1y3.us-west-1.aws.glb.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     when(request.getServerName()).thenReturn("pksqlc-3d235.domz6wj0p.us-west-1.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
 
     // === Schema Registry endpoints (start with psrc-) ===
     when(request.getServerName()).thenReturn("psrc-8kz20.us-east-2.aws.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
 
     // === Flink UDF Gateway endpoints (start with pflinkudfgwc-) ===
     when(request.getServerName()).thenReturn("pflinkudfgwc-3d235.us-west-2.aws.intranet.confluent-untrusted.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
 
     // === Invalid patterns ===
     when(request.getServerName()).thenReturn("api.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     when(request.getServerName()).thenReturn("lsrc-123-env.domain.com");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
     
     when(request.getServerName()).thenReturn(null);
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
   }
 
   @Test
-  public void testAutoTenantIdExtraction() {
+  public void testTenantIdExtractionWithFallback() {
     HttpServletRequest request = mock(HttpServletRequest.class);
     
-    // test AUTO mode - V3 pattern should be found first
+    // test path extraction takes priority - path pattern should be found first
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-6787w2/topics");
     when(request.getServerName()).thenReturn("lkc-6787w2-env5qj75n.us-west-2.aws.private.glb.stag.cpdev.cloud");
-    String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
+    String tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-6787w2", tenantId);
     
-    // test AUTO mode - V3 extraction with path ending at tenant ID (edge case)
+    // test path extraction with path ending at tenant ID (edge case)
     when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devc80y73q");
     when(request.getServerName()).thenReturn("kafka.pkc-devcyypqg6.svc.cluster.local");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-devc80y73q", tenantId);
     
-    // test AUTO mode - fallback to V4 when V3 fails
+    // test fallback to hostname when path extraction fails
     when(request.getRequestURI()).thenReturn("/some/other/path");
     when(request.getServerName()).thenReturn("lkc-abc123-env456.domain.com");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals("lkc-abc123", tenantId);
     
-    // test AUTO mode - both V3 and V4 fail
+    // test both path and hostname extraction fail
     when(request.getRequestURI()).thenReturn("/api/v1/other");
     when(request.getServerName()).thenReturn("api.confluent.cloud");
-    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
+    tenantId = TenantUtils.extractTenantId(request);
     assertEquals(TenantUtils.UNKNOWN_TENANT, tenantId);
   }
 } 

--- a/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
+++ b/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.Test;
+
+public class TenantUtilsTest {
+
+  @Test
+  public void testV3TenantIdExtraction() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    
+    // test successful V3 extraction
+    when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devccovmzyj/topics");
+    String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    assertEquals("lkc-devccovmzyj", tenantId);
+    
+    // test V3 extraction with different endpoint
+    when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-abc123def/consumer-groups");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    assertEquals("lkc-abc123def", tenantId);
+    
+    // test V3 extraction failure - wrong pattern
+    when(request.getRequestURI()).thenReturn("/api/v1/some/other/path");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    assertEquals("UNKNOWN", tenantId);
+    
+    // test V3 extraction failure - null URI
+    when(request.getRequestURI()).thenReturn(null);
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    assertEquals("UNKNOWN", tenantId);
+  }
+
+  @Test
+  public void testV4TenantIdExtraction() {
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    
+    // test successful V4 extraction
+    when(request.getServerName()).thenReturn("lkc-devccovmzyj-env.confluent.cloud");
+    String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    assertEquals("lkc-devccovmzyj", tenantId);
+    
+    // test V4 extraction with different environment
+    when(request.getServerName()).thenReturn("lkc-abc123def-prod.example.com");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    assertEquals("lkc-abc123def", tenantId);
+    
+    // test V4 extraction failure - wrong pattern
+    when(request.getServerName()).thenReturn("api.confluent.cloud");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    assertEquals("UNKNOWN", tenantId);
+    
+    // test V4 extraction failure - null hostname
+    when(request.getServerName()).thenReturn(null);
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V4);
+    assertEquals("UNKNOWN", tenantId);
+  }
+} 

--- a/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
+++ b/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
@@ -44,6 +44,11 @@ public class TenantUtilsTest {
     tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
     assertEquals("lkc-6787w2", tenantId);
     
+    // test V3 extraction with path ending at tenant ID (previously failing case)
+    when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devc80y73q");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
+    assertEquals("lkc-devc80y73q", tenantId);
+    
     // test V3 extraction failure - wrong pattern
     when(request.getRequestURI()).thenReturn("/api/v1/some/other/path");
     tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_V3);
@@ -99,6 +104,12 @@ public class TenantUtilsTest {
     when(request.getServerName()).thenReturn("lkc-6787w2-env5qj75n.us-west-2.aws.private.glb.stag.cpdev.cloud");
     String tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
     assertEquals("lkc-6787w2", tenantId);
+    
+    // test AUTO mode - V3 extraction with path ending at tenant ID (edge case)
+    when(request.getRequestURI()).thenReturn("/kafka/v3/clusters/lkc-devc80y73q");
+    when(request.getServerName()).thenReturn("kafka.pkc-devcyypqg6.svc.cluster.local");
+    tenantId = TenantUtils.extractTenantId(request, RestConfig.DOS_FILTER_TENANT_EXTRACTION_MODE_AUTO);
+    assertEquals("lkc-devc80y73q", tenantId);
     
     // test AUTO mode - fallback to V4 when V3 fails
     when(request.getRequestURI()).thenReturn("/some/other/path");


### PR DESCRIPTION
Please first read through the JIRA (and associated docs) [here](https://confluentinc.atlassian.net/browse/KNET-10736) to see motivation for this change. 

This implementation the suggestion in the JIRA to add tenant rate limiting by creating a new DoS Filter that overrides `extractUserId` with the tenant ID. Note that for both the V3 and V4 network, I was able to get the tenant ID from the path and extracting it from the hostname was not required for V4. But I've left the logic for hostname extraction as a fallback so V4 extraction will still work even if the path somehow doesn't have it.

Some implementation details:
- The order of the rate limiters currently goes from most most granular to least granular as I believe this makes the most sense: IP-based -> tenant-based -> global. Ideally the values of each should also be <= to the next one in the chain. Setting IP-based = tenant-based would allow us to give maximum req/sec available to the tenant, and they could handle specific IP rate limiting on their end. At that point, IP-based rate limiting is more of an individual tenant problem and not relevant to us. 
- For tenant ID extraction, I implemented a simple string matching solution that returns as soon as a match is found. Prior to this, I was taking a regex approach, but given tenant ID parsing is called on each request, performance is important and simple string matching should be more efficient.
- In the event a tenant ID is not recognized, we return null from the `extractUserId` function. That results in the fallback logic [here](https://github.com/confluentinc/rest-utils/blob/97439b296a3546e8e1ad0d5a8d3864a05e06505b/core/src/main/java/io/confluent/rest/jetty/DoSFilter.java#L532). So we fallback to session-based rate limiting if available or IP-address based rate limiting otherwise. I.e. the behavior is similar to what we would have without tenant rate limiting, which I think is the best we can do when tenant identification fails for whatever reason.
- Added config for the actual rate limit and flag to enable/disable tenant rate limiting. Kept the default rate limit at 25 to match the default IP and global rate limits. When tenant rate limiting is disabled, it should behave exactly as it did prior to this change. Will make a subsequent PR to make these both available as LD flags.

This code has been tested to be working in both V3 and V4 clusters. I ran a test to simulate the NNP problem (as described [here](https://confluentinc.atlassian.net/wiki/spaces/~712020196c4f65f87449a1834c0930c2dc26fe/pages/4608655417/Noisy+Neighbor+Problem+-+Repro)). Namely, one tenant from multiple IPs bombarded the cluster with reqs, while a second well-behaved tenant sent a low number of requests. Prior to this change, it was observed that tenant 2 was hit with constant `429`'s in addition to tenant 1. After the change, only tenant 1 experienced `429`'s, thus confirming the tenant rate limiting is working as expected.

I've added unit tests for both the path-based and hostname-based tenant ID extraction logic. I've also added an int test for the new tenant rate limiter, alongside the existing IP-based and global rate limiter tests.