### PR TITLE
fix: Check for NPEs before accessing request or response related objects

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -529,7 +529,7 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     private CountingInputStream wrappedRequestStream;
     private CountingOutputStream wrappedResponseStream;
     private final boolean enableGlobalStatsRequestTags;
-    private Map<String, String> capturedRequestTags;
+    private Map<String, String> capturedRequestTags = emptyMap();
 
     private MetricsRequestEventListener(final Map<Method, RequestScopedMetrics> metrics, Time time,
         boolean enableGlobalStatsRequestTags) {

--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -638,12 +638,11 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     private <T> T safeGet(Supplier<T> supplier, String operationName) {
       try {
         return supplier.get();
+      } catch (NullPointerException e) {
+        log.error("NPE while getting {}, potentially due to recycled request", operationName, e);
+        return null;
       } catch (Exception e) {
-        if (e instanceof NullPointerException) {
-          log.error("NPE while getting {}, potentially due to recycled request", operationName, e);
-        } else {
-          log.error("Error while getting {}", operationName, e);
-        }
+        log.error("Error while getting {}", operationName, e);
         return null;
       }
     }


### PR DESCRIPTION
We saw this stack trace while getting a 500 error.
There is an attempt to getProperty from the request after the RequestEvent has been finished. Since Jetty12 is quite aggressive in recycling the request and reponse, we run into an NPE, eventually causing the 500 intermittently. This is a defensive code to ensure we don't throw NPE and get the request tags at a much earlier stage to avoid this NPE.


```
java.lang.NullPointerException: Cannot invoke "org.eclipse.jetty.server.Request.getAttribute(String)" because the return value of "org.eclipse.jetty.ee10.servlet.ServletApiRequest.getRequest()" is null
	at org.eclipse.jetty.ee10.servlet.ServletApiRequest.getAttribute(ServletApiRequest.java:834)
	at org.glassfish.jersey.servlet.ServletPropertiesDelegate.getProperty(ServletPropertiesDelegate.java:38)
	at org.glassfish.jersey.message.internal.TracingAwarePropertiesDelegate.getProperty(TracingAwarePropertiesDelegate.java:74)
	at org.glassfish.jersey.server.ContainerRequest.getProperty(ContainerRequest.java:310)
	at io.confluent.rest.metrics.MetricsResourceMethodApplicationListener$RequestScopedMetrics.getMethodMetrics(MetricsResourceMethodApplicationListener.java:183)
	at io.confluent.rest.metrics.MetricsResourceMethodApplicationListener$MetricsRequestEventListener.getMethodMetrics(MetricsResourceMethodApplicationListener.java:619)
	at io.confluent.rest.metrics.MetricsResourceMethodApplicationListener$MetricsRequestEventListener.onEvent(MetricsResourceMethodApplicationListener.java:592)
	at org.glassfish.jersey.server.internal.monitoring.CompositeRequestEventListener.onEvent(CompositeRequestEventListener.java:47)
	at org.glassfish.jersey.server.internal.process.RequestProcessingContext.triggerEvent(RequestProcessingContext.java:203)
	at org.glassfish.jersey.server.ServerRuntime$Responder.release(ServerRuntime.java:795)
	at org.glassfish.jersey.server.ServerRuntime$Responder.process(ServerRuntime.java:390)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$3.run(ServerRuntime.java:927)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248)
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:266)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder.resume(ServerRuntime.java:967)
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder.resume(ServerRuntime.java:915)
	at io.confluent.kafkarest.resources.AsyncResponses$AsyncResponseBuilder.lambda$asyncResume$0(AsyncResponses.java:108)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2179)
	at io.confluent.kafkarest.common.KafkaFutures.lambda$toCompletableFuture$0(KafkaFutures.java:45)
	at org.apache.kafka.common.internals.KafkaFutureImpl.lambda$whenComplete$2(KafkaFutureImpl.java:97)
	at java.base/java.util.concurrent.CompletableFuture.uniWhenComplete(CompletableFuture.java:863)
	at java.base/java.util.concurrent.CompletableFuture$UniWhenComplete.tryFire(CompletableFuture.java:841)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:510)
	at java.base/java.util.concurrent.CompletableFuture.complete(CompletableFuture.java:2179)
	at org.apache.kafka.common.internals.KafkaCompletableFuture.kafkaComplete(KafkaCompletableFuture.java:39)
	at org.apache.kafka.common.internals.KafkaFutureImpl.complete(KafkaFutureImpl.java:112)
	at org.apache.kafka.clients.admin.KafkaAdminClient$9.handleResponse(KafkaAdminClient.java:2581)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.handleResponses(KafkaAdminClient.java:1382)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.processRequests(KafkaAdminClient.java:1536)
	at org.apache.kafka.clients.admin.KafkaAdminClient$AdminClientRunnable.run(KafkaAdminClient.java:1459)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	```