### PR TITLE
Update jackson-annotations to use jackson.annotations.version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -211,7 +211,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
+                <version>${jackson.annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>


### PR DESCRIPTION
## Summary
- Use `${jackson.annotations.version}` instead of `${jackson.version}` for jackson-annotations dependency
- Similar change as #652 (merged on master)
- Related to common change: https://github.com/confluentinc/common/pull/967

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)