### PR TITLE
fix(KNET-21303): bump async-http-client to 2.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <apache.httpclient.version>4.5.13</apache.httpclient.version>
         <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <jersey.version>3.1.11</jersey.version>
-        <asynchttpclient.version>2.14.5</asynchttpclient.version>
+        <asynchttpclient.version>2.15.0</asynchttpclient.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <io.confluent.rest-utils.version>8.0.2</io.confluent.rest-utils.version>
         <conscrypt.version>2.5.2</conscrypt.version>


### PR DESCRIPTION
Addresses CVE-2026-45300 by upgrading async-http-client from 2.14.5 to 2.15.0 on the FedRAMP 8.0.2-cp8 branch. Vulnerable versions (< 2.15.0) leak the Cookie header on cross-origin redirects (CWE-200, CVSS 7.4). 2.15.0 is the first patched 2.x release and matches the version already on master.

CVE: CVE-2026-45300