### PR TITLE
KNET-21206: Bump async-http-client to 2.14.5 (CVE-2026-40490)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>2.46</jersey.version>
-        <asynchttpclient.version>2.12.4</asynchttpclient.version>
+        <asynchttpclient.version>2.14.5</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>7.6.11-0</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
## Summary

Fixes [KNET-21206](https://confluentinc.atlassian.net/browse/KNET-21206) by bumping `org.asynchttpclient:async-http-client` from `2.12.4` to `2.14.5` to address [CVE-2026-40490](https://nvd.nist.gov/vuln/detail/CVE-2026-40490) ([GHSA-cmxv-58fp-fm3g](https://github.com/AsyncHttpClient/async-http-client/security/advisories/GHSA-cmxv-58fp-fm3g)).

## CVE details

- **Severity**: MEDIUM (CVSS 3.1: 6.8) — `AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N`
- **CWE-200**: Exposure of Sensitive Information to an Unauthorized Actor
- **Impact**: With `followRedirect(true)`, AsyncHttpClient forwards `Authorization` and `Proxy-Authorization` headers (and Realm credentials) to redirect targets across origin boundaries (different scheme/host/port, or HTTPS → HTTP). Even with `stripAuthorizationOnRedirect(true)`, the Realm bypass still re-generates Basic/Digest credentials via `NettyRequestFactory`. An attacker controlling a redirect target (open redirect, DNS rebinding, MITM on HTTP) can capture Bearer tokens or any other Authorization header value.
- **Vulnerable**: `>= 2.0.0, < 2.14.5` and `>= 3.0.0.Beta1, < 3.0.9`
- **Patched**: `2.14.5` (or `3.0.9` on the 3.x line)

## Why 2.14.5 (and not the v3 upgrade)

- 2.14.5 is the same CVE fix on the existing 2.x line — both `2.14.5` and `3.0.9` are listed as patched versions in the GHSA.
- Upstream `2.12.4 → 2.14.5` is a single security release commit (GHSA-cmxv-58fp-fm3g fix + transitive Netty/SLF4J bumps) with no documented breaking API changes.
- Avoids the breaking v3 upgrade proposed in [#543](https://github.com/confluentinc/rest-utils/pull/543), which is also currently in CONFLICTING state.
- Cleaner, low-risk backport story across the 9 maintenance branches called out in KNET-21206 (7.4.x → 8.2.x).

## Why this is safe

- `async-http-client` is **test scope only** in rest-utils: declared in `core/pom.xml` with `<scope>test</scope>`, exposed via the `rest-utils-test` published artifact. It is **not** part of the rest-utils production runtime.
- 2.14.5 is a single security-only release — header-stripping logic on cross-origin redirects + transitive Netty bumps. No documented breaking API changes.
- Local `mvn -pl core -am test-compile` succeeds against the bumped version on master.

## References

- Upstream fix commit: https://github.com/AsyncHttpClient/async-http-client/commit/ae557ad35246721c09dafb2976609cd0004e78ae
- Release notes: https://github.com/AsyncHttpClient/async-http-client/releases/tag/async-http-client-project-2.14.5
- GHSA: https://github.com/AsyncHttpClient/async-http-client/security/advisories/GHSA-cmxv-58fp-fm3g
- Related Renovatebot PR (superseded): https://github.com/confluentinc/rest-utils/pull/543

----
🤖 Generated with [Claude Code](https://claude.com/claude-code)


[KNET-21206]: https://confluentinc.atlassian.net/browse/KNET-21206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ