### PR TITLE
DGS-22074 Make getSniServerName public

### DIFF
--- a/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniHandler.java
@@ -52,7 +52,7 @@ public class SniHandler extends HandlerWrapper {
     super.handle(target, baseRequest, request, response);
   }
 
-  protected static String getSniServerName(Request baseRequest) {
+  public static String getSniServerName(Request baseRequest) {
     EndPoint endpoint = baseRequest.getHttpChannel().getEndPoint();
     if (endpoint instanceof DecryptedEndPoint) {
       SSLSession session = ((DecryptedEndPoint) endpoint)


### PR DESCRIPTION
Make getSniServerName public so that it can be used by other applications like Schema registry.