### PR TITLE
Bump log4j2 to 2.25.4 for FedRAMP CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <io.confluent.rest-utils.version>8.0.2</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>
         <spiffe.version>0.8.13</spiffe.version>
+        <log4j2.version>2.25.4</log4j2.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Summary
- Override log4j2.version to 2.25.4 to fix CVE-2026-34477, CVE-2026-34478, CVE-2026-34479, CVE-2026-34480
- Parent common:8.0.2 is frozen in CodeArtifact with log4j 2.25.3, property override needed

## Test plan
- [ ] Verify log4j-core and log4j-1.2-api resolve to 2.25.4 in dependency tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)