### PR TITLE
DGS-24022 SPIRE Trust Manager Only

### DIFF
--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -207,17 +207,21 @@ public class RestConfig extends AbstractConfig {
   protected static final boolean METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_DEFAULT = false;
 
   public static final String SSL_SPIRE_ENABLED_CONFIG = "ssl.spire.enabled";
-  public static final String SSL_SPIRE_ENABLED_DOC =
-      "Whether to enable SPIRE SSL; once enabled, all keystore and truststore settings "
-      + "are ignored because SPIRE will handle the certificate and key management";
-  protected static final  boolean SSL_SPIRE_ENABLED_DEFAULT = false;
   public static final String SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG =
       "ssl.spire.trust.only.enabled";
+  public static final String SSL_SPIRE_ENABLED_DOC =
+      "Whether to enable SPIRE SSL. By default, SPIRE provides both the KeyManager "
+      + "(cert/key) and the TrustManager (peer-verification bundle), so all configured "
+      + "ssl.keystore.* and ssl.truststore.* settings are ignored. To keep using the "
+      + "configured keystore for the server cert/key while sourcing only the TrustManager "
+      + "from SPIRE, also enable " + SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + ".";
+  protected static final  boolean SSL_SPIRE_ENABLED_DEFAULT = false;
   public static final String SSL_SPIRE_TRUST_ONLY_ENABLED_DOC =
-      "Sub-case of " + SSL_SPIRE_ENABLED_CONFIG + ". When true, SPIRE is used only to source "
-      + "the TrustManager (peer-verification bundle); the server's KeyManager (cert/key) is "
-      + "still loaded from the configured keystore. Has no effect unless "
-      + SSL_SPIRE_ENABLED_CONFIG + " is also true.";
+      "Sub-case of " + SSL_SPIRE_ENABLED_CONFIG + ". When true, SPIRE is used only to "
+      + "source the TrustManager (peer-verification bundle); the server's KeyManager "
+      + "(cert/key) is still loaded from the configured keystore. The configured "
+      + "ssl.keystore.* settings are honored while ssl.truststore.* settings are "
+      + "ignored. Has no effect unless " + SSL_SPIRE_ENABLED_CONFIG + " is also true.";
   protected static final boolean SSL_SPIRE_TRUST_ONLY_ENABLED_DEFAULT = false;
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
   protected static final String SSL_KEYSTORE_RELOAD_DOC =

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -211,6 +211,14 @@ public class RestConfig extends AbstractConfig {
       "Whether to enable SPIRE SSL; once enabled, all keystore and truststore settings "
       + "are ignored because SPIRE will handle the certificate and key management";
   protected static final  boolean SSL_SPIRE_ENABLED_DEFAULT = false;
+  public static final String SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG =
+      "ssl.spire.trust.only.enabled";
+  public static final String SSL_SPIRE_TRUST_ONLY_ENABLED_DOC =
+      "Sub-case of " + SSL_SPIRE_ENABLED_CONFIG + ". When true, SPIRE is used only to source "
+      + "the TrustManager (peer-verification bundle); the server's KeyManager (cert/key) is "
+      + "still loaded from the configured keystore. Has no effect unless "
+      + SSL_SPIRE_ENABLED_CONFIG + " is also true.";
+  protected static final boolean SSL_SPIRE_TRUST_ONLY_ENABLED_DEFAULT = false;
   public static final String SSL_KEYSTORE_RELOAD_CONFIG = "ssl.keystore.reload";
   protected static final String SSL_KEYSTORE_RELOAD_DOC =
       "Enable auto reload of ssl keystore";
@@ -842,6 +850,12 @@ public class RestConfig extends AbstractConfig {
             SSL_SPIRE_ENABLED_DEFAULT,
             Importance.LOW,
             SSL_SPIRE_ENABLED_DOC
+        ).define(
+            SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG,
+            Type.BOOLEAN,
+            SSL_SPIRE_TRUST_ONLY_ENABLED_DEFAULT,
+            Importance.LOW,
+            SSL_SPIRE_TRUST_ONLY_ENABLED_DOC
         ).define(
             SSL_KEYSTORE_RELOAD_CONFIG,
             Type.BOOLEAN,

--- a/core/src/main/java/io/confluent/rest/SslConfig.java
+++ b/core/src/main/java/io/confluent/rest/SslConfig.java
@@ -129,4 +129,8 @@ public final class SslConfig {
   public Boolean getIsSpireEnabled() {
     return restConfig.getBoolean(RestConfig.SSL_SPIRE_ENABLED_CONFIG);
   }
+
+  public Boolean getIsSpireTrustOnlyEnabled() {
+    return restConfig.getBoolean(RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG);
+  }
 }

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -119,7 +119,26 @@ public final class SslFactory {
   public static SslContextFactory createSslContextFactory(
       SslConfig sslConfig,
       X509Source x509Source) {
-    SslContextFactory.Server sslContextFactory = createServerFactory(sslConfig, x509Source);
+    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+    
+    /*
+     * When sslConfig.getIsSpireEnabled() == true, the application is expected to use SPIFFE/SPIRE 
+     * for mTLS, which means it will get its certificates and keys from the SPIFFE Workload API 
+     * (via X509Source), not from a traditional Java keystore.
+     * 
+     * X509Source establishes a connection to the Workload API and sets up a watcher to monitor for 
+     * updates to the X.509 SVIDs and bundles. This watcher listens for changes and automatically 
+     * updates the in-memory certificates when new ones are issued, ensuring that expired 
+     * certificates are replaced seamlessly.
+     * 
+     */
+    if (sslConfig.getIsSpireEnabled()) {
+      if (sslConfig.getIsSpireTrustOnlyEnabled()) {
+        sslContextFactory = createSpireTrustOnlyServer(x509Source);
+      } else {
+        configureSpiffeSslContext(sslContextFactory, x509Source);
+      }
+    }
 
     if (!sslConfig.getKeyStorePath().isEmpty()) {
       configureKeyStore(sslContextFactory, sslConfig);
@@ -188,28 +207,9 @@ public final class SslFactory {
     }
   }
 
-  /*
-   * Builds the SslContextFactory.Server for the listener, dispatching on SPIRE config:
-   *   - Plain (no SPIRE): a vanilla SslContextFactory.Server.
-   *   - SPIRE full mode: vanilla factory + pre-built SPIFFE SSLContext installed via
-   *     setSslContext(...). SPIRE owns both KeyManager and TrustManager.
-   *   - SPIRE trust-only mode: subclassed factory that overrides getTrustManagers(...) to
-   *     return a SpiffeTrustManager. KeyManager continues to come from the keystore via
-   *     Jetty's lazy load() path.
-   */
-  private static SslContextFactory.Server createServerFactory(
-      SslConfig sslConfig, X509Source x509Source) {
-    if (!sslConfig.getIsSpireEnabled()) {
-      return new SslContextFactory.Server();
-    }
-    if (sslConfig.getIsSpireTrustOnlyEnabled()) {
-      return createSpireTrustOnlyServer(x509Source);
-    }
-    SslContextFactory.Server factory = new SslContextFactory.Server();
-    configureSpiffeSslContext(factory, x509Source);
-    return factory;
-  }
-
+  // SPIRE trust-only mode: subclass to override getTrustManagers(...) so the TrustManager
+  // comes from the SPIFFE bundle. KeyManager continues to be loaded from the configured
+  // keystore via Jetty's normal load() path.
   private static SslContextFactory.Server createSpireTrustOnlyServer(X509Source x509Source) {
     if (x509Source == null) {
       throw new RuntimeException(

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.spiffe.provider.SpiffeSslContextFactory;
 import io.spiffe.provider.SpiffeTrustManagerFactory;
 import io.spiffe.workloadapi.X509Source;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.conscrypt.OpenSSLProvider;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -134,8 +135,19 @@ public final class SslFactory {
      */
     if (sslConfig.getIsSpireEnabled()) {
       if (sslConfig.getIsSpireTrustOnlyEnabled()) {
+        if (sslConfig.getKeyStorePath().isEmpty()) {
+          throw new ConfigException(
+              RestConfig.SSL_KEYSTORE_LOCATION_CONFIG + " must be set when "
+                  + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + " is enabled; "
+                  + "SPIRE supplies the TrustManager but the KeyManager is still "
+                  + "loaded from the configured keystore.");
+        }
+        log.info("SPIRE trust-only SSL mode enabled: KeyManager from configured "
+            + "keystore, TrustManager from SPIRE bundle");
         sslContextFactory = createSpireTrustOnlyServer(x509Source);
       } else {
+        log.info("SPIRE SSL mode enabled: KeyManager and TrustManager sourced from SPIRE; "
+            + "configured ssl.keystore.* and ssl.truststore.* settings are ignored");
         configureSpiffeSslContext(sslContextFactory, x509Source);
       }
     }

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -138,16 +138,12 @@ public final class SslFactory {
         if (sslConfig.getKeyStorePath().isEmpty()) {
           throw new ConfigException(
               RestConfig.SSL_KEYSTORE_LOCATION_CONFIG + " must be set when "
-                  + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + " is enabled; "
-                  + "SPIRE supplies the TrustManager but the KeyManager is still "
-                  + "loaded from the configured keystore.");
+                  + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + " is enabled.");
         }
-        log.info("SPIRE trust-only SSL mode enabled: KeyManager from configured "
-            + "keystore, TrustManager from SPIRE bundle");
+        log.info("SPIRE trust-only SSL mode enabled");
         sslContextFactory = createSpireTrustOnlyServer(x509Source);
       } else {
-        log.info("SPIRE SSL mode enabled: KeyManager and TrustManager sourced from SPIRE; "
-            + "configured ssl.keystore.* and ssl.truststore.* settings are ignored");
+        log.info("SPIRE SSL mode enabled");
         configureSpiffeSslContext(sslContextFactory, x509Source);
       }
     }

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -18,6 +18,7 @@ package io.confluent.rest;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.spiffe.provider.SpiffeSslContextFactory;
+import io.spiffe.provider.SpiffeTrustManagerFactory;
 import io.spiffe.workloadapi.X509Source;
 import org.apache.kafka.common.config.types.Password;
 import org.conscrypt.OpenSSLProvider;
@@ -27,9 +28,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.security.Security;
+import java.security.cert.CRL;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -114,22 +119,7 @@ public final class SslFactory {
   public static SslContextFactory createSslContextFactory(
       SslConfig sslConfig,
       X509Source x509Source) {
-    SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
-    
-    /*
-     * When sslConfig.getIsSpireEnabled() == true, the application is expected to use SPIFFE/SPIRE 
-     * for mTLS, which means it will get its certificates and keys from the SPIFFE Workload API 
-     * (via X509Source), not from a traditional Java keystore.
-     * 
-     * X509Source establishes a connection to the Workload API and sets up a watcher to monitor for 
-     * updates to the X.509 SVIDs and bundles. This watcher listens for changes and automatically 
-     * updates the in-memory certificates when new ones are issued, ensuring that expired 
-     * certificates are replaced seamlessly.
-     * 
-     */
-    if (sslConfig.getIsSpireEnabled()) {
-      configureSpiffeSslContext(sslContextFactory, x509Source);
-    }
+    SslContextFactory.Server sslContextFactory = createServerFactory(sslConfig, x509Source);
 
     if (!sslConfig.getKeyStorePath().isEmpty()) {
       configureKeyStore(sslContextFactory, sslConfig);
@@ -196,6 +186,43 @@ public final class SslFactory {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  /*
+   * Builds the SslContextFactory.Server for the listener, dispatching on SPIRE config:
+   *   - Plain (no SPIRE): a vanilla SslContextFactory.Server.
+   *   - SPIRE full mode: vanilla factory + pre-built SPIFFE SSLContext installed via
+   *     setSslContext(...). SPIRE owns both KeyManager and TrustManager.
+   *   - SPIRE trust-only mode: subclassed factory that overrides getTrustManagers(...) to
+   *     return a SpiffeTrustManager. KeyManager continues to come from the keystore via
+   *     Jetty's lazy load() path.
+   */
+  private static SslContextFactory.Server createServerFactory(
+      SslConfig sslConfig, X509Source x509Source) {
+    if (!sslConfig.getIsSpireEnabled()) {
+      return new SslContextFactory.Server();
+    }
+    if (sslConfig.getIsSpireTrustOnlyEnabled()) {
+      return createSpireTrustOnlyServer(x509Source);
+    }
+    SslContextFactory.Server factory = new SslContextFactory.Server();
+    configureSpiffeSslContext(factory, x509Source);
+    return factory;
+  }
+
+  private static SslContextFactory.Server createSpireTrustOnlyServer(X509Source x509Source) {
+    if (x509Source == null) {
+      throw new RuntimeException(
+          "X509Source must be provided when SPIRE trust-only SSL is enabled");
+    }
+    return new SslContextFactory.Server() {
+      @Override
+      protected TrustManager[] getTrustManagers(KeyStore trustStore,
+                                                Collection<? extends CRL> crls) throws Exception {
+        return new SpiffeTrustManagerFactory()
+            .engineGetTrustManagersAcceptAnySpiffeId(x509Source);
+      }
+    };
   }
 
   private static void configureClientAuth(

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -244,6 +244,32 @@ public class SslFactoryTest {
         "Trust-only should be a no-op when SPIRE is disabled");
   }
 
+  @Test
+  public void testSpireTrustOnlyIgnoredWhenSpireTrustOnlyNotEnabled() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    rawConfig.put(RestConfig.SSL_SPIRE_ENABLED_CONFIG, "true");
+    rawConfig.put(RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG, "false");
+    setConfigs(rawConfig);
+
+    X509Source mockSource = Mockito.mock(X509Source.class);
+    SslContextFactory factory =
+        SslFactory.createSslContextFactory(new SslConfig(config), mockSource);
+
+    Assertions.assertEquals(SslContextFactory.Server.class, factory.getClass(),
+        "When trust-only is disabled, factory should be a base SslContextFactory.Server, "
+            + "not the trust-only subclass");
+
+    Method getTrustManagers = SslContextFactory.class.getDeclaredMethod(
+        "getTrustManagers", KeyStore.class, Collection.class);
+    getTrustManagers.setAccessible(true);
+    TrustManager[] tms = (TrustManager[]) getTrustManagers.invoke(factory, null, null);
+    Assertions.assertTrue(tms == null || tms.length == 0
+            || !(tms[0] instanceof SpiffeTrustManager),
+        "Without trust-only, getTrustManagers should not return a SpiffeTrustManager");
+  }
+
   private String asString(String... pems) {
     StringBuilder builder = new StringBuilder();
     for (String pem : pems) {

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
-import java.security.cert.CRL;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -260,14 +260,6 @@ public class SslFactoryTest {
     Assertions.assertEquals(SslContextFactory.Server.class, factory.getClass(),
         "When trust-only is disabled, factory should be a base SslContextFactory.Server, "
             + "not the trust-only subclass");
-
-    Method getTrustManagers = SslContextFactory.class.getDeclaredMethod(
-        "getTrustManagers", KeyStore.class, Collection.class);
-    getTrustManagers.setAccessible(true);
-    TrustManager[] tms = (TrustManager[]) getTrustManagers.invoke(factory, null, null);
-    Assertions.assertTrue(tms == null || tms.length == 0
-            || !(tms[0] instanceof SpiffeTrustManager),
-        "Without trust-only, getTrustManagers should not return a SpiffeTrustManager");
   }
 
   private String asString(String... pems) {

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -16,6 +16,8 @@
 
 package io.confluent.rest;
 
+import io.spiffe.provider.SpiffeTrustManager;
+import io.spiffe.workloadapi.X509Source;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.test.TestUtils;
@@ -23,12 +25,17 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import javax.net.ssl.TrustManager;
 import java.io.FileWriter;
+import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyStore;
+import java.security.cert.CRL;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -193,6 +200,49 @@ public class SslFactoryTest {
     rawConfig.put(RestConfig.SSL_TRUSTSTORE_TYPE_CONFIG, PEM_TYPE);
     setConfigs(rawConfig);
     Assertions.assertThrows(InvalidConfigurationException.class, () -> SslFactory.createSslContextFactory(new SslConfig(config)));
+  }
+
+  @Test
+  public void testSpireTrustOnlyUsesKeystoreKeyManagerAndSpireTrustManager() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    rawConfig.put(RestConfig.SSL_SPIRE_ENABLED_CONFIG, "true");
+    rawConfig.put(RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG, "true");
+    setConfigs(rawConfig);
+
+    X509Source mockSource = Mockito.mock(X509Source.class);
+    SslContextFactory factory =
+        SslFactory.createSslContextFactory(new SslConfig(config), mockSource);
+
+    Assertions.assertNotNull(factory.getKeyStore());
+    Assertions.assertEquals(getKeyStoreType(), factory.getKeyStore().getType());
+
+    Assertions.assertNotEquals(SslContextFactory.Server.class, factory.getClass(),
+        "Trust-only mode should return an SslContextFactory.Server subclass");
+
+    Method getTrustManagers = SslContextFactory.class.getDeclaredMethod(
+        "getTrustManagers", KeyStore.class, Collection.class);
+    getTrustManagers.setAccessible(true);
+    TrustManager[] tms = (TrustManager[]) getTrustManagers.invoke(factory, null, null);
+    Assertions.assertNotNull(tms);
+    Assertions.assertTrue(tms.length > 0, "Expected at least one TrustManager");
+    Assertions.assertTrue(tms[0] instanceof SpiffeTrustManager,
+        "Expected SpiffeTrustManager, got: " + tms[0].getClass().getName());
+  }
+
+  @Test
+  public void testSpireTrustOnlyIgnoredWhenSpireDisabled() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    rawConfig.put(RestConfig.SSL_SPIRE_ENABLED_CONFIG, "false");
+    rawConfig.put(RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG, "true");
+    setConfigs(rawConfig);
+
+    SslContextFactory factory = SslFactory.createSslContextFactory(new SslConfig(config));
+    Assertions.assertEquals(SslContextFactory.Server.class, factory.getClass(),
+        "Trust-only should be a no-op when SPIRE is disabled");
   }
 
   private String asString(String... pems) {


### PR DESCRIPTION
Create a mode to run the server with SPIRE TrustManager-only and default KeyManager.

Config for SR server,

```
listeners=http://0.0.0.0:8081,S2S://0.0.0.0:8085
listener.protocol.map=S2S:https
listener.name.s2s.ssl.spire.enabled=true
listener.name.s2s.ssl.client.authentication=REQUESTED
listener.name.s2s.ssl.spire.trust.only.enabled=true
ssl.keystore.location=/tmp/server.pem
ssl.keystore.type=PEM
s2s.server.enable=true
spire.agent.url=tcp://127.0.0.1:31523
```

Confirmed that client TLS REQUESTED (instead of REQUIRED) works as expected,

```

Port 8085 is HTTPS,

dhirajsuri@FYL4F3V7V5 confluent-cloud-plugins % curl -u tenant1-key:nohash \
  -H "Content-Type: application/json" \
  https://localhost:8085/subjects -k
[]%

Existing port 8081 is HTTP,
dhirajsuri@FYL4F3V7V5 confluent-cloud-plugins % curl -u tenant1-key:nohash \
  -H "Content-Type: application/json" \
  http://localhost:8081/subjects
[]%


Port 8085 rejects stale TLS client cert,

dhirajsuri@FYL4F3V7V5 ~ %   curl -H "Authorization: Bearer token" \
       -H "target-sr-cluster: lsrc-dummy" \
       -H "Host: localhost" \
       --cert $CERT_PATH/svid.0.pem \
       --key $CERT_PATH/svid.0.key \
       --cacert /Users/dhirajsuri/rest-utils/core/src/test/resources/certs/cert1.pem \
       --resolve localhost:8085:127.0.0.1 \
       https://localhost:8085/config
curl: (56) LibreSSL SSL_read: LibreSSL/3.3.6: error:1404C416:SSL routines:ST_OK:sslv3 alert certificate unknown, errno 0

Port 8085 accepts correct TLS client cert and client is able to validate non-SPIRE server cert with a local CA file,

dhirajsuri@FYL4F3V7V5 ~ %   curl -H "Authorization: Bearer token" \
       -H "target-sr-cluster: lsrc-dummy" \
       -H "Host: localhost" \
       --cert $CERT_PATH/svid.0.pem \
       --key $CERT_PATH/svid.0.key \
       --cacert /Users/dhirajsuri/rest-utils/core/src/test/resources/certs/cert1.pem \
       --resolve localhost:8085:127.0.0.1 \
       https://localhost:8085/config
{"compatibilityLevel":"BACKWARD"}%
```