### PR TITLE
Remove ce-kafka-http-server from downstream trigger list (no 8.2.x branch exists)

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -115,7 +115,6 @@ after_pipeline:
               sem-trigger -p metadata-service -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-rest -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p confluent-security-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
-              sem-trigger -p ce-kafka-http-server -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p secret-registry -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p confluent-cloud-plugins -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml
               sem-trigger -p kafka-streams-examples -b $SEMAPHORE_GIT_BRANCH -f .semaphore/semaphore.yml


### PR DESCRIPTION
## Why
- `sem-trigger -p ce-kafka-http-server` 404s on every 8.2.x build — `confluentinc/ce-kafka-http-server` has no 8.2.x branch (latest is 8.1.x).

## Change
- Drop the `sem-trigger -p ce-kafka-http-server` line from the `after_pipeline` block in `.semaphore/semaphore.yml`.

