### PR TITLE
Remove jackson annotations definitions 81

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,11 +209,6 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>2.1.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -199,16 +199,6 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-                <artifactId>jackson-jakarta-rs-json-provider</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jakarta.rs</groupId>
-                <artifactId>jackson-jakarta-rs-base</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>jakarta.annotation</groupId>
                 <artifactId>jakarta.annotation-api</artifactId>
                 <version>2.1.1</version>


### PR DESCRIPTION
Remove the dependency definitions for jackson-*
This is due to versioning change in jackson 21 where jackson-annotations versions are in form major.minor instead of major.minor.patchlevel.
This definitions are not required as common brings in the complete jackson-bom
see:  https://github.com/confluentinc/common/blob/6599ab960c388f9b4c7665382ff096b63c4331ea/pom.xml#L431