### PR TITLE
KNET-19517: Add dry-run mode for tenant rate limiting

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -827,11 +827,12 @@ public abstract class Application<T extends RestConfig> {
   // TODO: This is temporary code to be removed after tenant rate limit testing
   private void configureTenantDryRunFilter(ServletContextHandler context) {
     TenantDryRunFilter dryRunFilter = new TenantDryRunFilter();
-    FilterHolder filterHolder = new FilterHolder(dryRunFilter);
+    String tenantLimit = String.valueOf(config.getDosFilterTenantMaxRequestsPerSec());
+    FilterHolder filterHolder = configureDosFilter(dryRunFilter, tenantLimit);
     filterHolder.setName("tenant-dry-run-filter");
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
-    log.info("Tenant dry-run classifier enabled. Tenant extraction will be logged "
-        + "without rate limiting");
+    log.info("Tenant dry-run classifier enabled with {}req/sec limit. Tenant extraction and "
+        + "rate limit violations will be logged without actual rate limiting", tenantLimit);
   }
 
   private void configureGlobalDosFilter(ServletContextHandler context) {

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -782,7 +782,7 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureDosFilters(ServletContextHandler context) {
-    // TODO: Temporary code to be removed this code after tenant rate limit testing
+    // TODO: This is temporary code to be removed after tenant rate limit testing
     // Configure tenant dry-run classifier if enabled
     if (config.isDosFilterTenantDryRunEnabled()) {
       configureTenantDryRunFilter(context);
@@ -824,7 +824,7 @@ public abstract class Application<T extends RestConfig> {
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
   }
 
-  // TODO: Temporary code to be removed this code after tenant rate limit testing
+  // TODO: This is temporary code to be removed after tenant rate limit testing
   private void configureTenantDryRunFilter(ServletContextHandler context) {
     TenantDryRunFilter dryRunFilter = new TenantDryRunFilter();
     FilterHolder filterHolder = new FilterHolder(dryRunFilter);

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -782,6 +782,12 @@ public abstract class Application<T extends RestConfig> {
   }
 
   private void configureDosFilters(ServletContextHandler context) {
+    // TODO: Temporary code to be removed this code after tenant rate limit testing
+    // Configure tenant dry-run classifier if enabled
+    if (config.isDosFilterTenantDryRunEnabled()) {
+      configureTenantDryRunFilter(context);
+    }
+    
     if (!config.isDosFilterEnabled()) {
       return;
     }
@@ -816,6 +822,16 @@ public abstract class Application<T extends RestConfig> {
     String tenantLimit = String.valueOf(config.getDosFilterTenantMaxRequestsPerSec());
     FilterHolder filterHolder = configureDosFilter(dosFilter, tenantLimit);
     context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+  }
+
+  // TODO: Temporary code to be removed this code after tenant rate limit testing
+  private void configureTenantDryRunFilter(ServletContextHandler context) {
+    TenantDryRunFilter dryRunFilter = new TenantDryRunFilter();
+    FilterHolder filterHolder = new FilterHolder(dryRunFilter);
+    filterHolder.setName("tenant-dry-run-filter");
+    context.addFilter(filterHolder, "/*", EnumSet.of(DispatcherType.REQUEST));
+    log.info("Tenant dry-run classifier enabled. Tenant extraction will be logged "
+        + "without rate limiting");
   }
 
   private void configureGlobalDosFilter(ServletContextHandler context) {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -507,12 +507,13 @@ public class RestConfig extends AbstractConfig {
           + "are first delayed, then throttled. Default is 25";
   private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
-  private static final String DOS_FILTER_TENANT_DRY_RUN_CONFIG = "dos.filter.tenant.dry.run";
-  private static final String DOS_FILTER_TENANT_DRY_RUN_DOC =
+  private static final String DOS_FILTER_TENANT_DRY_RUN_ENABLED_CONFIG =
+      "dos.filter.tenant.dry.run.enabled";
+  private static final String DOS_FILTER_TENANT_DRY_RUN_ENABLED_DOC =
       "This is temporary config for tenant rate limit testing. "
           + "When true, enables tenant extraction and classification logging without actually "
           + "performing tenant-based rate limiting. Default is false.";
-  private static final boolean DOS_FILTER_TENANT_DRY_RUN_DEFAULT = false;
+  private static final boolean DOS_FILTER_TENANT_DRY_RUN_ENABLED_DEFAULT = false;
 
   private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";
   private static final String SERVER_CONNECTION_LIMIT_DOC =
@@ -1172,11 +1173,11 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC
         ).define(
-            DOS_FILTER_TENANT_DRY_RUN_CONFIG,
+            DOS_FILTER_TENANT_DRY_RUN_ENABLED_CONFIG,
             Type.BOOLEAN,
-            DOS_FILTER_TENANT_DRY_RUN_DEFAULT,
+            DOS_FILTER_TENANT_DRY_RUN_ENABLED_DEFAULT,
             Importance.LOW,
-            DOS_FILTER_TENANT_DRY_RUN_DOC
+            DOS_FILTER_TENANT_DRY_RUN_ENABLED_DOC
         ).define(
             SERVER_CONNECTION_LIMIT,
             Type.INT,
@@ -1448,7 +1449,7 @@ public class RestConfig extends AbstractConfig {
   }
 
   public final boolean isDosFilterTenantDryRunEnabled() {
-    return getBoolean(DOS_FILTER_TENANT_DRY_RUN_CONFIG);
+    return getBoolean(DOS_FILTER_TENANT_DRY_RUN_ENABLED_CONFIG);
   }
 
   public final int getServerConnectionLimit() {

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -507,6 +507,13 @@ public class RestConfig extends AbstractConfig {
           + "are first delayed, then throttled. Default is 25";
   private static final int DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DEFAULT = 25;
 
+  private static final String DOS_FILTER_TENANT_DRY_RUN_CONFIG = "dos.filter.tenant.dry.run";
+  private static final String DOS_FILTER_TENANT_DRY_RUN_DOC =
+      "This is temporary config for tenant rate limit testing. "
+          + "When true, enables tenant extraction and classification logging without actually "
+          + "performing tenant-based rate limiting. Default is false.";
+  private static final boolean DOS_FILTER_TENANT_DRY_RUN_DEFAULT = false;
+
   private static final String SERVER_CONNECTION_LIMIT = "server.connection.limit";
   private static final String SERVER_CONNECTION_LIMIT_DOC =
       "Limits the number of active connections on that server to the configured number. Once that "
@@ -1165,6 +1172,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_DOC
         ).define(
+            DOS_FILTER_TENANT_DRY_RUN_CONFIG,
+            Type.BOOLEAN,
+            DOS_FILTER_TENANT_DRY_RUN_DEFAULT,
+            Importance.LOW,
+            DOS_FILTER_TENANT_DRY_RUN_DOC
+        ).define(
             SERVER_CONNECTION_LIMIT,
             Type.INT,
             SERVER_CONNECTION_LIMIT_DEFAULT,
@@ -1432,6 +1445,10 @@ public class RestConfig extends AbstractConfig {
 
   public final int getDosFilterTenantMaxRequestsPerSec() {
     return getInt(DOS_FILTER_TENANT_MAX_REQUESTS_PER_SEC_CONFIG);
+  }
+
+  public final boolean isDosFilterTenantDryRunEnabled() {
+    return getBoolean(DOS_FILTER_TENANT_DRY_RUN_CONFIG);
   }
 
   public final int getServerConnectionLimit() {

--- a/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
@@ -16,6 +16,8 @@
 
 package io.confluent.rest;
 
+import static io.confluent.rest.TenantUtils.UNKNOWN_TENANT;
+
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.FilterConfig;
@@ -52,6 +54,12 @@ public class TenantDryRunFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String tenantId = TenantUtils.extractTenantId(httpRequest);
 
+        if (UNKNOWN_TENANT.equals(tenantId)) {
+          log.warn("Tenant classification: Failed to extract tenant ID from request: {} '{}' "
+                  + "(Host: '{}')",
+              httpRequest.getMethod(), httpRequest.getRequestURI(),
+              httpRequest.getServerName());
+        }
         log.info("Tenant classification: tenant='{}', request='{} {}', host='{}'",
             tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(),
             httpRequest.getServerName());

--- a/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
@@ -28,7 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * // TODO: This is a temporary class and to be removed this code after tenant rate limit testing
+ * // TODO: This is a temporary class and to be removed after tenant rate limit testing
  * A dry-run filter for measuring tenant classification accuracy
  * without actually performing rate limiting. This filter extracts tenant IDs
  * and logs the results for monitoring and analysis purposes.
@@ -52,11 +52,10 @@ public class TenantDryRunFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String tenantId = TenantUtils.extractTenantId(httpRequest);
 
-        if (log.isInfoEnabled()) {
-          log.info("Tenant classification: tenant='{}', request='{} {}', host='{}'",
-              tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(), 
-              httpRequest.getServerName());
-        }
+        log.info("Tenant classification: tenant='{}', request='{} {}', host='{}'",
+            tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(),
+            httpRequest.getServerName());
+
       }
     } catch (Exception e) {
       log.warn("Exception during tenant extraction in dry-run mode", e);

--- a/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
@@ -72,7 +72,7 @@ public class TenantDryRunFilter extends TenantDosFilter {
             request.getMethod(), request.getRequestURI(), request.getServerName());
       }
 
-      log.info("Tenant Dry Run: Tenant classification: tenant='{}', request='{} {}', host='{}'",
+      log.debug("Tenant Dry Run: Tenant classification: tenant='{}', request='{} {}', host='{}'",
           tenantId, request.getMethod(), request.getRequestURI(), request.getServerName());
     } catch (Exception e) {
       log.warn("Tenant Dry Run: Exception during tenant extraction", e);

--- a/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
+++ b/core/src/main/java/io/confluent/rest/TenantDryRunFilter.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.FilterConfig;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * // TODO: This is a temporary class and to be removed this code after tenant rate limit testing
+ * A dry-run filter for measuring tenant classification accuracy
+ * without actually performing rate limiting. This filter extracts tenant IDs
+ * and logs the results for monitoring and analysis purposes.
+ */
+public class TenantDryRunFilter implements Filter {
+
+  private static final Logger log = LoggerFactory.getLogger(TenantDryRunFilter.class);
+  
+  @Override
+  public void init(FilterConfig filterConfig) throws ServletException {
+    log.info("Tenant dry-run classifier initialized. This filter will extract and log "
+        + "tenant IDs without performing rate limiting.");
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    
+    try {
+      if (request instanceof HttpServletRequest) {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+        String tenantId = TenantUtils.extractTenantId(httpRequest);
+
+        if (log.isInfoEnabled()) {
+          log.info("Tenant classification: tenant='{}', request='{} {}', host='{}'",
+              tenantId, httpRequest.getMethod(), httpRequest.getRequestURI(), 
+              httpRequest.getServerName());
+        }
+      }
+    } catch (Exception e) {
+      log.warn("Exception during tenant extraction in dry-run mode", e);
+    }
+    
+    // Continue with the request chain with no rate limiting applied at the tenant level
+    chain.doFilter(request, response);
+  }
+
+  @Override
+  public void destroy() {
+    log.info("Tenant dry-run classifier destroyed.");
+  }
+}

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -58,10 +58,6 @@ public final class TenantUtils {
     if (!tenantId.equals(UNKNOWN_TENANT)) {
       return tenantId;
     }
-
-    log.warn("Failed to extract tenant ID from both path and hostname. "
-        + "Request: {} '{}' (Host: '{}')",
-        request.getMethod(), request.getRequestURI(), request.getServerName());
     return UNKNOWN_TENANT;
   }
 


### PR DESCRIPTION
This builds on the previous PR (#593) to add a dry-run mode for tenant rate limiting. I'm creating a separate PR for this as this is temporary code just to be used for the initial testing (as mentioned [here](https://confluentinc.atlassian.net/wiki/spaces/~712020196c4f65f87449a1834c0930c2dc26fe/pages/4636246473/Noisy+Neighbor+Problem+in+Multi-Tenant+Clusters#Deployment-%2F-Rollout-Considerations)) and I don't want to obscure the logic of the main PR. 

When in dry-run mode, we don't do any actual tenant rate limiting, but simply observe the results of tenant extraction. This is important to verify in production so we can catch any potential edge cases that result in failed tenant extraction. 