### PR TITLE
fips-tests: add explicit jetty-alpn-java-client version after common dropped jetty-bom (7.9.x)

### DIFF
--- a/fips-tests/pom.xml
+++ b/fips-tests/pom.xml
@@ -50,6 +50,7 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-alpn-java-client</artifactId>
+            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -83,12 +84,6 @@
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-fips</artifactId>
             <version>${bouncycastle.bcpkix-fips.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-fips</artifactId>
-            <version>1.0.7</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
## Summary
- The cp_packaging *Build rest-utils jar* job on `7.9.x` is failing with the same error that broke 7.8.x — Maven can no longer resolve a version for `org.eclipse.jetty:jetty-alpn-java-client` (failing job: https://semaphore.ci.confluent.io/jobs/a764a728-b344-4d00-95e1-d19ba46b9e3d).
- Root cause is in `confluentinc/common` PR #990 (`9c2d2eaa22`), which replaced `jetty-bom` with explicit per-artifact entries in `dependencyManagement` but only added the `*-server` variants. The regression originally landed on `common/7.8.x` (`8bc8dba5f1`, 2026-05-14) and has now propagated to `common/7.9.x` via the recent 7.8.x→7.9.x merge (`a9c100ddbc`). `jetty-alpn-java-client`, previously transitively managed by `jetty-bom`, no longer has a version.
- The proper long-term fix is to add `jetty-alpn-java-client` to `common`'s `dependencyManagement`. To unblock the package build immediately, this PR declares the version explicitly in `fips-tests/pom.xml` using the inherited `${jetty.version}` property. Mirrors PR #704 on 7.8.x.
- Also drops a stale duplicate `bcpkix-fips 1.0.7` dependency that has been emitting a Maven warning since the 7.7.x→7.8.x merge in Sep 2024 (`f450bc4e42`) and propagated down through 7.9.x.

## Test plan
- [ ] Re-run the cp_packaging *Build rest-utils jar* job on 7.9.x and confirm it passes
- [ ] Confirm `mvn -B -Pcp-build -DskipTests` succeeds for `rest-utils-fips-tests`
- [ ] Confirm no `'dependencies.dependency.version' for org.eclipse.jetty:jetty-alpn-java-client:jar is missing` error
- [ ] Confirm the `bcpkix-fips` duplicate warning is gone

## Related
- 7.8.x companion: #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)