### PR TITLE
[KNET-21308] Capture SNI via SNIMatcher instead of ExtendedSSLSession

### DIFF
--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -17,6 +17,7 @@
 package io.confluent.rest;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.rest.handlers.CapturingSniMatcher;
 import io.spiffe.provider.SpiffeSslContextFactory;
 import io.spiffe.workloadapi.X509Source;
 import org.apache.kafka.common.config.types.Password;
@@ -27,9 +28,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -114,7 +118,15 @@ public final class SslFactory {
   public static SslContextFactory createSslContextFactory(
       SslConfig sslConfig,
       X509Source x509Source) {
-    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server() {
+      @Override
+      public void customize(SSLEngine sslEngine) {
+        super.customize(sslEngine);
+        SSLParameters params = sslEngine.getSSLParameters();
+        params.setSNIMatchers(Collections.singletonList(new CapturingSniMatcher()));
+        sslEngine.setSSLParameters(params);
+      }
+    };
     
     /*
      * When sslConfig.getIsSpireEnabled() == true, the application is expected to use SPIFFE/SPIRE 

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -27,13 +27,17 @@ import org.eclipse.jetty.util.ssl.SslContextFactory.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.StandardConstants;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -123,8 +127,18 @@ public final class SslFactory {
       public void customize(SSLEngine sslEngine) {
         super.customize(sslEngine);
         SSLParameters params = sslEngine.getSSLParameters();
-        params.setSNIMatchers(Collections.singletonList(new CapturingSniMatcher()));
-        sslEngine.setSSLParameters(params);
+        Collection<SNIMatcher> existing = params.getSNIMatchers();
+        boolean hasHostNameMatcher = existing != null && existing.stream()
+            .anyMatch(m -> m.getType() == StandardConstants.SNI_HOST_NAME);
+        if (!hasHostNameMatcher) {
+          List<SNIMatcher> matchers = new ArrayList<>();
+          if (existing != null) {
+            matchers.addAll(existing);
+          }
+          matchers.add(new CapturingSniMatcher());
+          params.setSNIMatchers(matchers);
+          sslEngine.setSSLParameters(params);
+        }
       }
     };
     

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -17,6 +17,7 @@
 package io.confluent.rest;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.confluent.rest.handlers.CapturingSniMatcher;
 import io.spiffe.provider.SpiffeSslContextFactory;
 import io.spiffe.provider.SpiffeTrustManagerFactory;
 import io.spiffe.workloadapi.X509Source;
@@ -29,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.nio.file.Path;
@@ -37,6 +40,7 @@ import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.CRL;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -121,7 +125,15 @@ public final class SslFactory {
   public static SslContextFactory createSslContextFactory(
       SslConfig sslConfig,
       X509Source x509Source) {
-    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server() {
+      @Override
+      public void customize(SSLEngine sslEngine) {
+        super.customize(sslEngine);
+        SSLParameters params = sslEngine.getSSLParameters();
+        params.setSNIMatchers(Collections.singletonList(new CapturingSniMatcher()));
+        sslEngine.setSSLParameters(params);
+      }
+    };
     
     /*
      * When sslConfig.getIsSpireEnabled() == true, the application is expected to use SPIFFE/SPIRE 

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -29,9 +29,11 @@ import org.eclipse.jetty.util.ssl.SslContextFactory.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.net.ssl.SNIMatcher;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLParameters;
+import javax.net.ssl.StandardConstants;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import java.nio.file.Path;
@@ -39,8 +41,9 @@ import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
 import java.security.cert.CRL;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -130,8 +133,18 @@ public final class SslFactory {
       public void customize(SSLEngine sslEngine) {
         super.customize(sslEngine);
         SSLParameters params = sslEngine.getSSLParameters();
-        params.setSNIMatchers(Collections.singletonList(new CapturingSniMatcher()));
-        sslEngine.setSSLParameters(params);
+        Collection<SNIMatcher> existing = params.getSNIMatchers();
+        boolean hasHostNameMatcher = existing != null && existing.stream()
+            .anyMatch(m -> m.getType() == StandardConstants.SNI_HOST_NAME);
+        if (!hasHostNameMatcher) {
+          List<SNIMatcher> matchers = new ArrayList<>();
+          if (existing != null) {
+            matchers.addAll(existing);
+          }
+          matchers.add(new CapturingSniMatcher());
+          params.setSNIMatchers(matchers);
+          sslEngine.setSSLParameters(params);
+        }
       }
     };
     

--- a/core/src/main/java/io/confluent/rest/handlers/CapturingSniMatcher.java
+++ b/core/src/main/java/io/confluent/rest/handlers/CapturingSniMatcher.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2026 - Present Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.handlers;
+
+import javax.net.ssl.SNIHostName;
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SNIServerName;
+import javax.net.ssl.StandardConstants;
+
+/**
+ * An {@link SNIMatcher} that records the SNI host name presented during the TLS handshake
+ * so it can be read later by HTTP-level handlers. {@link #matches(SNIServerName)} always
+ * returns {@code true}; policy decisions (host header comparison, allowlist, prefix match)
+ * are deferred to the {@code SniHandler}, {@code PrefixSniHandler}, and
+ * {@code ExpectedSniHandler} request handlers.
+ *
+ * <p>A new instance must be installed per {@link javax.net.ssl.SSLEngine} since the captured
+ * value is per-connection state.
+ */
+public class CapturingSniMatcher extends SNIMatcher {
+
+  private volatile String capturedServerName;
+
+  public CapturingSniMatcher() {
+    super(StandardConstants.SNI_HOST_NAME);
+  }
+
+  @Override
+  public boolean matches(SNIServerName serverName) {
+    if (serverName instanceof SNIHostName) {
+      capturedServerName = ((SNIHostName) serverName).getAsciiName();
+    }
+    return true;
+  }
+
+  public String getCapturedServerName() {
+    return capturedServerName;
+  }
+}

--- a/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
@@ -20,24 +20,45 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.server.Request;
 
+import javax.net.ssl.ExtendedSSLSession;
+import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SNIServerName;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLSession;
 import java.util.Collection;
+import java.util.List;
 
 public class SniUtils {
   public static String getSniServerName(Request baseRequest) {
     EndPoint endpoint = baseRequest.getConnectionMetaData().getConnection().getEndPoint();
-    if (endpoint instanceof SslConnection.SslEndPoint) {
-      SSLEngine engine = ((SslConnection.SslEndPoint) endpoint)
-          .getSslConnection()
-          .getSSLEngine();
-      Collection<SNIMatcher> matchers = engine.getSSLParameters().getSNIMatchers();
-      if (matchers != null) {
-        for (SNIMatcher matcher : matchers) {
-          if (matcher instanceof CapturingSniMatcher) {
-            return ((CapturingSniMatcher) matcher).getCapturedServerName();
-          }
+    if (!(endpoint instanceof SslConnection.SslEndPoint)) {
+      return null;
+    }
+    SSLEngine engine = ((SslConnection.SslEndPoint) endpoint)
+        .getSslConnection()
+        .getSSLEngine();
+    Collection<SNIMatcher> matchers = engine.getSSLParameters().getSNIMatchers();
+    if (matchers != null) {
+      for (SNIMatcher matcher : matchers) {
+        if (matcher instanceof CapturingSniMatcher) {
+          return ((CapturingSniMatcher) matcher).getCapturedServerName();
         }
+      }
+    }
+    // No CapturingSniMatcher means Jetty installed its own matcher (AliasSNIMatcher)
+    // for cert selection. That matcher also populates ExtendedSSLSession's requested
+    // server names, so read from there.
+    SSLSession session = engine.getSession();
+    if (session instanceof ExtendedSSLSession) {
+      List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
+      if (servers != null) {
+        return servers.stream()
+            .findAny()
+            .filter(SNIHostName.class::isInstance)
+            .map(SNIHostName.class::cast)
+            .map(SNIHostName::getAsciiName)
+            .orElse(null);
       }
     }
     return null;

--- a/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
+++ b/core/src/main/java/io/confluent/rest/handlers/SniUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 - 2024 Confluent Inc.
+ * Copyright 2014 - 2026 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,29 +20,23 @@ import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.ssl.SslConnection;
 import org.eclipse.jetty.server.Request;
 
-import javax.net.ssl.ExtendedSSLSession;
-import javax.net.ssl.SNIHostName;
-import javax.net.ssl.SNIServerName;
-import javax.net.ssl.SSLSession;
-import java.util.List;
+import javax.net.ssl.SNIMatcher;
+import javax.net.ssl.SSLEngine;
+import java.util.Collection;
 
 public class SniUtils {
   public static String getSniServerName(Request baseRequest) {
     EndPoint endpoint = baseRequest.getConnectionMetaData().getConnection().getEndPoint();
     if (endpoint instanceof SslConnection.SslEndPoint) {
-      SSLSession session = ((SslConnection.SslEndPoint) endpoint)
+      SSLEngine engine = ((SslConnection.SslEndPoint) endpoint)
           .getSslConnection()
-          .getSSLEngine()
-          .getSession();
-      if (session instanceof ExtendedSSLSession) {
-        List<SNIServerName> servers = ((ExtendedSSLSession) session).getRequestedServerNames();
-        if (servers != null) {
-          return servers.stream()
-              .findAny()
-              .filter(SNIHostName.class::isInstance)
-              .map(SNIHostName.class::cast)
-              .map(SNIHostName::getAsciiName)
-              .orElse(null);
+          .getSSLEngine();
+      Collection<SNIMatcher> matchers = engine.getSSLParameters().getSNIMatchers();
+      if (matchers != null) {
+        for (SNIMatcher matcher : matchers) {
+          if (matcher instanceof CapturingSniMatcher) {
+            return ((CapturingSniMatcher) matcher).getCapturedServerName();
+          }
         }
       }
     }


### PR DESCRIPTION
[KNET-21308](https://confluentinc.atlassian.net/browse/KNET-21308)

## Summary
- Install a per-`SSLEngine` `CapturingSniMatcher` from `SslFactory.customize()`, **only when** no `SNI_HOST_NAME` matcher is already configured (Jetty installs its own `AliasSNIMatcher` whenever the keystore has hostname-bearing certs, used by `SniX509ExtendedKeyManager` for SNI-based cert selection — we coexist with it rather than trample it).
- `SniUtils.getSniServerName()` reads from `CapturingSniMatcher` when present; otherwise falls back to `ExtendedSSLSession.getRequestedServerNames()`, which is reliably populated because Jetty's `AliasSNIMatcher` ran.
- Covers the case where no SNI matcher would otherwise be configured (e.g. SPIFFE/SPIRE setups with no Java keystore), where `getRequestedServerNames()` is not populated server-side on some JSSE providers.
- No client-visible behavior change: matcher always returns `true`, so policy checks remain in the existing `SniHandler` / `PrefixSniHandler` / `ExpectedSniHandler`.

## Test plan
- [x] `mvn -pl core compile`
- [x] `mvn -pl core failsafe:integration-test -Dit.test='SniHandlerIntegrationTest,PrefixSniHandlerIntegrationTest,ExpectedSniHandlerIntegrationTest'` — 52/52 pass
- [x] `mvn -pl core test -Dtest=ExpectedSniHandlerTest` — 7/7 pass

[KNET-21308]: https://confluentinc.atlassian.net/browse/KNET-21308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ