### PR TITLE
MINOR: Add kafka-clients test-fixtures dependency for SSL test utilities

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -189,6 +189,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.asynchttpclient</groupId>
             <artifactId>async-http-client</artifactId>
             <version>${asynchttpclient.version}</version>

--- a/fips-tests/pom.xml
+++ b/fips-tests/pom.xml
@@ -41,6 +41,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${kafka.version}</version>
+            <classifier>test-fixtures</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service</artifactId>
             <version>1.1.1</version>


### PR DESCRIPTION
TestSslUtils and TestUtils were moved from the kafka-clients test classifier into a new test-fixtures classifier in Kafka 8.4.0-113-ccs, causing test compilation failures. Add the test-fixtures dependency to restore access to these classes.