### PR TITLE
fix: only log 4xx errors when debug is enabled in DebuggableExceptionMapper

### DIFF
--- a/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
+++ b/core/src/main/java/io/confluent/rest/exceptions/DebuggableExceptionMapper.java
@@ -104,7 +104,7 @@ public abstract class DebuggableExceptionMapper<E extends Throwable> implements 
     if (status.getFamily() == Family.SERVER_ERROR) {
       // Always log 5xx errors, as they indicate server-side issues.
       log.error("Request Failed with exception ",  exc);
-    } else {
+    } else if (restConfig != null && restConfig.getBoolean(RestConfig.DEBUG_CONFIG)) {
       // Only log other errors, including user-errors 4xx, if debugging enabled.
       log.debug("Request Failed with exception ",  exc);
     }

--- a/core/src/test/java/io/confluent/rest/DebuggableExceptionMapperTest.java
+++ b/core/src/test/java/io/confluent/rest/DebuggableExceptionMapperTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import io.confluent.rest.entities.ErrorMessage;
+import io.confluent.rest.exceptions.RestException;
+import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
+import jakarta.ws.rs.core.Response;
+import org.junit.jupiter.api.Test;
+
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DebuggableExceptionMapperTest {
+
+  @Test
+  public void testClientErrorNotLoggedWhenDebugDisabled() {
+    Properties props = new Properties();
+    props.setProperty("debug", "false");
+    RestConfig config = new TestRestConfig(props);
+    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper(config);
+
+    Response response = mapper.toResponse(new RestException("subject not found", 404, 40401));
+
+    assertEquals(404, response.getStatus());
+    ErrorMessage errorMessage = (ErrorMessage) response.getEntity();
+    assertEquals("subject not found", errorMessage.getMessage());
+  }
+
+  @Test
+  public void testClientErrorMessageIncludesStackTraceWhenDebugEnabled() {
+    Properties props = new Properties();
+    props.setProperty("debug", "true");
+    RestConfig config = new TestRestConfig(props);
+    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper(config);
+
+    Response response = mapper.toResponse(new RestException("subject not found", 404, 40401));
+
+    assertEquals(404, response.getStatus());
+    ErrorMessage errorMessage = (ErrorMessage) response.getEntity();
+    assertTrue(errorMessage.getMessage().contains("RestException"),
+        "Expected stack trace in message when debug=true");
+  }
+
+  @Test
+  public void testServerErrorMessageNotExpandedWhenDebugDisabled() {
+    Properties props = new Properties();
+    props.setProperty("debug", "false");
+    RestConfig config = new TestRestConfig(props);
+    WebApplicationExceptionMapper mapper = new WebApplicationExceptionMapper(config);
+
+    Response response = mapper.toResponse(new RestException("internal error", 500, 50001));
+
+    assertEquals(500, response.getStatus());
+    ErrorMessage errorMessage = (ErrorMessage) response.getEntity();
+    assertFalse(errorMessage.getMessage().contains("RestException"),
+        "Expected no stack trace in message when debug=false");
+  }
+}


### PR DESCRIPTION
## Problem

When `debug=false`, 4xx errors (such as `RestNotFoundException`) were still 
being logged via `log.debug(...)` unconditionally in `DebuggableExceptionMapper`. 
The comment in the code said "Only log other errors, including user-errors 4xx, 
if debugging enabled" — but the condition was never actually checked for logging.

Fixes the behaviour described in #221.

## Change

In `createResponse()`, the `else` branch that logs 4xx errors has been changed 
to an `else if` that checks `restConfig.getBoolean(RestConfig.DEBUG_CONFIG)` 
before logging. 5xx errors are unaffected — they always log at ERROR level.

**Before:**
```java
} else {
  log.debug("Request Failed with exception ", exc);
}
```

**After:**
```java
} else if (restConfig != null && restConfig.getBoolean(RestConfig.DEBUG_CONFIG)) {
  log.debug("Request Failed with exception ", exc);
}
```

## Tests

Added `DebuggableExceptionMapperTest` covering three cases:
- 4xx with `debug=false` → no stack trace in response message
- 4xx with `debug=true` → stack trace included in response message  
- 5xx with `debug=false` → always logs, no stack trace in message