### PR TITLE
[Common BOM] Remove redundant jetty.version dependencyManagement overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,64 +144,9 @@
             </dependency>
 
             <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jmx</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.http2</groupId>
-                <artifactId>jetty-http2-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-alpn-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-alpn-java-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-alpn-conscrypt-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.conscrypt</groupId>
                 <artifactId>conscrypt-openjdk-uber</artifactId>
                 <version>${conscrypt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.ee10</groupId>
-                <artifactId>jetty-ee10-servlet</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.ee10</groupId>
-                <artifactId>jetty-ee10-servlets</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-security</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.ee10.websocket</groupId>
-                <artifactId>jetty-ee10-websocket-jakarta-server</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.websocket</groupId>
-                <artifactId>javax-websocket-server-impl</artifactId>
-                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>jakarta.annotation</groupId>
@@ -234,16 +179,6 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${apache.httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.http2</groupId>
-                <artifactId>jetty-http2-client</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty.http2</groupId>
-                <artifactId>jetty-http2-client-transport</artifactId>
-                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.github.resilience4j</groupId>


### PR DESCRIPTION
## Summary
- Removes 12 `dependencyManagement` entries pinning `${jetty.version}` explicitly, now that `confluent-common-bom`'s `jetty-bom` and `jetty-ee10-bom` imports (transitively via the `common` parent POM) already manage them at the same version (`12.0.37`): `jetty-jmx`, `jetty-server`, `jetty-http2-server`, `jetty-alpn-server`, `jetty-alpn-java-server`, `jetty-alpn-conscrypt-server`, `jetty-ee10-servlet`, `jetty-ee10-servlets`, `jetty-security`, `jetty-ee10-websocket-jakarta-server`, `jetty-http2-client`, `jetty-http2-client-transport`.
- Also removes `org.eclipse.jetty.websocket:javax-websocket-server-impl` outright — this is a legacy javax-era artifact that doesn't exist in Maven Central at `12.0.37` (Jetty 12 uses `jakarta.websocket`, not `javax.websocket`) and isn't declared as an actual dependency anywhere in this repo. Dead `dependencyManagement` entry.
- `rest-utils` is `rest-utils-parent` — the canonical dependencyManagement source other repos (`schema-registry`, `kafka-rest`, etc.) inherit these GAVs from — so unlike a typical downstream consumer, this repo needed the BOM to actually cover these artifacts first. Verified that's now the case as of `confluent-common-bom` v0.1.10 (already live on `common`'s published `8.0.x`).
- Scoped to `8.0.x` only for now; once merged this should cascade forward via `ci-sem-pint`/pint merge to `8.1.x`–`8.4.x`/`master` normally.

## Test plan
- [x] `mvn validate` passes across the full reactor (all 5 modules)
- [x] `mvn help:effective-pom` on `core` and `fips-tests` confirms every previously-overridden artifact still resolves to `12.0.37`, unchanged
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)