### PR TITLE
[spire] remove explicit grpc-netty-linux

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,7 +21,7 @@
             <artifactId>java-spiffe-core</artifactId>
             <version>0.8.11</version>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>io.spiffe</groupId>
             <artifactId>grpc-netty-linux</artifactId>
             <version>0.8.11</version>
@@ -32,7 +32,7 @@
             <artifactId>grpc-netty-macos-aarch64</artifactId>
             <version>0.8.11</version>
             <scope>runtime</scope>
-        </dependency>
+        </dependency> -->
         <dependency>
             <groupId>io.spiffe</groupId>
             <artifactId>java-spiffe-provider</artifactId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -21,18 +21,6 @@
             <artifactId>java-spiffe-core</artifactId>
             <version>0.8.11</version>
         </dependency>
-        <!-- <dependency>
-            <groupId>io.spiffe</groupId>
-            <artifactId>grpc-netty-linux</artifactId>
-            <version>0.8.11</version>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.spiffe</groupId>
-            <artifactId>grpc-netty-macos-aarch64</artifactId>
-            <version>0.8.11</version>
-            <scope>runtime</scope>
-        </dependency> -->
         <dependency>
             <groupId>io.spiffe</groupId>
             <artifactId>java-spiffe-provider</artifactId>


### PR DESCRIPTION
We realized that `rest-util`  can't be deployed properly to linux server with spire enabled because the redundant dependency introduced. Please see this [thread](https://confluent.slack.com/archives/C0257BGCH0E/p1756142986631539). Akshay already tested this new change in this cluster and it worked.