### PR TITLE
Remove jackson definitions already present in common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,21 +190,6 @@
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-json-provider</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.jaxrs</groupId>
-                <artifactId>jackson-jaxrs-base</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-annotations</artifactId>
-                <version>${jackson.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.glassfish.jersey</groupId>
                 <artifactId>jersey-bom</artifactId>
                 <version>${jersey.version}</version>


### PR DESCRIPTION
Remove the dependency definitions for jackson-*
This is due to versioning change in jackson 21 where jackson-annotations versions are in form major.minor instead of major.minor.patchlevel.
This definitions are not required as common brings in the complete jackson-bom
see: https://github.com/confluentinc/common/blob/6599ab960c388f9b4c7665382ff096b63c4331ea/pom.xml#L431