### PR TITLE
DGS-24490 - blanket request timeout for SR

### DIFF
--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -30,6 +30,7 @@ import io.confluent.rest.exceptions.JsonParseExceptionMapper;
 import io.confluent.rest.extension.ResourceExtension;
 import io.confluent.rest.filters.CsrfTokenProtectionFilter;
 import io.confluent.rest.handlers.ExpectedSniHandler;
+import io.confluent.rest.handlers.RequestTimeoutHandler;
 import io.confluent.rest.handlers.SniHandler;
 import io.confluent.rest.handlers.PrefixSniHandler;
 import io.confluent.rest.jetty.DoSFilter;
@@ -450,6 +451,13 @@ public abstract class Application<T extends RestConfig> {
       context.insertHandler(new SniHandler());
     } else if (!expectedSniHeaders.isEmpty()) {
       context.insertHandler(new ExpectedSniHandler(expectedSniHeaders));
+    }
+
+    // Enforce a blanket request timeout (returns 504) when configured. Inserted last so it is
+    // the outermost wrapper and measures total in-context processing time.
+    long requestTimeoutMs = config.getLong(RestConfig.REQUEST_TIMEOUT_MS_CONFIG);
+    if (requestTimeoutMs > 0) {
+      context.insertHandler(new RequestTimeoutHandler(requestTimeoutMs));
     }
 
     Sequence handlers = new Sequence();

--- a/core/src/main/java/io/confluent/rest/Application.java
+++ b/core/src/main/java/io/confluent/rest/Application.java
@@ -457,7 +457,9 @@ public abstract class Application<T extends RestConfig> {
     // the outermost wrapper and measures total in-context processing time.
     long requestTimeoutMs = config.getLong(RestConfig.REQUEST_TIMEOUT_MS_CONFIG);
     if (requestTimeoutMs > 0) {
-      context.insertHandler(new RequestTimeoutHandler(requestTimeoutMs));
+      boolean interruptOnTimeout =
+          config.getBoolean(RestConfig.REQUEST_TIMEOUT_INTERRUPT_ENABLE_CONFIG);
+      context.insertHandler(new RequestTimeoutHandler(requestTimeoutMs, interruptOnTimeout));
     }
 
     Sequence handlers = new Sequence();

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -387,6 +387,16 @@ public class RestConfig extends AbstractConfig {
           + "the timeout.";
   public static final long REQUEST_TIMEOUT_MS_DEFAULT = 0;
 
+  public static final String REQUEST_TIMEOUT_INTERRUPT_ENABLE_CONFIG =
+          "request.timeout.interrupt.enable";
+  public static final String REQUEST_TIMEOUT_INTERRUPT_ENABLE_DOC =
+          "When a request exceeds " + REQUEST_TIMEOUT_MS_CONFIG + ", also interrupt the worker "
+          + "thread handling it. This can reclaim a thread blocked on an interruptible operation "
+          + "(e.g. network I/O), but has no effect on CPU-bound work that does not check the "
+          + "interrupt status, nor on non-interruptible blocking calls. Only has an effect when "
+          + REQUEST_TIMEOUT_MS_CONFIG + " is greater than 0.";
+  public static final boolean REQUEST_TIMEOUT_INTERRUPT_ENABLE_DEFAULT = false;
+
   public static final String THREAD_POOL_MIN_CONFIG = "thread.pool.min";
   public static final String THREAD_POOL_MIN_DOC =
           "The minimum number of threads will be started for HTTP Servlet server.";
@@ -1044,6 +1054,12 @@ public class RestConfig extends AbstractConfig {
             REQUEST_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             REQUEST_TIMEOUT_MS_DOC
+        ).define(
+            REQUEST_TIMEOUT_INTERRUPT_ENABLE_CONFIG,
+            Type.BOOLEAN,
+            REQUEST_TIMEOUT_INTERRUPT_ENABLE_DEFAULT,
+            Importance.LOW,
+            REQUEST_TIMEOUT_INTERRUPT_ENABLE_DOC
         ).define(
             THREAD_POOL_MIN_CONFIG,
             Type.INT,

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -379,6 +379,13 @@ public class RestConfig extends AbstractConfig {
           "The number of milliseconds to hold an idle session open for.";
   public static final long IDLE_TIMEOUT_MS_DEFAULT = 30_000;
 
+  public static final String REQUEST_TIMEOUT_MS_CONFIG = "request.timeout.ms";
+  public static final String REQUEST_TIMEOUT_MS_DOC =
+          "Maximum time in milliseconds a single HTTP request is allowed to take before the "
+          + "server aborts it and returns HTTP 504 Gateway Timeout. Guards against requests that "
+          + "hold a worker thread indefinitely. A value <= 0 (the default) disables the timeout.";
+  public static final long REQUEST_TIMEOUT_MS_DEFAULT = -1;
+
   public static final String THREAD_POOL_MIN_CONFIG = "thread.pool.min";
   public static final String THREAD_POOL_MIN_DOC =
           "The minimum number of threads will be started for HTTP Servlet server.";
@@ -1030,6 +1037,12 @@ public class RestConfig extends AbstractConfig {
             IDLE_TIMEOUT_MS_DEFAULT,
             Importance.LOW,
             IDLE_TIMEOUT_MS_DOC
+        ).define(
+            REQUEST_TIMEOUT_MS_CONFIG,
+            Type.LONG,
+            REQUEST_TIMEOUT_MS_DEFAULT,
+            Importance.LOW,
+            REQUEST_TIMEOUT_MS_DOC
         ).define(
             THREAD_POOL_MIN_CONFIG,
             Type.INT,

--- a/core/src/main/java/io/confluent/rest/RestConfig.java
+++ b/core/src/main/java/io/confluent/rest/RestConfig.java
@@ -383,8 +383,9 @@ public class RestConfig extends AbstractConfig {
   public static final String REQUEST_TIMEOUT_MS_DOC =
           "Maximum time in milliseconds a single HTTP request is allowed to take before the "
           + "server aborts it and returns HTTP 504 Gateway Timeout. Guards against requests that "
-          + "hold a worker thread indefinitely. A value <= 0 (the default) disables the timeout.";
-  public static final long REQUEST_TIMEOUT_MS_DEFAULT = -1;
+          + "hold a worker thread indefinitely. A value of 0 (the default) or less disables "
+          + "the timeout.";
+  public static final long REQUEST_TIMEOUT_MS_DEFAULT = 0;
 
   public static final String THREAD_POOL_MIN_CONFIG = "thread.pool.min";
   public static final String THREAD_POOL_MIN_DOC =

--- a/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Confluent Inc.
+ * Copyright 2026 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
@@ -71,21 +71,40 @@ public class RequestTimeoutHandler extends Handler.Wrapper {
     // execute (and potentially block in) the downstream request handling.
     final Thread handlingThread = Thread.currentThread();
 
-    final Scheduler.Task timeoutTask = request.getComponents().getScheduler().schedule(() -> {
-      if (done.compareAndSet(false, true)) {
-        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
-        log.warn("Request to {} exceeded the configured timeout of {} ms (elapsed {} ms); "
-                + "returning {}{}",
-            request.getHttpURI(), timeoutMs, elapsedMs, HttpStatus.GATEWAY_TIMEOUT_504,
-            interruptOnTimeout ? " and interrupting the worker thread" : "");
-        if (interruptOnTimeout) {
-          // Nudge the worker to abort; only effective for interruptible operations.
-          handlingThread.interrupt();
+    final Scheduler.Task timeoutTask;
+    try {
+      timeoutTask = request.getComponents().getScheduler().schedule(() -> {
+        if (done.compareAndSet(false, true)) {
+          long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+          log.warn("Request to {} exceeded the configured timeout of {} ms (elapsed {} ms); "
+                  + "returning {}{}",
+              request.getHttpURI(), timeoutMs, elapsedMs, HttpStatus.GATEWAY_TIMEOUT_504,
+              interruptOnTimeout ? " and interrupting the worker thread" : "");
+          // Write the error response before attempting to interrupt the worker thread. If the
+          // interrupt were to throw (e.g. a SecurityException), doing it first would prevent the
+          // 504 from ever reaching the client.
+          Response.writeError(request, response, callback,
+              HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out");
+          if (interruptOnTimeout) {
+            // Nudge the worker to abort; only effective for interruptible operations. Guard
+            // against any failure so it can never mask the response written above.
+            try {
+              handlingThread.interrupt();
+            } catch (RuntimeException e) {
+              log.warn("Failed to interrupt worker thread after request timeout to {}",
+                  request.getHttpURI(), e);
+            }
+          }
         }
-        Response.writeError(request, response, callback,
-            HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out");
-      }
-    }, timeoutMs, TimeUnit.MILLISECONDS);
+      }, timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (RuntimeException e) {
+      // The scheduler can reject new tasks (e.g. RejectedExecutionException while the server is
+      // shutting down). We cannot enforce the timeout in that case, so fall back to handling the
+      // request without one rather than failing it outright.
+      log.warn("Could not schedule request timeout task for {}; handling request without a "
+          + "timeout", request.getHttpURI(), e);
+      return super.handle(request, response, callback);
+    }
 
     // Forward only the first completion downstream and cancel the timer when the request
     // completes normally. If the timeout already fired, these become no-ops.

--- a/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.handlers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Enforces a blanket wall-clock timeout on every request flowing through it. If a request takes
+ * longer than {@code timeoutMs} to complete, it is aborted with an HTTP 504 Gateway Timeout
+ * response.
+ *
+ * <p>The deadline is scheduled on Jetty's own scheduler thread (via
+ * {@link Request#getComponents()}), so it fires independently of the worker thread handling the
+ * request. This is deliberate: a worker thread blocked deep inside a synchronous resource method
+ * (e.g. waiting on leader forwarding) never returns to the servlet container, so a servlet async
+ * {@code AsyncContext.setTimeout} would never start counting. Scheduling out-of-band lets us
+ * return a response to the client even while the worker thread remains blocked.
+ *
+ * <p>Note: this frees the client and the response/connection, but cannot force-kill the stuck
+ * worker thread (Java has no safe way to do so). The thread is reclaimed only once its downstream
+ * call returns or its own socket/idle timeout trips.
+ */
+public class RequestTimeoutHandler extends Handler.Wrapper {
+
+  private static final Logger log = LoggerFactory.getLogger(RequestTimeoutHandler.class);
+
+  private final long timeoutMs;
+
+  public RequestTimeoutHandler(long timeoutMs) {
+    this.timeoutMs = timeoutMs;
+  }
+
+  @Override
+  public boolean handle(Request request, Response response, Callback callback) throws Exception {
+    // Shared between the timeout task and the wrapped callback so that whichever fires first
+    // wins and the request is completed exactly once.
+    final AtomicBoolean done = new AtomicBoolean(false);
+
+    final Scheduler.Task timeoutTask = request.getComponents().getScheduler().schedule(() -> {
+      if (done.compareAndSet(false, true)) {
+        log.warn("Request to {} exceeded the configured timeout of {} ms; returning 504",
+            request.getHttpURI(), timeoutMs);
+        Response.writeError(request, response, callback,
+            HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out");
+      }
+    }, timeoutMs, TimeUnit.MILLISECONDS);
+
+    // Forward only the first completion downstream and cancel the timer when the request
+    // completes normally. If the timeout already fired, these become no-ops.
+    final Callback guarded = new Callback() {
+      @Override
+      public void succeeded() {
+        if (done.compareAndSet(false, true)) {
+          timeoutTask.cancel();
+          callback.succeeded();
+        }
+      }
+
+      @Override
+      public void failed(Throwable x) {
+        if (done.compareAndSet(false, true)) {
+          timeoutTask.cancel();
+          callback.failed(x);
+        }
+      }
+    };
+
+    return super.handle(request, response, guarded);
+  }
+}

--- a/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
@@ -39,18 +39,26 @@ import org.slf4j.LoggerFactory;
  * {@code AsyncContext.setTimeout} would never start counting. Scheduling out-of-band lets us
  * return a response to the client even while the worker thread remains blocked.
  *
- * <p>Note: this frees the client and the response/connection, but cannot force-kill the stuck
- * worker thread (Java has no safe way to do so). The thread is reclaimed only once its downstream
- * call returns or its own socket/idle timeout trips.
+ * <p>Note: by default this frees the client and the response/connection, but cannot force-kill
+ * the stuck worker thread (Java has no safe way to do so). The thread is reclaimed only once its
+ * downstream call returns or its own socket/idle timeout trips.
+ *
+ * <p>When {@code interruptOnTimeout} is enabled, the handler additionally interrupts the worker
+ * thread on timeout. This can reclaim a thread blocked on an <em>interruptible</em> operation
+ * (e.g. network I/O such as leader forwarding, {@code sleep}, lock/wait); it has <em>no</em>
+ * effect on CPU-bound work that never checks the interrupt status, nor on non-interruptible
+ * blocking calls. Enable it only where the long-running work is known to be interruptible.
  */
 public class RequestTimeoutHandler extends Handler.Wrapper {
 
   private static final Logger log = LoggerFactory.getLogger(RequestTimeoutHandler.class);
 
   private final long timeoutMs;
+  private final boolean interruptOnTimeout;
 
-  public RequestTimeoutHandler(long timeoutMs) {
+  public RequestTimeoutHandler(long timeoutMs, boolean interruptOnTimeout) {
     this.timeoutMs = timeoutMs;
+    this.interruptOnTimeout = interruptOnTimeout;
   }
 
   @Override
@@ -59,13 +67,21 @@ public class RequestTimeoutHandler extends Handler.Wrapper {
     // wins and the request is completed exactly once.
     final AtomicBoolean done = new AtomicBoolean(false);
     final long startNanos = System.nanoTime();
+    // The handler chain runs synchronously on this thread, so it is the worker thread that will
+    // execute (and potentially block in) the downstream request handling.
+    final Thread handlingThread = Thread.currentThread();
 
     final Scheduler.Task timeoutTask = request.getComponents().getScheduler().schedule(() -> {
       if (done.compareAndSet(false, true)) {
         long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
         log.warn("Request to {} exceeded the configured timeout of {} ms (elapsed {} ms); "
-                + "returning {}",
-            request.getHttpURI(), timeoutMs, elapsedMs, HttpStatus.GATEWAY_TIMEOUT_504);
+                + "returning {}{}",
+            request.getHttpURI(), timeoutMs, elapsedMs, HttpStatus.GATEWAY_TIMEOUT_504,
+            interruptOnTimeout ? " and interrupting the worker thread" : "");
+        if (interruptOnTimeout) {
+          // Nudge the worker to abort; only effective for interruptible operations.
+          handlingThread.interrupt();
+        }
         Response.writeError(request, response, callback,
             HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out");
       }

--- a/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
+++ b/core/src/main/java/io/confluent/rest/handlers/RequestTimeoutHandler.java
@@ -58,11 +58,14 @@ public class RequestTimeoutHandler extends Handler.Wrapper {
     // Shared between the timeout task and the wrapped callback so that whichever fires first
     // wins and the request is completed exactly once.
     final AtomicBoolean done = new AtomicBoolean(false);
+    final long startNanos = System.nanoTime();
 
     final Scheduler.Task timeoutTask = request.getComponents().getScheduler().schedule(() -> {
       if (done.compareAndSet(false, true)) {
-        log.warn("Request to {} exceeded the configured timeout of {} ms; returning 504",
-            request.getHttpURI(), timeoutMs);
+        long elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
+        log.warn("Request to {} exceeded the configured timeout of {} ms (elapsed {} ms); "
+                + "returning {}",
+            request.getHttpURI(), timeoutMs, elapsedMs, HttpStatus.GATEWAY_TIMEOUT_504);
         Response.writeError(request, response, callback,
             HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out");
       }

--- a/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Confluent Inc.
+ * Copyright 2026 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
@@ -81,6 +81,21 @@ public class RequestTimeoutIntegrationTest {
   }
 
   @Test
+  public void testIoBoundRequestTimesOutWith504() throws Exception {
+    startServer(500);
+
+    long start = System.currentTimeMillis();
+    int status = makeGetRequest("/slow-io");
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertEquals(504, status,
+        "a long I/O-bound operation that blocks the worker thread should be aborted with a 504");
+    // The handler sleeps far longer than the timeout; the 504 must come back from the scheduler
+    // thread while the worker thread is still blocked in the I/O call.
+    assertTrue(elapsed < 5_000, "504 should be returned promptly, took " + elapsed + " ms");
+  }
+
+  @Test
   public void testFastRequestIsUnaffected() throws Exception {
     startServer(10_000);
     assertEquals(200, makeGetRequest("/fast"), "fast request should succeed normally");
@@ -127,6 +142,7 @@ public class RequestTimeoutIntegrationTest {
   @Produces(MediaType.TEXT_PLAIN)
   public static class SlowResource {
     private static volatile CountDownLatch latch = new CountDownLatch(1);
+    private static volatile Thread ioThread;
 
     static void reset() {
       latch = new CountDownLatch(1);
@@ -134,6 +150,11 @@ public class RequestTimeoutIntegrationTest {
 
     static void release() {
       latch.countDown();
+      // Unblock the I/O-bound handler thread (if any) so teardown is prompt.
+      Thread t = ioThread;
+      if (t != null) {
+        t.interrupt();
+      }
     }
 
     @GET
@@ -143,6 +164,16 @@ public class RequestTimeoutIntegrationTest {
       // thread never lingers).
       latch.await(60, TimeUnit.SECONDS);
       return "slow";
+    }
+
+    @GET
+    @Path("/slow-io")
+    public String slowIo() throws InterruptedException {
+      // Simulate a long, synchronous I/O-bound operation (e.g. a slow downstream call) that
+      // occupies the worker thread well beyond the configured timeout.
+      ioThread = Thread.currentThread();
+      Thread.sleep(60_000);
+      return "slow-io";
     }
 
     @GET

--- a/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
@@ -54,9 +54,16 @@ public class RequestTimeoutIntegrationTest {
   }
 
   private void startServer(long requestTimeoutMs) throws Exception {
+    startServer(requestTimeoutMs, false);
+  }
+
+  private void startServer(long requestTimeoutMs, boolean interruptOnTimeout) throws Exception {
+    SlowResource.reset();
     Properties props = new Properties();
     props.setProperty(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
     props.setProperty(RestConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(requestTimeoutMs));
+    props.setProperty(RestConfig.REQUEST_TIMEOUT_INTERRUPT_ENABLE_CONFIG,
+        String.valueOf(interruptOnTimeout));
 
     TestRestConfig config = new TestRestConfig(props);
     server = new ApplicationServer<>(config);
@@ -66,7 +73,6 @@ public class RequestTimeoutIntegrationTest {
 
   @Test
   public void testSlowRequestTimesOutWith504() throws Exception {
-    SlowResource.reset();
     startServer(500);
 
     long start = System.currentTimeMillis();
@@ -93,6 +99,30 @@ public class RequestTimeoutIntegrationTest {
     // The handler sleeps far longer than the timeout; the 504 must come back from the scheduler
     // thread while the worker thread is still blocked in the I/O call.
     assertTrue(elapsed < 5_000, "504 should be returned promptly, took " + elapsed + " ms");
+  }
+
+  @Test
+  public void testInterruptOnTimeoutReleasesInterruptibleThread() throws Exception {
+    startServer(500, true); // interrupt-on-timeout enabled
+
+    long start = System.currentTimeMillis();
+    int status = makeGetRequest("/slow-io");
+
+    assertEquals(504, status, "request should be aborted with a 504");
+
+    // With interrupt enabled, the interruptible sleep should be released shortly after the
+    // timeout instead of running its full 60s.
+    long deadline = System.currentTimeMillis() + 5_000;
+    while (SlowResource.ioEndMs == 0 && System.currentTimeMillis() < deadline) {
+      Thread.sleep(20);
+    }
+    long handlerDuration = SlowResource.ioEndMs - start;
+
+    assertTrue(SlowResource.ioInterrupted,
+        "worker thread should have been interrupted by the timeout");
+    assertTrue(SlowResource.ioEndMs > 0 && handlerDuration < 5_000,
+        "worker thread should be released shortly after the timeout (not run the full 60s); "
+            + "handler ran ~" + handlerDuration + " ms");
   }
 
   @Test
@@ -143,9 +173,14 @@ public class RequestTimeoutIntegrationTest {
   public static class SlowResource {
     private static volatile CountDownLatch latch = new CountDownLatch(1);
     private static volatile Thread ioThread;
+    static volatile boolean ioInterrupted;
+    static volatile long ioEndMs;
 
     static void reset() {
       latch = new CountDownLatch(1);
+      ioThread = null;
+      ioInterrupted = false;
+      ioEndMs = 0;
     }
 
     static void release() {
@@ -168,11 +203,18 @@ public class RequestTimeoutIntegrationTest {
 
     @GET
     @Path("/slow-io")
-    public String slowIo() throws InterruptedException {
-      // Simulate a long, synchronous I/O-bound operation (e.g. a slow downstream call) that
-      // occupies the worker thread well beyond the configured timeout.
+    public String slowIo() {
+      // Simulate a long, synchronous I/O-bound (interruptible) operation, e.g. a slow downstream
+      // call, that occupies the worker thread well beyond the configured timeout.
       ioThread = Thread.currentThread();
-      Thread.sleep(60_000);
+      try {
+        Thread.sleep(60_000);
+      } catch (InterruptedException e) {
+        ioInterrupted = true;
+        Thread.currentThread().interrupt();
+      } finally {
+        ioEndMs = System.currentTimeMillis();
+      }
       return "slow-io";
     }
 

--- a/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/RequestTimeoutIntegrationTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.Configurable;
+import jakarta.ws.rs.core.MediaType;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class RequestTimeoutIntegrationTest {
+
+  private ApplicationServer<TestRestConfig> server;
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    // Release any request that is still blocked so the server can shut down promptly.
+    SlowResource.release();
+    if (server != null) {
+      server.stop();
+    }
+  }
+
+  private void startServer(long requestTimeoutMs) throws Exception {
+    Properties props = new Properties();
+    props.setProperty(RestConfig.LISTENERS_CONFIG, "http://0.0.0.0:0");
+    props.setProperty(RestConfig.REQUEST_TIMEOUT_MS_CONFIG, String.valueOf(requestTimeoutMs));
+
+    TestRestConfig config = new TestRestConfig(props);
+    server = new ApplicationServer<>(config);
+    server.registerApplication(new TestApp(config, "/"));
+    server.start();
+  }
+
+  @Test
+  public void testSlowRequestTimesOutWith504() throws Exception {
+    SlowResource.reset();
+    startServer(500);
+
+    long start = System.currentTimeMillis();
+    int status = makeGetRequest("/slow");
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertEquals(504, status, "slow request should be aborted with a 504");
+    // The endpoint blocks indefinitely (until released in teardown); the 504 must come back
+    // from the scheduler thread well before that, proving the abort fires while the worker
+    // thread is still blocked.
+    assertTrue(elapsed < 5_000, "504 should be returned promptly, took " + elapsed + " ms");
+  }
+
+  @Test
+  public void testFastRequestIsUnaffected() throws Exception {
+    startServer(10_000);
+    assertEquals(200, makeGetRequest("/fast"), "fast request should succeed normally");
+  }
+
+  private int makeGetRequest(final String path) throws Exception {
+    final HttpGet httpget = new HttpGet(getListeners().get(0).toString() + path);
+    try (CloseableHttpClient httpClient = HttpClients.createDefault();
+         CloseableHttpResponse response = httpClient.execute(httpget)) {
+      return response.getStatusLine().getStatusCode();
+    }
+  }
+
+  private List<URL> getListeners() {
+    return Arrays.stream(server.getConnectors())
+        .filter(ServerConnector.class::isInstance)
+        .map(ServerConnector.class::cast)
+        .map(connector -> {
+          try {
+            String protocol = new HashSet<>(connector.getProtocols())
+                .stream()
+                .map(String::toLowerCase)
+                .anyMatch(s -> s.equals("ssl")) ? "https" : "http";
+            return new URL(protocol, "localhost", connector.getLocalPort(), "");
+          } catch (final Exception e) {
+            throw new RuntimeException("Malformed listener", e);
+          }
+        })
+        .collect(Collectors.toList());
+  }
+
+  private static class TestApp extends Application<TestRestConfig> {
+    TestApp(TestRestConfig config, String path) {
+      super(config, path);
+    }
+
+    @Override
+    public void setupResources(final Configurable<?> config, final TestRestConfig appConfig) {
+      config.register(SlowResource.class);
+    }
+  }
+
+  @Path("/")
+  @Produces(MediaType.TEXT_PLAIN)
+  public static class SlowResource {
+    private static volatile CountDownLatch latch = new CountDownLatch(1);
+
+    static void reset() {
+      latch = new CountDownLatch(1);
+    }
+
+    static void release() {
+      latch.countDown();
+    }
+
+    @GET
+    @Path("/slow")
+    public String slow() throws InterruptedException {
+      // Block until the test releases the latch (or give up after a generous bound so a stray
+      // thread never lingers).
+      latch.await(60, TimeUnit.SECONDS);
+      return "slow";
+    }
+
+    @GET
+    @Path("/fast")
+    public String fast() {
+      return "fast";
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/RestConfigTest.java
+++ b/core/src/test/java/io/confluent/rest/RestConfigTest.java
@@ -440,4 +440,10 @@ public class RestConfigTest {
     props.put(PROPERTY_KEY, "FaLse");
     assertFalse(getBooleanOrDefault(props, PROPERTY_KEY, true));
   }
+
+  @Test
+  public void testRequestTimeoutMsDisabledByDefault() {
+    RestConfig config = new RestConfig(RestConfig.baseConfigDef());
+    assertEquals(-1L, config.getLong(RestConfig.REQUEST_TIMEOUT_MS_CONFIG));
+  }
 }

--- a/core/src/test/java/io/confluent/rest/RestConfigTest.java
+++ b/core/src/test/java/io/confluent/rest/RestConfigTest.java
@@ -444,6 +444,6 @@ public class RestConfigTest {
   @Test
   public void testRequestTimeoutMsDisabledByDefault() {
     RestConfig config = new RestConfig(RestConfig.baseConfigDef());
-    assertEquals(-1L, config.getLong(RestConfig.REQUEST_TIMEOUT_MS_CONFIG));
+    assertEquals(0L, config.getLong(RestConfig.REQUEST_TIMEOUT_MS_CONFIG));
   }
 }

--- a/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
+++ b/core/src/test/java/io/confluent/rest/TestMetricsReporter.java
@@ -19,13 +19,14 @@ package io.confluent.rest;
 import org.apache.kafka.common.metrics.KafkaMetric;
 import org.apache.kafka.common.metrics.MetricsReporter;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 public class TestMetricsReporter implements MetricsReporter {
 
-  private static List<KafkaMetric> metricTimeseries = new LinkedList<>();
+  private static volatile List<KafkaMetric> metricTimeseries = new CopyOnWriteArrayList<>();
 
   private Map<String, ?> configs;
 
@@ -39,10 +40,10 @@ public class TestMetricsReporter implements MetricsReporter {
   }
 
   public static List<KafkaMetric> getMetricTimeseries() {
-    return metricTimeseries;
+    return new ArrayList<>(metricTimeseries);
   }
 
-  public static void reset() { metricTimeseries = new LinkedList<>(); }
+  public static void reset() { metricTimeseries = new CopyOnWriteArrayList<>(); }
 
   public static void print() {
     for (KafkaMetric metric : metricTimeseries) {

--- a/core/src/test/java/io/confluent/rest/handlers/RequestTimeoutHandlerTest.java
+++ b/core/src/test/java/io/confluent/rest/handlers/RequestTimeoutHandlerTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest.handlers;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.server.Components;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+public class RequestTimeoutHandlerTest {
+
+  private static final long TIMEOUT_MS = 500L;
+
+  private Request request;
+  private Response response;
+  private Callback callback;
+  private Scheduler scheduler;
+  private Scheduler.Task task;
+
+  @BeforeEach
+  public void setUp() {
+    request = mock(Request.class);
+    response = mock(Response.class);
+    callback = mock(Callback.class);
+    scheduler = mock(Scheduler.class);
+    task = mock(Scheduler.Task.class);
+
+    Components components = mock(Components.class);
+    when(request.getComponents()).thenReturn(components);
+    when(components.getScheduler()).thenReturn(scheduler);
+    when(request.getHttpURI()).thenReturn(HttpURI.from("http://localhost/slow"));
+    when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenReturn(task);
+    // Make sure no interrupt status leaks between tests run on this (the worker) thread.
+    Thread.interrupted();
+  }
+
+  @AfterEach
+  public void tearDown() {
+    // Clear any interrupt flag set by the interrupt-on-timeout tests so it does not leak.
+    Thread.interrupted();
+  }
+
+  /** Wires a wrapped handler that captures the (guarded) callback and never completes it. */
+  private CapturingHandler buildChain(RequestTimeoutHandler handler) {
+    CapturingHandler next = new CapturingHandler();
+    handler.setHandler(next);
+    return next;
+  }
+
+  private Runnable captureTimeoutTask() {
+    ArgumentCaptor<Runnable> captor = ArgumentCaptor.forClass(Runnable.class);
+    verify(scheduler).schedule(captor.capture(), eq(TIMEOUT_MS), eq(TimeUnit.MILLISECONDS));
+    return captor.getValue();
+  }
+
+  @Test
+  public void timeoutFiringWritesGatewayTimeoutAndSkipsOriginalCallback() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    try (MockedStatic<Response> mockedResponse = Mockito.mockStatic(Response.class)) {
+      handler.handle(request, response, callback);
+      Runnable timeoutTask = captureTimeoutTask();
+
+      // Simulate the scheduler firing the deadline while the worker is still blocked.
+      timeoutTask.run();
+
+      mockedResponse.verify(() -> Response.writeError(
+          request, response, callback, HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out"));
+
+      // The original callback must not be completed directly; writeError owns it now.
+      verify(callback, never()).succeeded();
+      verify(callback, never()).failed(any());
+
+      // A late success from the (eventually unblocked) worker must be a no-op.
+      next.received.succeeded();
+      verify(callback, never()).succeeded();
+      verify(task, never()).cancel();
+    }
+  }
+
+  @Test
+  public void normalSuccessCancelsTimeoutAndForwardsCompletion() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    handler.handle(request, response, callback);
+
+    next.received.succeeded();
+
+    verify(task).cancel();
+    verify(callback).succeeded();
+    verify(callback, never()).failed(any());
+  }
+
+  @Test
+  public void normalFailureCancelsTimeoutAndForwardsFailure() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    handler.handle(request, response, callback);
+
+    RuntimeException boom = new RuntimeException("boom");
+    next.received.failed(boom);
+
+    verify(task).cancel();
+    verify(callback).failed(boom);
+    verify(callback, never()).succeeded();
+  }
+
+  @Test
+  public void completionAfterTimeoutIsIgnored() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    try (MockedStatic<Response> mockedResponse = Mockito.mockStatic(Response.class)) {
+      handler.handle(request, response, callback);
+      captureTimeoutTask().run();
+
+      // Worker finally returns; both completion paths must be no-ops after a timeout.
+      next.received.succeeded();
+      next.received.failed(new RuntimeException("late"));
+
+      verify(callback, never()).succeeded();
+      verify(callback, never()).failed(any());
+      mockedResponse.verify(() -> Response.writeError(
+          request, response, callback, HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out"),
+          times(1));
+    }
+  }
+
+  @Test
+  public void interruptOnTimeoutInterruptsWorkerThreadAfterWritingResponse() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, true);
+    buildChain(handler);
+
+    try (MockedStatic<Response> mockedResponse = Mockito.mockStatic(Response.class)) {
+      // handle() captures Thread.currentThread() as the worker; running the task on this same
+      // thread therefore lets us observe the interrupt directly.
+      handler.handle(request, response, callback);
+      Runnable timeoutTask = captureTimeoutTask();
+
+      assertFalse(Thread.currentThread().isInterrupted(), "precondition: not interrupted");
+      timeoutTask.run();
+
+      // The 504 is still written even though interrupt-on-timeout is enabled, and the worker
+      // thread carries the interrupt flag.
+      mockedResponse.verify(() -> Response.writeError(
+          request, response, callback, HttpStatus.GATEWAY_TIMEOUT_504, "Request timed out"));
+      assertTrue(Thread.interrupted(), "worker thread should have been interrupted");
+    }
+  }
+
+  @Test
+  public void interruptDisabledDoesNotInterruptWorkerThread() throws Exception {
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    buildChain(handler);
+
+    try (MockedStatic<Response> mockedResponse = Mockito.mockStatic(Response.class)) {
+      handler.handle(request, response, callback);
+      captureTimeoutTask().run();
+    }
+
+    assertFalse(Thread.currentThread().isInterrupted(),
+        "worker thread must not be interrupted when interrupt-on-timeout is disabled");
+  }
+
+  @Test
+  public void schedulerRejectionFallsBackToHandlingWithoutTimeout() throws Exception {
+    when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenThrow(new RejectedExecutionException("scheduler shut down"));
+
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    try (MockedStatic<Response> mockedResponse = Mockito.mockStatic(Response.class)) {
+      boolean handled = handler.handle(request, response, callback);
+
+      // The request is still handled by the downstream chain ...
+      assertTrue(handled, "request should still be handled when the timeout cannot be scheduled");
+      // ... and the original callback is forwarded unwrapped (no timeout guarding it).
+      assertSame(callback, next.received,
+          "downstream should receive the original callback when scheduling is rejected");
+      mockedResponse.verifyNoInteractions();
+    }
+
+    verify(task, never()).cancel();
+  }
+
+  @Test
+  public void schedulerRejectionStillForwardsCompletionToOriginalCallback() throws Exception {
+    when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+        .thenThrow(new RejectedExecutionException("scheduler shut down"));
+
+    RequestTimeoutHandler handler = new RequestTimeoutHandler(TIMEOUT_MS, false);
+    CapturingHandler next = buildChain(handler);
+
+    handler.handle(request, response, callback);
+    next.received.succeeded();
+
+    verify(callback).succeeded();
+    verifyNoInteractions(task);
+  }
+
+  /** Wrapped handler that records the callback it is handed and never completes it itself. */
+  private static class CapturingHandler extends Handler.Abstract {
+    private volatile Callback received;
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) {
+      this.received = callback;
+      return true;
+    }
+  }
+}

--- a/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
+++ b/core/src/test/java/io/confluent/rest/metrics/MetricsResourceMethodApplicationListenerIntegrationTest.java
@@ -15,6 +15,7 @@ import io.confluent.rest.exceptions.WebApplicationExceptionMapper;
 import jakarta.ws.rs.container.PreMatching;
 import jakarta.ws.rs.core.Response.Status;
 import org.apache.kafka.common.metrics.KafkaMetric;
+import org.apache.kafka.test.TestUtils;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ErrorHandler;
@@ -122,9 +123,12 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void testSuccessMetrics() {
+  public void testSuccessMetrics() throws Exception {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> makeSuccessfulCall());
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-total", totalRequests);
 
     // checkpoints ensure that all the assertions are tested
     int totalRequestsCheckpoint = 0;
@@ -163,7 +167,7 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void test4xxMetrics() {
+  public void test4xxMetrics() throws Exception {
     Response response = ClientBuilder.newClient(app.resourceConfig.getConfiguration())
         .target(server.getURI())
         .path("/private/fake")
@@ -176,6 +180,9 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
         .path("/private/fake")
         .request(MediaType.APPLICATION_JSON_TYPE)
         .get();
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-error-count", "4xx", 2);
 
     //checkpoints ensure that all the assertions are tested
     int rateCheckpoint4xx = 0;
@@ -246,16 +253,16 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void test429Metrics() throws InterruptedException {
+  public void test429Metrics() throws Exception {
     make429Call();
     make429Call();
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-error-count", "429", 2);
 
     //checkpoints ensure that all the assertions are tested
     int windowCheckpoint429 = 0;
     int rateCheckpoint429 = 0;
-
-    // Frustrating, but we get a concurrent modification exception if we don't wait for the metrics to finish writing before querying the metrics list
-    Thread.sleep(500);
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")
@@ -290,18 +297,18 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   @Test
   // This tests validates that with METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG enabled true,
   // the request-tags "value1" "value2" are on the global metrics for 429
-  public void test429Metrics_WithGlobalStatsRequestTagsEnabled() throws InterruptedException {
+  public void test429Metrics_WithGlobalStatsRequestTagsEnabled() throws Exception {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> make429Call());
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetricSum("request-error-count", "429", totalRequests);
 
     //checkpoints ensure that all the assertions are tested
     int rateCheckpoint429 = 0;
     int windowCheckpoint429 = 0;
     int windowTag1Checkpoint429 = 0;
     int windowTag2Checkpoint429 = 0;
-
-    // Frustrating, but we get a concurrent modification exception if we don't wait for the metrics to finish writing before querying the metrics list
-    Thread.sleep(500);
 
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
       if (metric.metricName().name().equals("request-error-rate")
@@ -344,9 +351,12 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void testException5xxMetrics() {
+  public void testException5xxMetrics() throws Exception {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> makeFailedCall());
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-error-total", "5xx", totalRequests);
 
     int totalCheckpoint = 0;
     int totalCheckpoint5xx = 0;
@@ -422,9 +432,12 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   @Test
   // This tests validates that with METRICS_GLOBAL_STATS_REQUEST_TAGS_ENABLE_CONFIG enabled true,
   // the request-tags "value1" "value2" are on the global metrics for 5XX
-  public void testException5xxMetrics_WithGlobalStatsRequestTagsEnabled() {
+  public void testException5xxMetrics_WithGlobalStatsRequestTagsEnabled() throws Exception {
     int totalRequests = 10;
     IntStream.range(0, totalRequests).forEach((i) -> makeFailedCall());
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetricSum("request-error-total", "5xx", totalRequests);
 
     int totalCheckpoint = 0;
     int totalCheckpoint5xx = 0;
@@ -532,15 +545,18 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void testMetricLatencySloSlaEnabled() {
+  public void testMetricLatencySloSlaEnabled() throws Exception {
     makeSuccessfulCall();
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-total", 1);
 
     Map<String, String> allMetrics = TestMetricsReporter.getMetricTimeseries()
         .stream()
         .collect(Collectors.toMap(
             x -> x.metricName().name(),
             x -> x.metricValue().toString(),
-            (a, b) -> Double.valueOf(a).compareTo(Double.valueOf(b)) > 0 ? a : b));
+          (a, b) -> Double.valueOf(a).compareTo(Double.valueOf(b)) > 0 ? a : b));
 
     assertTrue(allMetrics.containsKey("response-below-latency-slo-total"));
     assertTrue(allMetrics.containsKey("response-above-latency-slo-total"));
@@ -569,11 +585,14 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
   }
 
   @Test
-  public void testGlobalLatencyMetricsForErrorsBeforeResourceMatching() {
+  public void testGlobalLatencyMetricsForErrorsBeforeResourceMatching() throws Exception {
     // call service that fails before resource matching
     long start = System.currentTimeMillis();
     makeFilterErrorCall();
     long elapsed = System.currentTimeMillis() - start + 100; // add buffer of a 100 ms
+
+    // Metrics recording in the Jersey listener may lag behind the HTTP response.
+    waitForJerseyMetric("request-latency-avg", Double.MIN_VALUE);
 
     // assert that global request latency metrics should all be under client elapsed time
     for (KafkaMetric metric : TestMetricsReporter.getMetricTimeseries()) {
@@ -629,6 +648,48 @@ public class MetricsResourceMethodApplicationListenerIntegrationTest {
 
   private boolean is5xxError(Map<String, String> tags) {
     return tags.getOrDefault(HTTP_STATUS_CODE_TAG, "").equals("5xx");
+  }
+
+  /**
+   * Wait for a jersey-metrics metric to reach a minimum value.
+   */
+  private void waitForJerseyMetric(String metricName, double minValue) throws Exception {
+    TestUtils.waitForCondition(
+        () -> TestMetricsReporter.getMetricTimeseries().stream()
+            .anyMatch(m -> m.metricName().group().equals("jersey-metrics")
+                && m.metricName().name().equals(metricName)
+                && ((Double) m.metricValue()) >= minValue),
+        metricName + " metric did not reach " + minValue);
+  }
+
+  /**
+   * Wait for a jersey-metrics metric with a specific HTTP status code tag to reach a minimum value.
+   */
+  private void waitForJerseyMetric(String metricName, String statusCode, double minValue)
+      throws Exception {
+    TestUtils.waitForCondition(
+        () -> TestMetricsReporter.getMetricTimeseries().stream()
+            .anyMatch(m -> m.metricName().group().equals("jersey-metrics")
+                && m.metricName().name().equals(metricName)
+                && m.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals(statusCode)
+                && ((Double) m.metricValue()) >= minValue),
+        metricName + " [" + statusCode + "] metric did not reach " + minValue);
+  }
+
+  /**
+   * Wait for the sum of jersey-metrics metrics (across tag variants) with a specific
+   * HTTP status code tag to reach a minimum total.
+   */
+  private void waitForJerseyMetricSum(String metricName, String statusCode, double minTotal)
+      throws Exception {
+    TestUtils.waitForCondition(
+        () -> TestMetricsReporter.getMetricTimeseries().stream()
+            .filter(m -> m.metricName().group().equals("jersey-metrics")
+                && m.metricName().name().equals(metricName)
+                && m.metricName().tags().getOrDefault(HTTP_STATUS_CODE_TAG, "").equals(statusCode))
+            .mapToDouble(m -> (Double) m.metricValue())
+            .sum() >= minTotal,
+        metricName + " [" + statusCode + "] metrics sum did not reach " + minTotal);
   }
 
   private void assertMetric(KafkaMetric metric, int expectedValue) {


### PR DESCRIPTION
Description
Implement a blanket timeout for requests at the Jetty layer and return a HTTP 500 response to customers if a request takes more than 10 minutes to complete. Also free up the  Jetty thread in this scenario.
This change is off by default and turned on in the SR repo, and should only effect SR. 
PR on the SR side : https://github.com/confluentinc/schema-registry/pull/4373