### PR TITLE
bugFix: return the method metrics when requestTags are empty, instead of creating new MethodMetrics

### DIFF
--- a/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
+++ b/core/src/main/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListener.java
@@ -175,6 +175,12 @@ public class MetricsResourceMethodApplicationListener implements ApplicationEven
     public MethodMetrics metrics(Map<String, String> requestTags) {
       // The key will also be used to identify a unique sensor,
       // so we want to pass the sorted tags to MethodMetrics
+      if (requestTags == null || requestTags.isEmpty()) {
+        // Method metrics without request tags don't necessarily represent method level aggregations
+        // e.g., when invocations of a method have both requests w/ and w/o tags
+        return methodMetrics;
+      }
+
       SortedMap<String, String> key = new TreeMap<>(requestTags);
       return requestMetrics.computeIfAbsent(key, (k) ->
           new MethodMetrics(context.method, context.performanceMetric, context.metrics,

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -23,7 +23,6 @@ import org.eclipse.jetty.util.Callback;
 import org.glassfish.jersey.server.ServerProperties;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -344,8 +343,6 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(3, windowCheckpoint429 + windowTag1Checkpoint429 + windowTag2Checkpoint429);
   }
 
-  // TODO: Flaky test disabled: KNET-19715
-  @Disabled
   @Test
   public void testException5xxMetrics() {
     int totalRequests = 10;
@@ -550,6 +547,11 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertTrue(allMetrics.containsKey("response-below-latency-sla-total"));
     assertTrue(allMetrics.containsKey("response-above-latency-sla-total"));
 
+    assertTrue(allMetrics.containsKey("hello.response-below-latency-sla-total"));
+    assertTrue(allMetrics.containsKey("hello.response-above-latency-sla-total"));
+    assertTrue(allMetrics.containsKey("hello.response-below-latency-slo-total"));
+    assertTrue(allMetrics.containsKey("hello.response-above-latency-slo-total"));
+
     assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-slo-total")).intValue()
         + Double.valueOf(allMetrics.get("response-above-latency-slo-total")).intValue());
     assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-sla-total")).intValue()
@@ -559,10 +561,13 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
     assertEquals(1, Double.valueOf(allMetrics.get("response-above-latency-slo-total")).intValue());
     assertEquals(1, Double.valueOf(allMetrics.get("response-below-latency-sla-total")).intValue());
     assertEquals(0, Double.valueOf(allMetrics.get("response-above-latency-sla-total")).intValue());
+
+    assertEquals(0, Double.valueOf(allMetrics.get("hello.response-below-latency-slo-total")).intValue());
+    assertEquals(1, Double.valueOf(allMetrics.get("hello.response-above-latency-slo-total")).intValue());
+    assertEquals(1, Double.valueOf(allMetrics.get("hello.response-below-latency-sla-total")).intValue());
+    assertEquals(0, Double.valueOf(allMetrics.get("hello.response-above-latency-sla-total")).intValue());
   }
 
-  // Flaky test disabled: KNET-19715
-  @Disabled
   @Test
   public void testGlobalLatencyMetricsForErrorsBeforeResourceMatching() {
     // call service that fails before resource matching


### PR DESCRIPTION
This PR introduced a bug - https://github.com/confluentinc/rest-utils/pull/595/files In the refactoring, 
we removed this method entirely. In this if the requests tags are available, we create a `new` MethodMetrics. But if not available, then we should just return the `methodMetrics`. 

This lead to `SLO` metrics being wiped out entirely. I have added an integration test to ensure this doesn't happen again.

```
private MethodMetrics getMethodMetrics(RequestEvent event) {
      Object tagsObj = event.getContainerRequest().getProperty(REQUEST_TAGS_PROP_KEY);
      if (tagsObj == null) {
        // Method metrics without request tags don't necessarily represent method level aggregations
        // e.g., when invocations of a method have both requests w/ and w/o tags
        return this.metrics();
      }
      if (!(tagsObj instanceof Map<?, ?>)) {
        throw new ClassCastException("Expected the value for property " + REQUEST_TAGS_PROP_KEY
            + " to be a " + Map.class + ", but it is " + tagsObj.getClass());
      }
      @SuppressWarnings("unchecked")
      Map<String, String> tags = (Map<String, String>) tagsObj;
      // we have additional tags, find the appropriate metrics holder
      return this.metrics(tags);
    }
 ```