### PR TITLE
KNET-21206: Bump async-http-client to 2.14.5 for CVE-2026-40490

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>3.1.11</jersey.version>
-        <asynchttpclient.version>2.12.4</asynchttpclient.version>
+        <asynchttpclient.version>2.14.5</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>8.0.2</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
CVE-2026-40490 (CVSS 6.8 MEDIUM, CWE-200) leaks Authorization and Proxy-Authorization headers on cross-origin redirects in org.asynchttpclient:async-http-client. Affects versions < 2.14.5 on the 2.x line and < 3.0.9 on the 3.x line.

Bump to 2.14.5: minimal patch on the same 2.x line, single upstream security release commit, no documented breaking API changes. Avoids the breaking v3.0.9 major upgrade proposed in Renovatebot PR #543.

In rest-utils, async-http-client is test-scope only via the rest-utils-test artifact (core/pom.xml).