### PR TITLE
Update java-spiffe version to 0.8.13

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -33,6 +33,11 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.spiffe</groupId>
+            <artifactId>grpc-netty-linux</artifactId>
+            <version>${javaSpiffe.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>
             <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
             <version>${jetty.version}</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,12 +19,18 @@
         <dependency>
             <groupId>io.spiffe</groupId>
             <artifactId>java-spiffe-core</artifactId>
-            <version>0.8.11</version>
+            <version>${javaSpiffe.version}</version>
         </dependency>
         <dependency>
             <groupId>io.spiffe</groupId>
             <artifactId>java-spiffe-provider</artifactId>
-            <version>0.8.11</version>
+            <version>${javaSpiffe.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.spiffe</groupId>
+                    <artifactId>grpc-netty-macos-aarch64</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.ee10.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>8.2.0-0</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>
+        <javaSpiffe.version>0.8.13</javaSpiffe.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
This is required as a part of a CVE fix. We need the exclusions in order to avoid the `grpc-netty-macos-aarch64` dependency which doesn't work with linux based systems.

In case we were to use `0.8.11` for `java-spiffe-provider`, we would be able to do everything on linux. This is because [0.8.11](https://mvnrepository.com/artifact/io.spiffe/java-spiffe-provider/0.8.11) uses [grpc-netty-linux](https://mvnrepository.com/artifact/io.spiffe/grpc-netty-linux) as a runtime dependency.
However, if we are to use [0.8.13](https://mvnrepository.com/artifact/io.spiffe/java-spiffe-provider/0.8.13) (latest), it uses [grpc-netty-macos-aarch64](https://mvnrepository.com/artifact/io.spiffe/grpc-netty-macos-aarch64) as a runtime dependency, and hence we face the following error in linux:
```shell
IllegalStateException: Operating System is not supported.
```

