### PR TITLE
CPBR-2977 | Hardcoding the CP rpm installation dependency version of CP packages

### DIFF
--- a/confluent-rest-utils.spec.in
+++ b/confluent-rest-utils.spec.in
@@ -11,7 +11,7 @@ Vendor: Confluent, Inc.
 Packager: Confluent Packaging <packages@confluent.io>
 BuildArch: noarch
 
-Requires: confluent-common >= ##RPMVERSION##
+Requires: confluent-common = ##RPMVERSION##
 
 %description
 


### PR DESCRIPTION
When customers install older patch releases (e.g., CP 7.6.1), they automatically get the latest patch version dependencies (e.g., CP 7.6.6), causing compatibility issues due to jar version mismatches. This PR will hardcode the CP version to installation version.