### PR TITLE
Tenant rate limiting reliability improvement for V4 networking 

### DIFF
--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -51,14 +51,16 @@ public final class TenantUtils {
     // Try hostname extraction first (works for V4 networking and is more reliable)
     String tenantId = extractTenantIdFromHostname(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
-      log.debug("Tenant extracted from hostname: tenant='{}', host='{}'", tenantId, request.getServerName());
+      log.debug("Tenant extracted from hostname: tenant='{}', host='{}'",
+          tenantId, request.getServerName());
       return tenantId;
     }
 
     // Fall back to path extraction for V3 networking
     tenantId = extractTenantIdFromPath(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
-      log.debug("Tenant extracted from path: tenant='{}', uri='{}'", tenantId, request.getRequestURI());
+      log.debug("Tenant extracted from path: tenant='{}', uri='{}'",
+          tenantId, request.getRequestURI());
       return tenantId;
     }
 

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -35,8 +35,9 @@ public final class TenantUtils {
   private TenantUtils() {}
 
   /**
-   * Extracts tenant ID from an HTTP request.
-   * Attempts path extraction first, then falls back to hostname extraction.
+   * Extracts tenant ID for request
+   * Attempts hostname extraction first (applies to V4 networking - majority case),
+   * then falls back to request path extraction (applies to V3 networking).
    *
    * @param request the HTTP request
    * @return the tenant ID, or "UNKNOWN" if extraction fails
@@ -47,17 +48,18 @@ public final class TenantUtils {
       return UNKNOWN_TENANT;
     }
 
-    // Always try path extraction first (works for both V3 and V4)
-    String tenantId = extractTenantIdFromPath(request);
+    // Try hostname extraction first (works for V4 networking and is more reliable)
+    String tenantId = extractTenantIdFromHostname(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
       return tenantId;
     }
 
-    // Fall back to hostname extraction (V4)
-    tenantId = extractTenantIdFromHostname(request);
+    // Fall back to path extraction for V3 networking
+    tenantId = extractTenantIdFromPath(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
       return tenantId;
     }
+
     return UNKNOWN_TENANT;
   }
 

--- a/core/src/main/java/io/confluent/rest/TenantUtils.java
+++ b/core/src/main/java/io/confluent/rest/TenantUtils.java
@@ -51,12 +51,14 @@ public final class TenantUtils {
     // Try hostname extraction first (works for V4 networking and is more reliable)
     String tenantId = extractTenantIdFromHostname(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
+      log.debug("Tenant extracted from hostname: tenant='{}', host='{}'", tenantId, request.getServerName());
       return tenantId;
     }
 
     // Fall back to path extraction for V3 networking
     tenantId = extractTenantIdFromPath(request);
     if (!tenantId.equals(UNKNOWN_TENANT)) {
+      log.debug("Tenant extracted from path: tenant='{}', uri='{}'", tenantId, request.getRequestURI());
       return tenantId;
     }
 

--- a/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
+++ b/core/src/test/java/io/confluent/rest/TenantUtilsTest.java
@@ -171,19 +171,19 @@ public class TenantUtilsTest {
   public void testTenantIdExtractionWithFallback() {
     HttpServletRequest request = mock(HttpServletRequest.class);
 
-    // Path extraction takes priority when both are available
+    // Hostname extraction takes priority when both are available
     assertTenantExtraction(request, "/kafka/v3/clusters/lkc-6787w2/topics", 
         "lkc-6787w2-env5qj75n.us-west-2.aws.private.glb.stag.cpdev.cloud", "lkc-6787w2");
     
-    // Path extraction works even with non-tenant hostname
+    // Fallback to path extraction when hostname extraction fails  
     assertTenantExtraction(request, "/kafka/v3/clusters/lkc-devc80y73q", 
         "kafka.pkc-devcyypqg6.svc.cluster.local", "lkc-devc80y73q");
     
-    // Fallback to hostname when path extraction fails
+    // Hostname extraction succeeds when path extraction would fail
     assertTenantExtraction(request, "/some/other/path", 
         "lkc-abc123-env456.domain.com", "lkc-abc123");
     
-    // Both path and hostname extraction fail
+    // Both hostname and path extraction fail
     assertTenantExtraction(request, "/api/v1/other", 
         "api.confluent.cloud", TenantUtils.UNKNOWN_TENANT);
   }


### PR DESCRIPTION
Currently, tenant rate limiting prioritizes extracting the LKC ID from the request path. This is not always reliable as `DosFilter`s occur before auth, which means even bad requests that eventually get rejected will still create a rate limiter for this tenant. In the extreme case, a malicious client could use another tenant's LKC in order to throttle them

The fix here has two parts (the first is this PR, the second is an LD flag change)

1. Reverse the order of extraction methods. Before, we first attempted path extraction (as this works for both V3 and V4) and then fallback to the more reliable hostname extraction (V4 only). By first attempting hostname extraction, that means V4 networks will never extract the LKC from the path, eliminating the risk above (see below for why hostname extraction is secure).

2. Update the LD flag [here](https://app.launchdarkly.com/projects/default/flags/kafka.kafka_rest_service.dos_filter_tenant_enabled/targeting?env=devel&selected-env=devel) to disable tenant rate limiting for V3 networks due to the security risk. Namely, we will set a rule that disabled tenant rate limiting when `sniEnabled` is false for a cluster. Since we will eventually move to V4 entirely, I think not supporting V3 networks should be fine (as discussed with Tiffany). If we decide to go back on that and accept the security risk, we simply remove this rule to enable for V3 again. 

Once we're certain we don't want to support V3, we can remove the path extraction logic altogether. 

The above explanation assumed that hostname extraction is secure (i.e. a client cannot fake the LKC when extracted via hostname). This is true because before the `DosFilters` are applied, the `SniHandler` does the following check to ensure that the ServerName and SniServerName (TLS SNI source of truth) are equal (see [here](https://github.com/confluentinc/rest-utils/blob/71bd2b03332564fdedc123a6a903bd4a7f5705a3/core/src/main/java/io/confluent/rest/handlers/SniHandler.java#L40) for the code). If not, then the request is rejected before it ever reaches the rate limiting, and so a malicious client cannot pass a fake LKC to the tenant rate limiter 