### PR TITLE
disable: flaky tests with JIRA to fix in KNET-19715

### DIFF
--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -344,6 +344,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(3, windowCheckpoint429 + windowTag1Checkpoint429 + windowTag2Checkpoint429);
   }
 
+  // TODO: Flaky test disabled: KNET-19715
+  @Disabled
   @Test
   public void testException5xxMetrics() {
     int totalRequests = 10;
@@ -559,6 +561,8 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(0, Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
   }
 
+  // Flaky test disabled: KNET-19715
+  @Disabled
   @Test
   public void testGlobalLatencyMetricsForErrorsBeforeResourceMatching() {
     // call service that fails before resource matching

--- a/fips-tests/src/test/java/io/confluent/rest/Http2FipsTest.java
+++ b/fips-tests/src/test/java/io/confluent/rest/Http2FipsTest.java
@@ -57,6 +57,7 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -146,6 +147,8 @@ class Http2FipsTest {
     return new TestRestConfig(props);
   }
 
+  // Flaky test disabled: KNET-19715
+  @Disabled
   @Test
   public void testHttp2() throws Exception {
     TestRestConfig config = buildTestConfig(true, "TLSv1.3", "BCJSSE");
@@ -173,6 +176,8 @@ class Http2FipsTest {
     }
   }
 
+  // Flaky test disabled: KNET-19715
+  @Disabled
   @Test
   public void testHttp2AmbiguousSegment() throws Exception {
     // This test is ensuring that URI-encoded / characters work in URIs in all variants
@@ -222,6 +227,8 @@ class Http2FipsTest {
     }
   }
 
+  // Flaky test disabled: KNET-19715
+  @Disabled
   @Test
   public void testHttp2NotEnabled() throws Exception {
     TestRestConfig config = buildTestConfig(false);


### PR DESCRIPTION
Master build is failing with these flaky tests. How is it deemed flaky? Because a different run fails a different tests.

Only FIPS tests failing in this run - https://semaphore.ci.confluent.io/workflows/32a65340-2ab1-457d-860c-06fa977de64e/summary?report_id=17990af8-cb17-371c-9a8e-215e0e201902
Only testException5xxMetrics failing in this run - https://semaphore.ci.confluent.io/workflows/26154b0f-9ecc-4197-935d-43b88fbf00b5/summary?report_id=17990af8-cb17-371c-9a8e-215e0e201902
Only testGlobalLatencyMetricsForErrorsBeforeResourceMatching failing in this run https://semaphore.ci.confluent.io/workflows/50a06e36-6869-4ae8-b7ea-a1894f4dc327/summary?report_id=17990af8-cb17-371c-9a8e-215e0e201902&test_id=a6f46777-fc43-3cbf-a436-f5751b16e2b6


JIRA to enable/delete these tests - https://confluentinc.atlassian.net/browse/KNET-19715