### PR TITLE
DGS-22074 Make getSniServerName public

### DIFF
--- a/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
@@ -27,7 +27,7 @@ import javax.net.ssl.SSLSession;
 import java.util.List;
 
 public class SniUtils {
-  protected static String getSniServerName(Request baseRequest) {
+  public static String getSniServerName(Request baseRequest) {
     EndPoint endpoint = baseRequest.getConnectionMetaData().getConnection().getEndPoint();
     if (endpoint instanceof SslConnection.SslEndPoint) {
       SSLSession session = ((SslConnection.SslEndPoint) endpoint)


### PR DESCRIPTION
 Make getSniServerName public to be used in downstream applications. Port of https://github.com/confluentinc/rest-utils/pull/610