### PR TITLE
fips-tests: add explicit jetty-alpn-java-client version after common dropped jetty-bom (7.8.x)

### DIFF
--- a/fips-tests/pom.xml
+++ b/fips-tests/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-java-client</artifactId>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,12 +84,6 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
             <version>${bouncycastle.bcpkix-fips.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-fips</artifactId>
-            <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- The cp_packaging *Build rest-utils jar* job on `7.8.x` is failing because Maven can no longer resolve a version for `org.eclipse.jetty:jetty-alpn-java-client` (failing job: https://semaphore.ci.confluent.io/jobs/87a001a4-c757-4d91-b379-4a0f9de9c9d2).
- Root cause is in `confluentinc/common` PR #990 (`9c2d2eaa22`, merged into `common/7.8.x` via `8bc8dba5f1` on 2026-05-14), which replaced `jetty-bom` with explicit per-artifact entries in `dependencyManagement` but only added the `*-server` variants. `jetty-alpn-java-client`, previously transitively managed by `jetty-bom`, was missed. Only `common/7.8.x` carries this regression; other release branches still use `jetty-bom` and are unaffected — that is why this failure is isolated to `rest-utils/7.8.x`.
- The proper long-term fix is to add `jetty-alpn-java-client` to `common`'s `dependencyManagement`. To unblock the package build immediately, this PR declares the version explicitly in `fips-tests/pom.xml` using the inherited `${jetty.version}` property.
- Also drops a stale duplicate `bcpkix-fips 1.0.7` dependency that has been emitting a Maven warning since the 7.7.x→7.8.x merge in Sep 2024 (`f450bc4e42`).

## Test plan
- [ ] Re-run the cp_packaging *Build rest-utils jar* job on 7.8.x and confirm it passes
- [ ] Confirm `mvn -B -Pcp-build -DskipTests` succeeds for `rest-utils-fips-tests`
- [ ] Confirm no `'dependencies.dependency.version' for org.eclipse.jetty:jetty-alpn-java-client:jar is missing` error
- [ ] Confirm the `bcpkix-fips` duplicate warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)