### PR TITLE
Add config to enforce required SNI headers

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -460,7 +460,8 @@ public abstract class Application<T extends RestConfig> {
     } else if (config.getSniCheckEnable()) {
       context.insertHandler(new SniHandler());
     } else if (!expectedSniHeaders.isEmpty()) {
-      context.insertHandler(new ExpectedSniHandler(expectedSniHeaders));
+      context.insertHandler(
+          new ExpectedSniHandler(expectedSniHeaders, config.getRejectInvalidSniHeaders()));
     }
 
     Sequence handlers = new Sequence();

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -579,6 +579,13 @@ public class RestConfig extends AbstractConfig {
           + "present, log a warning when handling connections, but do not reject the connection.";
   protected static final String EXPECTED_SNI_HEADERS_DEFAULT = "";
 
+  public static final String REJECT_INVALID_SNI_HEADERS_CONFIG = "reject.invalid.sni.headers";
+  protected static final String REJECT_INVALID_SNI_HEADERS_DOC =
+      "If true, reject incoming requests whose SNI header does not match the configured list "
+          + "of expected SNI headers (see " + EXPECTED_SNI_HEADERS_CONFIG + ") with an HTTP 400 "
+          + "response. If false (default), a warning is logged but the request is allowed.";
+  protected static final boolean REJECT_INVALID_SNI_HEADERS_DEFAULT = false;
+
   public static final String PROXY_PROTOCOL_ENABLED_CONFIG =
       "proxy.protocol.enabled";
   protected static final String PROXY_PROTOCOL_ENABLED_DOC =
@@ -1250,6 +1257,12 @@ public class RestConfig extends AbstractConfig {
             Importance.LOW,
             EXPECTED_SNI_HEADERS_DOC
         ).define(
+            REJECT_INVALID_SNI_HEADERS_CONFIG,
+            Type.BOOLEAN,
+            REJECT_INVALID_SNI_HEADERS_DEFAULT,
+            Importance.LOW,
+            REJECT_INVALID_SNI_HEADERS_DOC
+        ).define(
             LISTENER_PROTOCOL_MAP_CONFIG,
             Type.LIST,
             LISTENER_PROTOCOL_MAP_DEFAULT,
@@ -1693,6 +1706,10 @@ public class RestConfig extends AbstractConfig {
 
   public final List<String> getExpectedSniHeaders() {
     return getList(EXPECTED_SNI_HEADERS_CONFIG);
+  }
+
+  public final boolean getRejectInvalidSniHeaders() {
+    return getBoolean(REJECT_INVALID_SNI_HEADERS_CONFIG);
   }
 
   /**

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -16,6 +16,8 @@
 
 package io.confluent.rest.handlers;
 
+import static org.eclipse.jetty.http.HttpStatus.Code.BAD_REQUEST;
+
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Handler;
@@ -27,10 +29,18 @@ import java.util.List;
 
 public class ExpectedSniHandler extends Handler.Wrapper {
   private static final Logger log = LoggerFactory.getLogger(ExpectedSniHandler.class);
+  private static final String INVALID_SNI_MESSAGE = "Invalid SNI";
+
   private final List<String> expectedSniHeaders;
+  private final boolean rejectInvalidSniHeaders;
 
   public ExpectedSniHandler(List<String> expectedSniHeaders) {
+    this(expectedSniHeaders, false);
+  }
+
+  public ExpectedSniHandler(List<String> expectedSniHeaders, boolean rejectInvalidSniHeaders) {
     this.expectedSniHeaders = expectedSniHeaders;
+    this.rejectInvalidSniHeaders = rejectInvalidSniHeaders;
   }
 
   @Override
@@ -43,6 +53,13 @@ public class ExpectedSniHandler extends Handler.Wrapper {
     } else if (!expectedSniHeaders.contains(sniServerName)) {
       log.warn("SNI header {} is not in the configured list of expected headers {}; "
           + "request URI is {}", sniServerName, this.expectedSniHeaders, baseRequest.getHttpURI());
+    } else {
+      return super.handle(baseRequest, response, callback);
+    }
+    if (rejectInvalidSniHeaders) {
+      Response.writeError(baseRequest, response, callback,
+          BAD_REQUEST.getCode(), INVALID_SNI_MESSAGE);
+      return true;
     }
     return super.handle(baseRequest, response, callback);
   }

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -54,7 +54,7 @@ public class ExpectedSniHandler extends Handler.Wrapper {
     if (sniServerName == null) {
       log.warn("No SNI header present on request; request URI is {}", baseRequest.getHttpURI());
       invalid = true;
-    } else if (!expectedSniHeaders.contains(sniServerName)){
+    } else if (!expectedSniHeaders.contains(sniServerName)) {
       log.warn("SNI header {} is not in the configured list of expected headers {}; "
               + "request URI is {}", sniServerName, expectedSniHeaders, baseRequest.getHttpURI());
       invalid = true;

--- a/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/ExpectedSniHandler.java
@@ -48,19 +48,25 @@ public class ExpectedSniHandler extends Handler.Wrapper {
                      Response response,
                      Callback callback) throws Exception {
     String sniServerName = SniUtils.getSniServerName(baseRequest);
+
+    // Check whether the SNI is either missing or not in the valid list
+    boolean invalid = false;
     if (sniServerName == null) {
       log.warn("No SNI header present on request; request URI is {}", baseRequest.getHttpURI());
-    } else if (!expectedSniHeaders.contains(sniServerName)) {
+      invalid = true;
+    } else if (!expectedSniHeaders.contains(sniServerName)){
       log.warn("SNI header {} is not in the configured list of expected headers {}; "
-          + "request URI is {}", sniServerName, this.expectedSniHeaders, baseRequest.getHttpURI());
-    } else {
-      return super.handle(baseRequest, response, callback);
+              + "request URI is {}", sniServerName, expectedSniHeaders, baseRequest.getHttpURI());
+      invalid = true;
     }
-    if (rejectInvalidSniHeaders) {
+
+    // If the SNI is invalid and the rejection flag is set, return an error
+    if (invalid && rejectInvalidSniHeaders) {
       Response.writeError(baseRequest, response, callback,
-          BAD_REQUEST.getCode(), INVALID_SNI_MESSAGE);
+              BAD_REQUEST.getCode(), INVALID_SNI_MESSAGE);
       return true;
     }
+
     return super.handle(baseRequest, response, callback);
   }
 }

--- a/core/src/test/java/io/confluent/rest/ExpectedSniHandlerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/ExpectedSniHandlerIntegrationTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static io.confluent.rest.TestUtils.getFreePort;
+import static io.confluent.rest.TestUtils.httpClient;
+import static org.eclipse.jetty.http.HttpStatus.Code.BAD_REQUEST;
+import static org.eclipse.jetty.http.HttpStatus.Code.OK;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.test.TestSslUtils;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * End-to-end coverage for {@link io.confluent.rest.handlers.ExpectedSniHandler}, exercising
+ * the {@code expected.sni.headers} and {@code reject.invalid.sni.headers} configs through a
+ * real in-memory {@link Application} with TLS.
+ *
+ * <p>The server always listens on {@code localhost} (so the client's SNI value is
+ * "localhost"). Mismatches are produced by configuring {@code expected.sni.headers} to a
+ * value other than "localhost".
+ */
+@Tag("IntegrationTest")
+public class ExpectedSniHandlerIntegrationTest {
+
+  public static final String TEST_SSL_PASSWORD = "test1234";
+  public static final String LISTENER_HOST = "localhost";
+  public static final String OTHER_HOST = "expected-other-host";
+
+  private Server server;
+  private HttpClient httpClient;
+  private Properties props;
+  private File clientKeystore;
+
+  @BeforeEach
+  public void setup(TestInfo info) throws Exception {
+    props = new Properties();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    httpClient.stop();
+    server.stop();
+    server.join();
+  }
+
+  /** Plain HTTP has no SNI on the wire; when reject is disabled, the request is allowed
+   * through with only a warning. */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void test_http_rejectDisabled_pass(boolean http2Enabled) throws Exception {
+    props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
+    props.setProperty(RestConfig.EXPECTED_SNI_HEADERS_CONFIG, OTHER_HOST);
+    props.setProperty(RestConfig.REJECT_INVALID_SNI_HEADERS_CONFIG, "false");
+    startHttpServer("http");
+    startHttpClient("http");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_HTML)
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  /** Plain HTTP has no SNI on the wire; when reject is enabled, a null SNI is treated
+   * as invalid and the request is rejected with HTTP 400 "Invalid SNI". */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void test_http_rejectEnabled_returns400InvalidSni(boolean http2Enabled) throws Exception {
+    props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
+    props.setProperty(RestConfig.EXPECTED_SNI_HEADERS_CONFIG, OTHER_HOST);
+    props.setProperty(RestConfig.REJECT_INVALID_SNI_HEADERS_CONFIG, "true");
+    startHttpServer("http");
+    startHttpClient("http");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_HTML)
+        .send();
+
+    assertEquals(BAD_REQUEST.getCode(), response.getStatus());
+    assertThat(response.getContentAsString(), containsString("Invalid SNI"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideMtlsAndHttp2")
+  public void test_https_sniMatchesExpected_pass(boolean mTLSEnabled, boolean http2Enabled)
+      throws Exception {
+    props.setProperty(RestConfig.EXPECTED_SNI_HEADERS_CONFIG, LISTENER_HOST);
+    props.setProperty(RestConfig.REJECT_INVALID_SNI_HEADERS_CONFIG, "true");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
+    startHttpServer("https");
+    startHttpClient("https");
+
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideMtlsAndHttp2")
+  public void test_https_sniMismatch_rejectDisabled_pass(boolean mTLSEnabled, boolean http2Enabled)
+      throws Exception {
+    props.setProperty(RestConfig.EXPECTED_SNI_HEADERS_CONFIG, OTHER_HOST);
+    props.setProperty(RestConfig.REJECT_INVALID_SNI_HEADERS_CONFIG, "false");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
+    startHttpServer("https");
+    startHttpClient("https");
+
+    // Client sends SNI=localhost, expected list is OTHER_HOST → mismatch, but reject is off.
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        .send();
+
+    assertEquals(OK.getCode(), response.getStatus());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideMtlsAndHttp2")
+  public void test_https_sniMismatch_rejectEnabled_returns400InvalidSni(
+      boolean mTLSEnabled, boolean http2Enabled) throws Exception {
+    props.setProperty(RestConfig.EXPECTED_SNI_HEADERS_CONFIG, OTHER_HOST);
+    props.setProperty(RestConfig.REJECT_INVALID_SNI_HEADERS_CONFIG, "true");
+    if (mTLSEnabled) {
+      props.setProperty(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+          RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    }
+    props.setProperty(RestConfig.HTTP2_ENABLED_CONFIG, String.valueOf(http2Enabled));
+    startHttpServer("https");
+    startHttpClient("https");
+
+    // Client sends SNI=localhost, expected list is OTHER_HOST → mismatch, reject is on.
+    ContentResponse response = httpClient.newRequest(server.getURI())
+        .path("/resource")
+        .accept(MediaType.TEXT_PLAIN)
+        .send();
+
+    assertEquals(BAD_REQUEST.getCode(), response.getStatus());
+    assertThat(response.getContentAsString(), containsString("Invalid SNI"));
+  }
+
+  private static Stream<Arguments> provideMtlsAndHttp2() {
+    return Stream.of(
+        Arguments.of(false, false),
+        Arguments.of(false, true),
+        Arguments.of(true, false),
+        Arguments.of(true, true)
+    );
+  }
+
+  private void startHttpClient(String scheme) throws Exception {
+    System.setProperty("sun.net.http.allowRestrictedHeaders", "true");
+
+    if (scheme.equals("https")) {
+      SSLContextBuilder sslContextBuilder = SSLContexts.custom()
+          .loadTrustMaterial(new TrustSelfSignedStrategy());
+      sslContextBuilder.loadKeyMaterial(new File(clientKeystore.getAbsolutePath()),
+          TEST_SSL_PASSWORD.toCharArray(),
+          TEST_SSL_PASSWORD.toCharArray());
+      SSLContext sslContext = sslContextBuilder.build();
+
+      SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+      // Force SNI for non-standard domains like "localhost"
+      // (see https://github.com/eclipse/jetty.project/pull/6296)
+      sslContextFactory.setSNIProvider(
+          SslContextFactory.Client.SniProvider.NON_DOMAIN_SNI_PROVIDER);
+      sslContextFactory.setSslContext(sslContext);
+
+      httpClient = httpClient(sslContextFactory);
+    } else {
+      httpClient = new HttpClient();
+    }
+
+    httpClient.start();
+  }
+
+  private void startHttpServer(String scheme) throws Exception {
+    String url = scheme + "://" + LISTENER_HOST + ":" + getFreePort();
+    props.setProperty(RestConfig.LISTENERS_CONFIG, url);
+
+    if (scheme.equals("https")) {
+      File serverKeystore;
+      File trustStore;
+      try {
+        trustStore = File.createTempFile("ExpectedSniTest-truststore", ".jks");
+        serverKeystore = File.createTempFile("ExpectedSniTest-server-keystore", ".jks");
+        clientKeystore = File.createTempFile("ExpectedSniTest-client-keystore", ".jks");
+      } catch (IOException ioe) {
+        throw new RuntimeException(
+            "Unable to create temporary files for truststores and keystores.");
+      }
+      Map<String, X509Certificate> certs = new HashMap<>();
+      createKeystoreWithCert(clientKeystore, ServiceType.CLIENT, certs);
+      createKeystoreWithCert(serverKeystore, ServiceType.SERVER, certs);
+      TestSslUtils.createTrustStore(trustStore.getAbsolutePath(), new Password(TEST_SSL_PASSWORD),
+          certs);
+
+      configServerKeystore(props, serverKeystore);
+      configServerTruststore(props, trustStore);
+    }
+    TestApp application = new TestApp(new TestRestConfig(props), "/");
+    server = application.createServer();
+
+    server.start();
+  }
+
+  private void configServerKeystore(Properties props, File serverKeystore) {
+    props.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, serverKeystore.getAbsolutePath());
+    props.put(RestConfig.SSL_KEYSTORE_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+    props.put(RestConfig.SSL_KEY_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+  }
+
+  private void configServerTruststore(Properties props, File trustStore) {
+    props.put(RestConfig.SSL_TRUSTSTORE_LOCATION_CONFIG, trustStore.getAbsolutePath());
+    props.put(RestConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG, TEST_SSL_PASSWORD);
+  }
+
+  private void createKeystoreWithCert(File file, ServiceType type,
+      Map<String, X509Certificate> certs) throws Exception {
+    KeyPair keypair = TestSslUtils.generateKeyPair("RSA");
+    TestSslUtils.CertificateBuilder certificateBuilder = new TestSslUtils.CertificateBuilder(30,
+        "SHA1withRSA");
+
+    X509Certificate cCert = certificateBuilder
+        .sanDnsNames(LISTENER_HOST)
+        .generate("CN=mymachine.local, O=A client", keypair);
+
+    String alias = type.toString().toLowerCase();
+    TestSslUtils.createKeyStore(file.getPath(), new Password(TEST_SSL_PASSWORD),
+        new Password(TEST_SSL_PASSWORD), alias, keypair.getPrivate(), cCert);
+    certs.put(alias, cCert);
+  }
+
+  private static class TestApp extends Application<TestRestConfig> implements AutoCloseable {
+
+    TestApp(TestRestConfig config, String path) {
+      super(config, path);
+    }
+
+    @Override
+    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) {
+      config.register(RestResource.class);
+    }
+
+    @Override
+    public void close() throws Exception {
+      stop();
+    }
+  }
+
+  @Path("/")
+  public static class RestResource {
+
+    @GET
+    @Path("/resource")
+    public String get() {
+      return "Hello";
+    }
+  }
+
+  private enum ServiceType {
+    CLIENT,
+    SERVER
+  }
+}

--- a/core/src/test/java/io/confluent/rest/handlers/ExpectedSniHandlerTest.java
+++ b/core/src/test/java/io/confluent/rest/handlers/ExpectedSniHandlerTest.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+public class ExpectedSniHandlerTest {
+
+  private static final List<String> EXPECTED_SNIS =
+      Arrays.asList("host1.example.com", "host2.example.com");
+
+  /**
+   * Records whether the wrapped (downstream) handler was invoked, so tests can verify
+   * that rejected requests do NOT reach the wrapped handler.
+   */
+  private static final class RecordingHandler extends Handler.Abstract {
+    boolean invoked = false;
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) {
+      invoked = true;
+      return true;
+    }
+  }
+
+  @Test
+  public void handle_sniMatches_passesThrough() throws Exception {
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS, true);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn("host1.example.com");
+
+      handler.handle(request, response, callback);
+
+      assertTrue(next.invoked, "wrapped handler should be invoked when SNI matches");
+      responseStatic.verify(
+          () -> Response.writeError(any(Request.class), any(Response.class),
+              any(Callback.class), anyInt(), anyString()),
+          never());
+    }
+  }
+
+  @Test
+  public void handle_sniMismatch_rejectDisabled_passesThrough() throws Exception {
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://other.example.com/path"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS, false);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn("other.example.com");
+
+      handler.handle(request, response, callback);
+
+      assertTrue(next.invoked, "wrapped handler should still be invoked when reject is disabled");
+      responseStatic.verify(
+          () -> Response.writeError(any(Request.class), any(Response.class),
+              any(Callback.class), anyInt(), anyString()),
+          never());
+    }
+  }
+
+  @Test
+  public void handle_sniMismatch_rejectEnabled_returns400InvalidSni() throws Exception {
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://other.example.com/path"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS, true);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn("other.example.com");
+
+      boolean handled = handler.handle(request, response, callback);
+
+      assertTrue(handled, "handle() should return true when the request was rejected");
+      assertFalse(next.invoked, "wrapped handler must not be invoked when rejected");
+      responseStatic.verify(
+          () -> Response.writeError(eq(request), eq(response), eq(callback),
+              eq(400), eq("Invalid SNI")),
+          times(1));
+    }
+  }
+
+  @Test
+  public void handle_sniNull_rejectEnabled_returns400InvalidSni() throws Exception {
+    // A null SNI (e.g. plain HTTP, or a non-SSL endpoint) is treated the same as a
+    // non-matching SNI: rejected with HTTP 400 when reject mode is enabled.
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://anything/"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS, true);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn(null);
+
+      boolean handled = handler.handle(request, response, callback);
+
+      assertTrue(handled);
+      assertFalse(next.invoked, "wrapped handler must not be invoked when rejected");
+      responseStatic.verify(
+          () -> Response.writeError(eq(request), eq(response), eq(callback),
+              eq(400), eq("Invalid SNI")),
+          times(1));
+    }
+  }
+
+  @Test
+  public void handle_sniNull_rejectDisabled_passesThrough() throws Exception {
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://anything/"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS, false);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn(null);
+
+      handler.handle(request, response, callback);
+
+      assertTrue(next.invoked);
+      responseStatic.verify(
+          () -> Response.writeError(any(Request.class), any(Response.class),
+              any(Callback.class), anyInt(), anyString()),
+          never());
+    }
+  }
+
+  @Test
+  public void handle_emptyExpectedList_rejectEnabled_rejectsAnySni() throws Exception {
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://x/"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(Collections.emptyList(), true);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn("foo");
+
+      boolean handled = handler.handle(request, response, callback);
+
+      assertTrue(handled);
+      assertFalse(next.invoked);
+      responseStatic.verify(
+          () -> Response.writeError(eq(request), eq(response), eq(callback),
+              eq(400), eq("Invalid SNI")),
+          times(1));
+    }
+  }
+
+  @Test
+  public void singleArgConstructor_defaultsToWarnOnly() throws Exception {
+    // The single-arg constructor preserves the original warn-only behavior so existing
+    // call sites that don't opt in keep their current semantics.
+    RecordingHandler next = new RecordingHandler();
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    Callback callback = mock(Callback.class);
+
+    when(request.getHttpURI()).thenReturn(HttpURI.from("https://other/"));
+
+    ExpectedSniHandler handler = new ExpectedSniHandler(EXPECTED_SNIS);
+    handler.setHandler(next);
+
+    try (MockedStatic<SniUtils> sniUtils = mockStatic(SniUtils.class);
+         MockedStatic<Response> responseStatic = mockStatic(Response.class)) {
+      sniUtils.when(() -> SniUtils.getSniServerName(request)).thenReturn("not-in-list");
+
+      handler.handle(request, response, callback);
+
+      assertTrue(next.invoked);
+      responseStatic.verify(
+          () -> Response.writeError(any(Request.class), any(Response.class),
+              any(Callback.class), anyInt(), anyString()),
+          never());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new config, `reject.invalid.sni.headers`. When this config is set to true, `ExpectedSniHandler` will reject connections with an HTTP 400 error if the SNI header of the incoming connection is missing or does not match the configured list of valid hostnames.