### PR TITLE
CPBR-2977 | Hardcoding the CP deb installation dependency version

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://confluent.io
 
 Package: confluent-rest-utils
 Architecture: all
-Depends: confluent-common
+Depends: confluent-common (= ${source:Version})
 Description: Confluent utilities for writing Java REST APIs
  Confluent REST Utils provides a small framework and utilities for writing Java
  REST APIs using Jersey, Jackson, Jetty, and Hibernate Validator.


### PR DESCRIPTION
When customers install older patch releases (e.g., CP 7.6.1), they automatically get the latest patch version dependencies (e.g., CP 7.6.6), causing compatibility issues due to jar version mismatches. This PR will hardcode the CP version to installation version.