### PR TITLE
Skip TLS validation for non-SPIRE client certs

### DIFF
--- a/core/src/main/java/io/confluent/rest/SpireOptionalTrustManager.java
+++ b/core/src/main/java/io/confluent/rest/SpireOptionalTrustManager.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import java.net.Socket;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Trust manager for the SPIRE trust-only listener. A leaf certificate carrying a {@code
+ * spiffe://} URI SAN is validated against the SPIFFE trust bundle, and the connection is
+ * rejected if that validation fails.
+ */
+final class SpireOptionalTrustManager extends X509ExtendedTrustManager {
+
+  private static final Logger log = LoggerFactory.getLogger(SpireOptionalTrustManager.class);
+
+  // From the GeneralName ASN.1 CHOICE in RFC 5280 4.2.1.6: type 6 is uniformResourceIdentifier.
+  private static final int URI_SAN_TYPE = 6;
+  private static final String SPIFFE_URI_SCHEME = "spiffe://";
+
+  private final X509ExtendedTrustManager spiffeTrustManager;
+
+  private SpireOptionalTrustManager(X509ExtendedTrustManager spiffeTrustManager) {
+    this.spiffeTrustManager = Objects.requireNonNull(spiffeTrustManager, "spiffeTrustManager");
+  }
+
+  /**
+   * Wraps the first {@link X509ExtendedTrustManager} found among {@code spiffeTrustManagers}.
+   */
+  static TrustManager[] wrap(TrustManager[] spiffeTrustManagers) {
+    return new TrustManager[] {new SpireOptionalTrustManager(firstX509(spiffeTrustManagers))};
+  }
+
+  private static X509ExtendedTrustManager firstX509(TrustManager[] trustManagers) {
+    if (trustManagers != null) {
+      for (TrustManager trustManager : trustManagers) {
+        if (trustManager instanceof X509ExtendedTrustManager) {
+          return (X509ExtendedTrustManager) trustManager;
+        }
+      }
+    }
+    throw new IllegalStateException(
+        "No X509ExtendedTrustManager found among the SPIFFE trust managers");
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    if (isSpiffeCert(chain)) {
+      logValidatingSpiffeCert();
+      spiffeTrustManager.checkClientTrusted(chain, authType);
+    } else {
+      logSkippingNonSpiffeCert();
+    }
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    if (isSpiffeCert(chain)) {
+      logValidatingSpiffeCert();
+      spiffeTrustManager.checkClientTrusted(chain, authType, socket);
+    } else {
+      logSkippingNonSpiffeCert();
+    }
+  }
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+      throws CertificateException {
+    if (isSpiffeCert(chain)) {
+      logValidatingSpiffeCert();
+      spiffeTrustManager.checkClientTrusted(chain, authType, engine);
+    } else {
+      logSkippingNonSpiffeCert();
+    }
+  }
+
+  private static void logValidatingSpiffeCert() {
+    log.debug("Client certificate carries a spiffe:// SAN; validating against the SPIFFE "
+        + "trust bundle");
+  }
+
+  private static void logSkippingNonSpiffeCert() {
+    log.debug("Client certificate does not carry a spiffe:// SAN; skipping validation and "
+        + "treating the connection as unauthenticated");
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType)
+      throws CertificateException {
+    spiffeTrustManager.checkServerTrusted(chain, authType);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket)
+      throws CertificateException {
+    spiffeTrustManager.checkServerTrusted(chain, authType, socket);
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
+      throws CertificateException {
+    spiffeTrustManager.checkServerTrusted(chain, authType, engine);
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return spiffeTrustManager.getAcceptedIssuers();
+  }
+
+  private static boolean isSpiffeCert(X509Certificate[] chain) {
+    if (chain == null || chain.length == 0) {
+      return false;
+    }
+    Collection<List<?>> subjectAlternativeNames;
+    try {
+      subjectAlternativeNames = chain[0].getSubjectAlternativeNames();
+    } catch (CertificateParsingException e) {
+      log.debug("Failed to parse SAN entries while checking for a SPIFFE URI SAN; "
+          + "treating certificate as non-SPIFFE", e);
+      return false;
+    }
+    if (subjectAlternativeNames == null) {
+      return false;
+    }
+    for (List<?> san : subjectAlternativeNames) {
+      if (isSpiffeUriSan(san)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isSpiffeUriSan(List<?> san) {
+    // getSubjectAlternativeNames() can legally contain null entries.
+    if (san == null || san.size() < 2 || !(san.get(0) instanceof Integer)
+        || (Integer) san.get(0) != URI_SAN_TYPE) {
+      return false;
+    }
+    Object value = san.get(1);
+    return value instanceof String && ((String) value).startsWith(SPIFFE_URI_SCHEME);
+  }
+}

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -135,11 +135,7 @@ public final class SslFactory {
      */
     if (sslConfig.getIsSpireEnabled()) {
       if (sslConfig.getIsSpireTrustOnlyEnabled()) {
-        if (sslConfig.getKeyStorePath().isEmpty()) {
-          throw new ConfigException(
-              RestConfig.SSL_KEYSTORE_LOCATION_CONFIG + " must be set when "
-                  + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + " is enabled.");
-        }
+        validateSpireTrustOnlyConfig(sslConfig);
         log.info("SPIRE trust-only SSL mode enabled");
         sslContextFactory = createSpireTrustOnlyServer(x509Source);
       } else {
@@ -212,6 +208,22 @@ public final class SslFactory {
       sslContextFactory.setSslContext(sslContext);
     } catch (Exception e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  private static void validateSpireTrustOnlyConfig(SslConfig sslConfig) {
+    if (sslConfig.getKeyStorePath().isEmpty()) {
+      throw new ConfigException(
+          RestConfig.SSL_KEYSTORE_LOCATION_CONFIG + " must be set when "
+              + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + " is enabled.");
+    }
+    if (sslConfig.getClientAuth() == SslClientAuth.NEED) {
+      throw new ConfigException(
+          RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG + "="
+              + RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED + " is incompatible with "
+              + RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG + ": on this listener, a "
+              + "non-SPIFFE client certificate is not validated at all, so requiring a "
+              + "client certificate would accept any certificate without verifying it.");
     }
   }
 

--- a/core/src/main/java/io/confluent/rest/SslFactory.java
+++ b/core/src/main/java/io/confluent/rest/SslFactory.java
@@ -215,9 +215,10 @@ public final class SslFactory {
     }
   }
 
-  // SPIRE trust-only mode: subclass to override getTrustManagers(...) so the TrustManager
-  // comes from the SPIFFE bundle. KeyManager continues to be loaded from the configured
-  // keystore via Jetty's normal load() path.
+  // SPIRE trust-only mode: subclass to override getTrustManagers(...) with a
+  // SpireOptionalTrustManager that validates spiffe:// SAN certs against the SPIFFE bundle and
+  // skips validation entirely for any other certificate. KeyManager continues to be loaded from
+  // the configured keystore via Jetty's normal load() path.
   private static SslContextFactory.Server createSpireTrustOnlyServer(X509Source x509Source) {
     if (x509Source == null) {
       throw new RuntimeException(
@@ -227,8 +228,9 @@ public final class SslFactory {
       @Override
       protected TrustManager[] getTrustManagers(KeyStore trustStore,
                                                 Collection<? extends CRL> crls) throws Exception {
-        return new SpiffeTrustManagerFactory()
+        TrustManager[] spiffeTrustManagers = new SpiffeTrustManagerFactory()
             .engineGetTrustManagersAcceptAnySpiffeId(x509Source);
+        return SpireOptionalTrustManager.wrap(spiffeTrustManagers);
       }
     };
   }

--- a/core/src/test/java/io/confluent/rest/SpireOptionalTrustManagerTest.java
+++ b/core/src/test/java/io/confluent/rest/SpireOptionalTrustManagerTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2026 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.rest;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateParsingException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509ExtendedTrustManager;
+import org.junit.jupiter.api.Test;
+
+public class SpireOptionalTrustManagerTest {
+
+  private static X509Certificate certWithSans(List<List<?>> sans) throws Exception {
+    X509Certificate cert = mock(X509Certificate.class);
+    when(cert.getSubjectAlternativeNames()).thenReturn(sans);
+    return cert;
+  }
+
+  private static X509ExtendedTrustManager wrappedTrustManager(
+      X509ExtendedTrustManager spiffeManager) {
+    TrustManager[] wrapped = SpireOptionalTrustManager.wrap(new TrustManager[] {spiffeManager});
+    return (X509ExtendedTrustManager) wrapped[0];
+  }
+
+  @Test
+  public void checkClientTrustedValidatesSpiffeCertAgainstSpiffeManager() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate[] chain = {certWithSans(
+        Collections.singletonList(Arrays.asList(6, "spiffe://example.org/workload")))};
+
+    trustManager.checkClientTrusted(chain, "RSA");
+
+    verify(spiffeManager).checkClientTrusted(chain, "RSA");
+  }
+
+  @Test
+  public void checkClientTrustedPropagatesFailureForInvalidSpiffeCert() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate[] chain = {certWithSans(
+        Collections.singletonList(Arrays.asList(6, "spiffe://example.org/workload")))};
+    doThrow(new CertificateException("untrusted SVID"))
+        .when(spiffeManager).checkClientTrusted(chain, "RSA");
+
+    assertThrows(CertificateException.class, () -> trustManager.checkClientTrusted(chain, "RSA"));
+  }
+
+  @Test
+  public void checkClientTrustedSkipsValidationForNonSpiffeCert() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate[] chain = {certWithSans(
+        Collections.singletonList(Arrays.asList(2, "leader.internal.example.com")))};
+
+    trustManager.checkClientTrusted(chain, "RSA");
+
+    verify(spiffeManager, never())
+        .checkClientTrusted(any(X509Certificate[].class), any(String.class));
+  }
+
+  @Test
+  public void checkClientTrustedSkipsValidationWhenNoSansPresent() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate[] chain = {certWithSans(null)};
+
+    trustManager.checkClientTrusted(chain, "RSA");
+
+    verify(spiffeManager, never())
+        .checkClientTrusted(any(X509Certificate[].class), any(String.class));
+  }
+
+  @Test
+  public void checkClientTrustedSkipsValidationWhenSanEntryIsNull() throws Exception {
+    // getSubjectAlternativeNames() can legally contain null entries; this must not NPE.
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate[] chain = {certWithSans(Collections.singletonList(null))};
+
+    trustManager.checkClientTrusted(chain, "RSA");
+
+    verify(spiffeManager, never())
+        .checkClientTrusted(any(X509Certificate[].class), any(String.class));
+  }
+
+  @Test
+  public void checkClientTrustedSkipsValidationWhenSansUnparseable() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    X509Certificate cert = mock(X509Certificate.class);
+    when(cert.getSubjectAlternativeNames())
+        .thenThrow(new CertificateParsingException("boom"));
+    X509Certificate[] chain = {cert};
+
+    trustManager.checkClientTrusted(chain, "RSA");
+
+    verify(spiffeManager, never())
+        .checkClientTrusted(any(X509Certificate[].class), any(String.class));
+  }
+
+  @Test
+  public void checkClientTrustedSkipsValidationWhenChainIsEmpty() throws Exception {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    trustManager.checkClientTrusted(new X509Certificate[0], "RSA");
+
+    verify(spiffeManager, never())
+        .checkClientTrusted(any(X509Certificate[].class), any(String.class));
+  }
+
+  @Test
+  public void getAcceptedIssuersDelegatesToSpiffeManager() {
+    X509ExtendedTrustManager spiffeManager = mock(X509ExtendedTrustManager.class);
+    X509Certificate[] issuers = {mock(X509Certificate.class)};
+    when(spiffeManager.getAcceptedIssuers()).thenReturn(issuers);
+    X509ExtendedTrustManager trustManager = wrappedTrustManager(spiffeManager);
+
+    assertArrayEquals(issuers, trustManager.getAcceptedIssuers());
+  }
+
+  @Test
+  public void wrapThrowsWhenNoX509ExtendedTrustManagerAmongSpiffeManagers() {
+    TrustManager[] notExtended = new TrustManager[] {mock(TrustManager.class)};
+
+    assertThrows(IllegalStateException.class, () -> SpireOptionalTrustManager.wrap(notExtended));
+  }
+}

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -17,6 +17,7 @@
 package io.confluent.rest;
 
 import io.spiffe.workloadapi.X509Source;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
 import org.apache.kafka.test.TestUtils;
@@ -230,6 +231,22 @@ public class SslFactoryTest {
     Assertions.assertTrue(tms.length > 0, "Expected at least one TrustManager");
     Assertions.assertTrue(tms[0] instanceof SpireOptionalTrustManager,
         "Expected SpireOptionalTrustManager, got: " + tms[0].getClass().getName());
+  }
+
+  @Test
+  public void testSpireTrustOnlyRejectsRequiredClientAuth() throws Exception {
+    Map<String, String> rawConfig = new HashMap<>();
+    rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
+    rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
+    rawConfig.put(RestConfig.SSL_SPIRE_ENABLED_CONFIG, "true");
+    rawConfig.put(RestConfig.SSL_SPIRE_TRUST_ONLY_ENABLED_CONFIG, "true");
+    rawConfig.put(RestConfig.SSL_CLIENT_AUTHENTICATION_CONFIG,
+        RestConfig.SSL_CLIENT_AUTHENTICATION_REQUIRED);
+    setConfigs(rawConfig);
+
+    X509Source mockSource = Mockito.mock(X509Source.class);
+    Assertions.assertThrows(ConfigException.class,
+        () -> SslFactory.createSslContextFactory(new SslConfig(config), mockSource));
   }
 
   // The trust-only subclass must only be installed when BOTH ssl.spire.enabled and

--- a/core/src/test/java/io/confluent/rest/SslFactoryTest.java
+++ b/core/src/test/java/io/confluent/rest/SslFactoryTest.java
@@ -16,7 +16,6 @@
 
 package io.confluent.rest;
 
-import io.spiffe.provider.SpiffeTrustManager;
 import io.spiffe.workloadapi.X509Source;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.errors.InvalidConfigurationException;
@@ -204,7 +203,8 @@ public class SslFactoryTest {
   }
 
   @Test
-  public void testSpireTrustOnlyUsesKeystoreKeyManagerAndSpireTrustManager() throws Exception {
+  public void testSpireTrustOnlyUsesKeystoreKeyManagerAndSpireOptionalTrustManager()
+      throws Exception {
     Map<String, String> rawConfig = new HashMap<>();
     rawConfig.put(RestConfig.SSL_KEYSTORE_LOCATION_CONFIG, asFile(asString(KEY, CERTCHAIN)));
     rawConfig.put(RestConfig.SSL_KEYSTORE_TYPE_CONFIG, PEM_TYPE);
@@ -228,8 +228,8 @@ public class SslFactoryTest {
     TrustManager[] tms = (TrustManager[]) getTrustManagers.invoke(factory, null, null);
     Assertions.assertNotNull(tms);
     Assertions.assertTrue(tms.length > 0, "Expected at least one TrustManager");
-    Assertions.assertTrue(tms[0] instanceof SpiffeTrustManager,
-        "Expected SpiffeTrustManager, got: " + tms[0].getClass().getName());
+    Assertions.assertTrue(tms[0] instanceof SpireOptionalTrustManager,
+        "Expected SpireOptionalTrustManager, got: " + tms[0].getClass().getName());
   }
 
   // The trust-only subclass must only be installed when BOTH ssl.spire.enabled and


### PR DESCRIPTION
Skip TLS validation for non-SPIRE client certs